### PR TITLE
[PDPConnectfr] Fix PDPCONNECTFR_LIVE="0" wrongly routing to the production endpoint

### DIFF
--- a/pdpconnectfr/class/providers/AbstractPDPProvider.class.php
+++ b/pdpconnectfr/class/providers/AbstractPDPProvider.class.php
@@ -146,17 +146,21 @@ abstract class AbstractPDPProvider
 	 */
 	public function getApiUrl($mode = 'api')
 	{
-		$prod = getDolGlobalString('PDPCONNECTFR_LIVE', '');
+		// Use getDolGlobalInt so that PDPCONNECTFR_LIVE = "0" is correctly treated as test mode.
+		// A previous "$prod != ''" comparison was incorrect because '0' != '' is true in PHP,
+		// which made the module hit the production endpoint as soon as the user had ever toggled
+		// the "real mode" switch (the const gets stored as "0" instead of being deleted).
+		$prod = getDolGlobalInt('PDPCONNECTFR_LIVE');
 
 		if ($mode === 'auth') {
 			$url = $this->config['test_auth_url'];
-			if ($prod != '') {
+			if (!empty($prod)) {
 				$url = $this->config['prod_auth_url'];
 			}
 			return $url;
 		} else {
 			$url = $this->config['test_api_url'];
-			if ($prod != '') {
+			if (!empty($prod)) {
 				$url = $this->config['prod_api_url'];
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes #178.

`AbstractPDPProvider::getApiUrl()` selected the production vs test URL with `if ($prod != '')`, where `$prod = getDolGlobalString('PDPCONNECTFR_LIVE', '')`. Because `"0" != ""` evaluates to `true` in PHP, as soon as `PDPCONNECTFR_LIVE` was persisted as `"0"` (which happens after the user toggles "Real mode" on then off), every API call was silently routed to the **production** endpoint while still using the **test** credentials, leading to `HTTP 403 Forbidden` and the UI error `Impossible d'obtenir le jeton d'accès auprès du fournisseur du point d'accès.`

The fix aligns `getApiUrl()` with the convention used in the rest of the module: read the constant as an int via `getDolGlobalInt('PDPCONNECTFR_LIVE')` and branch on `!empty($prod)`. `"0"` is now correctly treated as test mode.

## Test plan

- [x] On Dolibarr 18.0.10 with `PDPCONNECTFR_LIVE = "0"` stored, clicking "Se connecter (Générer le jeton d'accès)" against the Esalink PA: before the fix, HTTP 403 on `https://hubtimize.fr/.../token` (production); after the fix, HTTP 200 on `https://ppd.hubtimize.fr/.../token` (test) and the token is correctly persisted.
- [x] With `PDPCONNECTFR_LIVE = 1`: still routes to the production endpoint (no regression).
- [x] With `PDPCONNECTFR_LIVE` unset: still routes to the test endpoint (no regression).

## Notes

This is a logic bug, not a Dolibarr version compatibility issue. It affects all Dolibarr versions running the module. No behavioral change beyond restoring the intended test/prod selection.

---

*Generated with the help of Claude Code, reviewed and tested by a human*