### PR TITLE
[PDPConnectfr] Restore admin/setup.php parity with v20+ on Dolibarr v18-v19

### DIFF
--- a/pdpconnectfr/admin/setup.php
+++ b/pdpconnectfr/admin/setup.php
@@ -347,8 +347,47 @@ print info_admin($langs->trans("PDPConnectInfo").'<br>'.$langs->trans("PDPConnec
  }
  */
 
+/**
+ * Render a FormSetup with a section title and v18/v19 visual parity with v20+.
+ *
+ * @param FormSetup $formSetupInstance Form setup instance
+ * @param string    $title             Section title to display in the first column header
+ * @return string                      HTML output
+ */
+$pdpRenderFormSetup = function ($formSetupInstance, $title) use ($langs) {
+	if ((float) DOL_VERSION >= 20) {
+		// Native multi-arg signature available since Dolibarr 20.0.0
+		return $formSetupInstance->generateOutput(true, false, $title, 'titlefieldmiddle');
+	}
+
+	// v18/v19 fallback: generateOutput() accepts only $editMode and always renders a Cancel button.
+	// Capture the HTML and rewrite the header row + suppress the Cancel link to mimic v20+ rendering.
+	$html = $formSetupInstance->generateOutput(true);
+
+	$titleEscaped = htmlspecialchars($title, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+	$parameterLabel = $langs->trans('Parameter');
+	$valueLabel = $langs->trans('Value');
+
+	// Replace the default "Parameter / Value" header with the section title (v20+ behavior)
+	$html = preg_replace(
+		'#<tr class="liste_titre">\s*<td>'.preg_quote($parameterLabel, '#').'</td>\s*<td>'.preg_quote($valueLabel, '#').'</td>\s*</tr>#',
+		'<tr class="liste_titre"><td class="titlefieldmiddle">'.$titleEscaped.'</td><td></td></tr>',
+		$html,
+		1
+	);
+
+	// Suppress the Cancel button to mimic v20+ rendering (Cancel was commented out upstream)
+	$html = preg_replace(
+		'#&nbsp;&nbsp;\s*<a class="button button-cancel"[^>]*>[^<]*</a>#',
+		'',
+		$html
+	);
+
+	return $html;
+};
+
 if (!empty($formSetup->items)) {
-	print $formSetup->generateOutput(3, false, $langs->transnoentitiesnoconv('PlatformPartner'), 'titlefieldmiddle');
+	print $pdpRenderFormSetup($formSetup, $langs->transnoentitiesnoconv('PlatformPartner'));
 }
 
 if (!empty($provider) && !empty($formSetup2->items)) {
@@ -360,7 +399,7 @@ if ($stringwarning) {
 }
 
 if (!empty($formSetup2->items)) {
-	print $formSetup2->generateOutput(true, false, $langs->transnoentitiesnoconv('PDPConnectionSetup'), 'titlefieldmiddle');
+	print $pdpRenderFormSetup($formSetup2, $langs->transnoentitiesnoconv('PDPConnectionSetup'));
 	print '<br>';
 }
 

--- a/pdpconnectfr/class/providers/EsalinkPDPProvider.class.php
+++ b/pdpconnectfr/class/providers/EsalinkPDPProvider.class.php
@@ -160,6 +160,11 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 		$item = $formSetup->newItem($prefix . 'PASSWORD'.(getDolGlobalInt('PDPCONNECTFR_LIVE') ? '_PROD' : ''));
 		if (method_exists('FormSetupItem', 'setAsGenericPassword')) {
 			$item->setAsGenericPassword();
+		} else {
+			// Dolibarr 18/19 fallback: setAsGenericPassword() does not exist yet.
+			// Force a masked password input so the secret is not displayed in clear text.
+			$item->fieldAttr['type'] = 'password';
+			$item->fieldAttr['autocomplete'] = 'new-password';
 		}
 		$item->nameText = $langs->transnoentities('PDPCONNECTFR_CLIENT_SECRET');
 		$item->cssClass = 'minwidth500';

--- a/pdpconnectfr/class/providers/SuperPDPProvider.class.php
+++ b/pdpconnectfr/class/providers/SuperPDPProvider.class.php
@@ -218,6 +218,11 @@ class SuperPDPProvider extends AbstractPDPProvider
 			$item = $formSetup->newItem($prefix.'CLIENT_SECRET'.(getDolGlobalInt('PDPCONNECTFR_LIVE') ? '_PROD' : ''));
 			if (method_exists('FormSetupItem', 'setAsGenericPassword')) {
 				$item->setAsGenericPassword();
+			} else {
+				// Dolibarr 18/19 fallback: setAsGenericPassword() does not exist yet.
+				// Force a masked password input so the secret is not displayed in clear text.
+				$item->fieldAttr['type'] = 'password';
+				$item->fieldAttr['autocomplete'] = 'new-password';
 			}
 			$item->nameText = $langs->trans('PDPCONNECTFR_CLIENT_SECRET');
 			$item->cssClass = 'minwidth500';


### PR DESCRIPTION
## Summary

Fixes #176.

This PR restores correct rendering of the `pdpconnectfr` module configuration page (`admin/setup.php`) on Dolibarr 18 / 19, with no behavioral change on Dolibarr 20+.

Three related compatibility fixes are bundled, all guarded so that v20+ behavior is strictly unchanged:

1. **Section titles and Cancel button on `admin/setup.php`**
   `FormSetup::generateOutput()` only accepts a single `$editMode` argument on Dolibarr 18 / 19. The multi-arg signature `($editMode, $hideTitle, $title, $cssfirstcolumn)` was introduced in core commit `b177e68` and is only available from v20.0.0. The current code calls `generateOutput()` with 4 arguments, so on v18/v19 the section titles ("Plateforme partenaire", "Configuration de la connexion au point d'accès") and the `titlefieldmiddle` styling are silently dropped, and a Cancel button is rendered (the Cancel button is commented out from v20+).
   On v18/v19 the form HTML is now captured and rewritten via regex to inject the section title into the first column header (matching v20+ rendering) and to suppress the Cancel button.

2. **Client Secret masking on Esalink provider**
   `EsalinkPDPProvider` uses `FormSetupItem::setAsGenericPassword()` to mask the Client Secret input, but this method only exists from v20+. The module already guards the call with `method_exists()` but had no fallback, so on v18/v19 the secret was rendered as a plain text input.
   When `setAsGenericPassword()` is unavailable, the fix sets `fieldAttr['type'] = 'password'` (and `autocomplete = new-password`) so the browser masks the value natively.

3. **Client Secret masking on SuperPDP provider**
   Same fix as above, applied to `SuperPDPProvider`.

All version-gating follows the existing convention in this module (`(float) DOL_VERSION < N` and `method_exists()`).

## Test plan

- [x] On Dolibarr 18.0.10: section titles displayed in the table header, single Save button, Client Secret masked
- [x] On Dolibarr 22.0.4: rendering unchanged (native multi-arg code path)
- [ ] Verify on Dolibarr 19 (no instance at hand, code path identical to v18 via `(float) DOL_VERSION < 20`)

## Notes

This is a Dolibarr version compatibility fix only. No functional behavior is changed on the supported v20+ baseline.

---

*Generated with the help of Claude Code, reviewed and tested by a human*