### PR TITLE
FIX: add the FacturX Xml into the PDF for Dolibarr before 24.0

### DIFF
--- a/pdpconnectfr/class/protocols/FacturXProtocol.class.php
+++ b/pdpconnectfr/class/protocols/FacturXProtocol.class.php
@@ -893,7 +893,8 @@ class FacturXProtocol extends AbstractProtocol
 			if (file_exists($xmlfile)) {
 				$pdf->Annotation(10, 10, 5, 5, 'factur-x.xml', array(
 					'Subtype' => 'FileAttachment',
-					'Name' => 'PushPin'
+					'Name' => 'PushPin',
+					'FS' => $xmlfile
 				));
 			}
 


### PR DESCRIPTION
Tha Facture X Xml file was missing as attachement in the annotation