### PR TITLE
    Fix : Dolibarr version 24 is not a sufficient test. Check for existence of Dolibarr FPDF class that is a subclass of TCPDF to distinguish with FPDF class defined in setasign instead

### DIFF
--- a/pdpconnectfr/class/protocols/FacturXProtocol.class.php
+++ b/pdpconnectfr/class/protocols/FacturXProtocol.class.php
@@ -509,7 +509,7 @@ class FacturXProtocol extends AbstractProtocol
 		// 2 methods are provided depending on the version of Dolibarr.
 		// TODO A third method can be tried using the atgp/factur-x library.
 
-		if ((float) DOL_VERSION < 24.0) {
+		if (class_exists('FPDF', false) && is_subclass_of('FPDF', 'TCPDF')) {
 			// Generate the PDF including the XML using the TCPDF library.
 			// Bugged version that include the factur-x.xml file twice in the PDF. Only Acrobat Reader show there is 2 files, other PDF reader works correctly showing one file.
 			// But it works with Esalink and is the only solution when Dolibarr < 24.0 because such version have a class FPDF provided by default in Dolibarr


### PR DESCRIPTION
Fix : Dolibarr version 24 is not a sufficient test. Check for existence of Dolibarr FPDF class that is a subclass of TCPDF to distinguish with FPDF class defined in setasign instead. It also avoids unnecessary checks against a fixed Dolibarr version.
