### PR TITLE
fix: normalize SIREN/SIRET spaces before comparison, fix PHP8 array_merge TypeError

### DIFF
--- a/pdpconnectfr/class/actions_pdpconnectfr.class.php
+++ b/pdpconnectfr/class/actions_pdpconnectfr.class.php
@@ -353,10 +353,11 @@ class ActionsPdpconnectfr extends CommonHookActions
 						}
 					} else {
 						// If there is an error, we move warnings into error message
-						$this->errors = array_merge($this->errors, $protocol->errors);
-						$this->errors = array_merge($this->errors, $this->warnings);
+						// Cast to array to avoid TypeError on PHP 8 when property is null
+						$this->errors = array_merge($this->errors, (array) $protocol->errors);
+						$this->errors = array_merge($this->errors, (array) $this->warnings);
 						$this->warnings = array();
-						dol_syslog(__METHOD__ . " " . implode(',', $protocol->errors));
+						dol_syslog(__METHOD__ . " " . implode(',', (array) $protocol->errors));
 						$error++;
 					}
 				}

--- a/pdpconnectfr/class/pdpconnectfr.class.php
+++ b/pdpconnectfr/class/pdpconnectfr.class.php
@@ -718,7 +718,7 @@ class PdpConnectFr
 					$provider = getDolGlobalString('PDPCONNECTFR_PDP');
 					$uriConf = 'PDPCONNECTFR_' . strtoupper($provider) . '_ROUTING_ID';
 					$einvoiceid = getDolGlobalString($uriConf);
-					if (!preg_match('/^'.$mysoc->idprof1.'/', $einvoiceid)) {
+					if (!preg_match('/^'.preg_replace('/\s+/', '', $mysoc->idprof1).'/', $this->removeSpaces($einvoiceid))) {
 						$baseWarnings[] = $langs->trans("FxCheckErrorRoutingIDFR", $einvoiceid);
 					} else {
 						$baseErrors[] = $langs->trans("FxCheckErrorRoutingID");
@@ -2139,7 +2139,7 @@ class PdpConnectFr
 			if ($mysoc->country_code == 'FR') {
 				if (!empty($einvoiceid)) {
 					$einvoiceid = $this->removeSpaces($einvoiceid);
-					if (!preg_match('/^'.$mysoc->idprof1.'/', $einvoiceid)) {
+					if (!preg_match('/^'.preg_replace('/\s+/', '', $mysoc->idprof1).'/', $einvoiceid)) {
 						dol_syslog("Error: The seller communication URI seems not correct (should be or start with your SIRET number). Value: " . $einvoiceid, LOG_ERR);
 						$einvoiceid = '';
 					}

--- a/pdpconnectfr/class/protocols/FacturXProtocol.class.php
+++ b/pdpconnectfr/class/protocols/FacturXProtocol.class.php
@@ -232,12 +232,12 @@ class FacturXProtocol extends AbstractProtocol
 
 		// More tests
 		if ($mysoc->country_code == 'FR' && !empty($mysoc->idprof1) && !empty($mysoc->idprof2)) {
-			if (strpos($mysoc->idprof2, $mysoc->idprof1) !== 0) {
+			if (strpos(preg_replace('/\s+/', '', $mysoc->idprof2), preg_replace('/\s+/', '', $mysoc->idprof1)) !== 0) {
 				throw new Exception('BADVALUEFORSIRENORSIRET: The seller has both a SIREN and SIRET but SIRET does not start with value of SIREN.');
 			}
 		}
 		if ($object->thirdparty->country_code == 'FR' && !empty($object->thirdparty->idprof1) && !empty($object->thirdparty->idprof2)) {
-			if (strpos($object->thirdparty->idprof2, $object->thirdparty->idprof1) !== 0) {
+			if (strpos(preg_replace('/\s+/', '', $object->thirdparty->idprof2), preg_replace('/\s+/', '', $object->thirdparty->idprof1)) !== 0) {
 				throw new Exception('BADVALUEFORSIRENORSIRET: The buyer both a SIREN and SIRET but SIRET does not start with value of SIREN.');
 			}
 		}


### PR DESCRIPTION
- Normalize idprof1/idprof2 with preg_replace('/\s+/', '') before strpos and preg_match comparisons in FacturXProtocol and pdpconnectfr class, so values stored with spaces (e.g. '123 456 789') are handled correctly
- Cast protocol->errors and warnings to array before array_merge to avoid TypeError on PHP 8 when property is null (actions_pdpconnectfr.class.php)