### PR TITLE
Lower minimum Dolibarr version requirement to v21

### DIFF
--- a/pdpconnectfr/core/modules/modPDPConnectFR.class.php
+++ b/pdpconnectfr/core/modules/modPDPConnectFR.class.php
@@ -152,7 +152,7 @@ class modPDPConnectFR extends DolibarrModules
 		// Prerequisites
 		$this->phpmin = array(7, 2); // Minimum version of PHP required by module
 		// $this->phpmax = array(8, 0); // Maximum version of PHP required by module
-		$this->need_dolibarr_version = array(22, -3); // Minimum version of Dolibarr required by module
+		$this->need_dolibarr_version = array(21, -3); // Minimum version of Dolibarr required by module
 		// $this->max_dolibarr_version = array(19, -3); // Maximum version of Dolibarr required by module
 		$this->need_javascript_ajax = 0;
 


### PR DESCRIPTION
Hello,
I have tested pdpconnectfr module with Dolibarr v21 and SUPER PDP :

- [x] Generate invoice in CII format
- [x] Send invoice to SUPER PDP sandbox
- [x] Sync payment status and history

For CII format things seem to work OK. I did encounter the following error when trying to send the same invoice in FacturX format to SUPER PDP sandbox : 
```HTTP 400 - CREATE_ERROR - Le fichier ne contient pas un et un seul fichier factur-x.xml ou xrechnung.xml```
Not sure where this error is coming from, might not be linked to v21.

I propose to lower Dolibarr version requirement to v21.

Thanks