### PR TITLE
feat(credit-note): add BT-25 source invoice reference per EN16931

### DIFF
--- a/pdpconnectfr/class/pdpconnectfr.class.php
+++ b/pdpconnectfr/class/pdpconnectfr.class.php
@@ -992,6 +992,37 @@ class PdpConnectFr
 	}
 
 	/**
+	 * Validate invoice-level configuration for E-Invoicing.
+	 * Checks constraints specific to the invoice itself (type, linked documents...).
+	 *
+	 * @param Facture $invoice   Invoice object
+	 * @return array{res:int, message:string} Returns array with 'res' (1 on success, -1 on error and 0 on warning) and info 'message'
+	 */
+	public function validateInvoiceConfiguration($invoice)
+	{
+		global $langs;
+
+		$res = 1;
+		$message = '';
+		$baseErrors = [];
+
+		// Credit note: BT-25 (InvoiceReferencedDocument) is mandatory per EN16931
+		// The source invoice reference must be set in fk_facture_source
+		if ($invoice->type == $invoice::TYPE_CREDIT_NOTE) {
+			if (empty($invoice->fk_facture_source)) {
+				$baseErrors[] = $langs->trans("FxCheckErrorCreditNoteNoSource");
+			}
+		}
+
+		if (!empty($baseErrors)) {
+			$res = -1;
+			$message .= '<br> Error: ' . implode('<br> Error: ', $baseErrors);
+		}
+
+		return ['res' => $res, 'message' => $message];
+	}
+
+	/**
 	 * Check required information for E-Invoicing
 	 *
 	 * @param Facture 	$invoice   Invoice object
@@ -1000,9 +1031,10 @@ class PdpConnectFr
 	public function checkRequiredinformations($invoice)
 	{
 		$messages = [];
-		$mysocConfigCheck   = $this->validateMyCompanyConfiguration();
-		$socConfigCheck     = $this->validatethirdpartyConfiguration($invoice->thirdparty);
-		$chorusConfigCheck  = null;
+		$mysocConfigCheck    = $this->validateMyCompanyConfiguration();
+		$socConfigCheck      = $this->validatethirdpartyConfiguration($invoice->thirdparty);
+		$invoiceConfigCheck  = $this->validateInvoiceConfiguration($invoice);
+		$chorusConfigCheck   = null;
 		if (getDolGlobalInt('PDPCONNECTFR_USE_CHORUS')) {
 			$chorusConfigCheck = $this->validateChorusInformations($invoice);
 		}
@@ -1020,6 +1052,9 @@ class PdpConnectFr
 		if (!empty($socConfigCheck['message'])) {
 			$messages[] = $socConfigCheck['message'];
 		}
+		if (!empty($invoiceConfigCheck['message'])) {
+			$messages[] = $invoiceConfigCheck['message'];
+		}
 		if (!empty($chorusConfigCheck['message'])) {
 			$messages[] = $chorusConfigCheck['message'];
 		}
@@ -1028,9 +1063,12 @@ class PdpConnectFr
 		}
 
 		$res = 1;
-		if ($mysocConfigCheck['res'] === -1 || $socConfigCheck['res'] === -1 || (isset($chorusConfigCheck) && $chorusConfigCheck['res'] === -1)) {
+		if ($mysocConfigCheck['res'] === -1 || $socConfigCheck['res'] === -1
+			|| $invoiceConfigCheck['res'] === -1
+			|| (isset($chorusConfigCheck) && $chorusConfigCheck['res'] === -1)) {
 			$res = -1;
 		} elseif ($mysocConfigCheck['res'] === 0 || $socConfigCheck['res'] === 0
+			|| $invoiceConfigCheck['res'] === 0
 			|| (isset($chorusConfigCheck) && $chorusConfigCheck['res'] === 0)
 			|| (isset($apiConfigCheck) && $apiConfigCheck['res'] === 0)) {
 			$res = 0;

--- a/pdpconnectfr/class/protocols/FacturXProtocol.class.php
+++ b/pdpconnectfr/class/protocols/FacturXProtocol.class.php
@@ -409,6 +409,23 @@ class FacturXProtocol extends AbstractProtocol
 		// Set Business Process ID according to invoice type
 		$facturxpdf->setDocumentBusinessProcess($this->getBillingProcessID($object));
 
+		// Add reference to source invoice for credit notes (BT-25/BT-26, mandatory per EN16931)
+		if ($object->type == $object::TYPE_CREDIT_NOTE && !empty($object->fk_facture_source)) {
+			$sourceFact = new Facture($this->db);
+			if ($sourceFact->fetch($object->fk_facture_source) > 0) {
+				$sourceFactDate = new DateTime(dol_print_date($sourceFact->date, 'dayrfc'));
+				$sourceType = $this->_getTypeOfInvoice($sourceFact);
+				$facturxpdf->setDocumentInvoiceReferencedDocument(
+					$sourceFact->ref,
+					$sourceType,
+					$sourceFactDate
+				);
+				dol_syslog(get_class($this).'::generateXML Set source invoice reference '.$sourceFact->ref.' for credit note '.$object->ref);
+			} else {
+				dol_syslog(get_class($this).'::generateXML Cannot fetch source invoice id='.$object->fk_facture_source.' for credit note '.$object->ref, LOG_WARNING);
+			}
+		}
+
 
 		// --- 11. Process Invoice Lines ---
 		// is there multi VAT information ? in case we need to collect all data to be able to join it at the end
@@ -445,6 +462,16 @@ class FacturXProtocol extends AbstractProtocol
 			$isSubTotalLine = $this->_isLineFromExternalModule($line, $object->element, 'modSubtotal');
 			if ($isSubTotalLine) {
 				continue;
+			}
+
+			// For credit notes, EN16931 requires positive amounts (sign is implied by TypeCode 381)
+			if ($object->type == $object::TYPE_CREDIT_NOTE) {
+				$line->subprice     = abs($line->subprice);
+				$line->subprice_ttc = abs($line->subprice_ttc);
+				$line->total_ht     = abs($line->total_ht);
+				$line->total_ttc    = abs($line->total_ttc);
+				$line->total_tva    = abs($line->total_tva);
+				$line->qty          = abs($line->qty);
 			}
 
 			if ($line->subprice < 0 || $line->subprice_ttc < 0) {

--- a/pdpconnectfr/langs/en_US/pdpconnectfr.lang
+++ b/pdpconnectfr/langs/en_US/pdpconnectfr.lang
@@ -82,6 +82,7 @@ FxCheckWarnSIRENClosed=The company associated with SIREN %s is closed according 
 FxCheckWarnNameMismatch=The company name on record (%s) does not match the name in the French national business registry (%s).
 FxCheckWarnZIPMismatch=The ZIP code on record (%s) does not match the one in the French national business registry (%s).
 FxCheckWarnTownMismatch=The town on record (%s) does not match the one in the French national business registry (%s).
+FxCheckErrorCreditNoteNoSource=This credit note has no source invoice linked. Please link the source invoice before generating the e-invoice.
 InvoiceNotSentToPDPDueToThirdpartyIssues=The invoice was not sent to the Access Point due to errors in the third-party data
 PDPCONNECTFR_ENABLE_API_VALIDATION=Enable third-party data validation via government APIs (SIREN, VAT)
 PDPCONNECTFR_ENABLE_API_VALIDATION_HELP=If enabled, third-party data (SIREN/SIRET and VAT number) is verified in real time via the French National Business Registry (data.gouv.fr) and the VIES service (EU) before generating and sending the e-invoice. If these services are unavailable, the check is skipped (non-blocking warning).

--- a/pdpconnectfr/langs/fr_FR/pdpconnectfr.lang
+++ b/pdpconnectfr/langs/fr_FR/pdpconnectfr.lang
@@ -82,6 +82,7 @@ FxCheckWarnSIRENClosed=L'entreprise associée au SIREN %s est cessée dans le re
 FxCheckWarnNameMismatch=La dénomination sociale du tiers (%s) ne correspond pas à celle du registre national des entreprises (%s).
 FxCheckWarnZIPMismatch=Le code postal du tiers (%s) ne correspond pas à celui du registre national des entreprises (%s).
 FxCheckWarnTownMismatch=La ville du tiers (%s) ne correspond pas à celle du registre national des entreprises (%s).
+FxCheckErrorCreditNoteNoSource=Cet avoir ne référence aucune facture d'origine. Veuillez lier la facture source avant de générer la facture électronique.
 InvoiceNotSentToPDPDueToThirdpartyIssues=La facture n'a pas été envoyée au point d'accès en raison d'erreurs sur les données du tiers
 PDPCONNECTFR_ENABLE_API_VALIDATION=Activer la validation des données du tiers via les APIs gouvernementales (SIREN, TVA)
 PDPCONNECTFR_ENABLE_API_VALIDATION_HELP=Si activée, les données du tiers (SIREN/SIRET et numéro de TVA) sont vérifiées en temps réel via le Registre National des Entreprises (data.gouv.fr) et le service VIES (UE) avant la génération et l'envoi de la facture électronique. En cas d'indisponibilité de ces services, le contrôle est ignoré (avertissement non bloquant).


### PR DESCRIPTION
- Add validateInvoiceConfiguration() to block credit note XML generation when no source invoice is linked (fk_facture_source missing)
- Integrate check into checkRequiredinformations()
- Set InvoiceReferencedDocument (BT-25/BT-26) in FacturX XML for credit notes via setDocumentInvoiceReferencedDocument()
- Pass line amounts through abs() for credit notes (EN16931 TypeCode 381 requires positive amounts, sign is implied by document type)
- Add translation key FxCheckErrorCreditNoteNoSource (fr_FR + en_US)