### PR TITLE
Index Descriptor File Generation Script

### DIFF
--- a/dev/build/makeindexyaml.php
+++ b/dev/build/makeindexyaml.php
@@ -48,13 +48,83 @@ function combineYamlFiles($files, $outputFile) {
         // Remove any text before the first occurrence of 'packages:' for all files except the first one
         if ($file !== $files[0]) {
             $content = preg_replace('/^.*?(?=packages:\s*)/s', '', $content);
+
             // remove the first line of the file
             $content = preg_replace('/^.+\n/', '', $content);
+
+            // Complet auto tags
+            $content = completAutoTags($content, dirname($file));
         }
         $combinedContent .= $content . "\n";
     }
     file_put_contents($outputFile, $combinedContent);
 }
+
+/**
+ * Completes auto tags in the YAML content.
+ *
+ * @param   string  $content        YAML content.
+ * @param   string  $modulePath     Path of the module directory.
+ *
+ * @return  string  Modified YAML content.
+ */
+function completAutoTags($content, $modulePath) {
+    // Look for missing auto tags in the module's core class file
+    $coreClassFile = $modulePath . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . 'mod' . basename($modulePath) . '.class.php';
+
+    $tags = array(
+        'current_version'   => 'version',
+        'dolibarrmin'       => 'need_dolibarr_version',
+        'dolibarrmax'       => 'max_dolibarr_version',
+        'phpmin'            => 'phpmin',
+        'phpmax'            => 'phpmax'
+    );
+
+    /**
+     * Replaces only the double quotes that surround values in the given content.
+     *
+     * This function uses a regular expression to find patterns in the format of `: "value"`,
+     * and replaces the double quotes with single quotes. Additionally, it replaces any
+     * internal single quotes within the value with typographic apostrophes (’).
+     *
+     * @param string $content The content in which to perform the replacements.
+     * @return string The modified content with the replacements made.
+     */
+    $content = preg_replace_callback('/:\s*"([^"]*)"/', function ($matches) {
+        return ": '" . str_replace("'", "’", $matches[1]) . "'";
+    }, $content);
+
+    if (file_exists($coreClassFile)) {
+        $coreClassContent = file_get_contents($coreClassFile);
+
+        foreach ($tags as $tag => $property) {
+            $value = '';
+
+            // Case where the value is an array
+            if (preg_match('/\$this->' . preg_quote($property) . '\s*=\s*array\(([^)]+)\)/', $coreClassContent, $matches)) {
+                $value = trim($matches[1]);
+                $value = preg_replace('/\s+/', '', $value); // Remove spaces
+                $value = str_replace(',', '.', $value); // Replace commas with dots
+            }
+
+            // Case where the value is a simple string
+            elseif (preg_match('/\$this->' . preg_quote($property) . '\s*=\s*[\'"]([^\'"]+)[\'"]/', $coreClassContent, $matches)) {
+                $value = trim($matches[1]);
+            }
+
+            if (!empty($value)) {
+                // Replace "auto" with the found value
+                $content = preg_replace('/(' . preg_quote($tag) . ':\s*)["\']?auto["\']?/', "$1\"$value\"", $content);
+            } else {
+                // Remove "auto" if no value is found
+                $content = preg_replace('/(' . preg_quote($tag) . ':\s*)["\']?auto["\']?/', "$1\"\"", $content);
+            }
+        }
+    }
+
+    return $content;
+}
+
 
 $directoryToSearch = realpath(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..');
 $outputFile = $directoryToSearch . DIRECTORY_SEPARATOR . 'index.yaml';
@@ -68,5 +138,5 @@ $yamlFiles = array_filter($yamlFiles, function($file) use ($outputFile) {
 
 combineYamlFiles($yamlFiles, $outputFile);
 
-print "Combined index.yaml file created at: " . $outputFile;
+syslog(LOG_INFO, "Combined index.yaml file created at: " . $outputFile);
 

--- a/helloasso/index.yaml
+++ b/helloasso/index.yaml
@@ -14,11 +14,11 @@ packages:
       category: '68, 67'
       git: 'https://github.com/Dolibarr/dolibarr-community-modules/tree/main/helloasso'
       cover: 'https://raw.githubusercontent.com/Dolibarr/dolibarr-community-modules/main/helloasso/cover.png'
-      current_version: '1.0.0'
-      dolibarrmin: '21.0'
-      dolibarrmax: '22.*'
-      phpmin: '7.1'
-      phpmax: '8.4'
+      current_version: 'auto'
+      dolibarrmin: 'auto'
+      dolibarrmax: 'auto'
+      phpmin: 'auto'
+      phpmax: 'auto'
       # direct-download is yes if we can download the module to install it in application
       direct-download: yes
       # dolistore-upload is manual if module is also uploaded manually on dolistore.com, auto if sync automatically

--- a/index.yaml
+++ b/index.yaml
@@ -22,21 +22,21 @@ packages:
     - modulename: 'helloasso'
       author: 'Dolicloud'
       label:
-        fr: "HelloAsso (by DoliCloud)"
-        en: "HelloAsso (by DoliCloud)"
+        fr: 'HelloAsso (by DoliCloud)'
+        en: 'HelloAsso (by DoliCloud)'
       description:
-        fr: "Offre une solution pour réaliser un paiement en ligne pour toute cotisation d'adhésion, don, facture client ou commande client via l'API HelloAsso."
-        en: "Provides a way to make an online checkout of any membership dues, donation, customer invoice or customer order with the HelloAsso API."
+        fr: 'Offre une solution pour réaliser un paiement en ligne pour toute cotisation d’adhésion, don, facture client ou commande client via l’API HelloAsso.'
+        en: 'Provides a way to make an online checkout of any membership dues, donation, customer invoice or customer order with the HelloAsso API.'
       created_at: '2024-12-10'
       last_updated_at: '2025-02-06'
       category: '68, 67'
       git: 'https://github.com/Dolibarr/dolibarr-community-modules/tree/main/helloasso'
       cover: 'https://raw.githubusercontent.com/Dolibarr/dolibarr-community-modules/main/helloasso/cover.png'
-      current_version: '1.0.0'
-      dolibarrmin: '21.0'
-      dolibarrmax: '22.*'
-      phpmin: '7.1'
-      phpmax: '8.4'
+      current_version: "1.0"
+      dolibarrmin: "21.0.-4"
+      dolibarrmax: ""
+      phpmin: "7.1"
+      phpmax: "8.4"
       # direct-download is yes if we can download the module to install it in application
       direct-download: yes
       # dolistore-upload is manual if module is also uploaded manually on dolistore.com, auto if sync automatically


### PR DESCRIPTION
This script searches through all directories for files named index.yaml, automatically completes the tags in their YAML content, and then merges their contents into a single index.yaml file to be used as a descriptor file.

The index.yaml file sent in this PR is generated by the script.