### PR TITLE
[PDPConnectfr] Fix empty e-invoice button label on Dolibarr v18-v19 and ghost dropdown on draft invoices

### DIFF
--- a/pdpconnectfr/class/actions_pdpconnectfr.class.php
+++ b/pdpconnectfr/class/actions_pdpconnectfr.class.php
@@ -215,7 +215,12 @@ class ActionsPdpconnectfr extends CommonHookActions
 			}
 
 			print '<!-- Current AP: ' . getDolGlobalString('PDPCONNECTFR_PDP') . ' -->';
-			print dolGetButtonAction('', $langs->trans('einvoice'), 'default', $url_button, '', true);
+			if (!empty($url_button)) {
+				// Pass the visible label as the 1st arg ($label), not the 2nd ($text). On Dolibarr 18/19
+				// the dropdown <a> renders only $label; v22+ falls back to $text when $label is empty,
+				// but to keep behavior consistent across versions we always use $label.
+				print dolGetButtonAction($langs->trans('einvoice'), '', 'default', $url_button, '', true);
+			}
 		}
 
 
@@ -254,7 +259,9 @@ class ActionsPdpconnectfr extends CommonHookActions
 						);
 					}
 
-					print dolGetButtonAction('', $langs->trans('einvoice'), 'default', $url_button, '', true);
+					if (!empty($url_button)) {
+						print dolGetButtonAction($langs->trans('einvoice'), '', 'default', $url_button, '', true);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes #180.

`ActionsPdpconnectfr::addMoreActionsButtons()` injects an e-invoice dropdown on customer and supplier invoice cards by calling:

```php
print dolGetButtonAction('', $langs->trans('einvoice'), 'default', $url_button, '', true);
```

Two visual defects on Dolibarr 18 / 19:

1. **Empty dropdown label.** The visible text was passed as `$text` (2nd arg) instead of `$label` (1st arg). Dolibarr 22+ falls back to `$text` when `$label` is empty (`$text ?: $label`), so the label is shown; Dolibarr 18 / 19 only uses `$label`, so the dropdown toggle is rendered empty.
   Fix: pass the visible text as `$label`.

2. **Ghost dropdown on draft invoices.** On a draft invoice (status not VALIDATED or CLOSED), `$url_button = []`. Dolibarr 22+ returns an empty string when the actions list is empty; Dolibarr 18 / 19 still wraps the empty list in a visible dropdown container.
   Fix: skip the print entirely when `$url_button` is empty.

Both changes are version-agnostic — no `DOL_VERSION` gate is needed; the new behavior is the intended one on every supported Dolibarr version, including v22+.

## Test plan

- [x] On Dolibarr 18.0.10, draft invoice: no more empty dropdown rendered next to the standard Save / Clone / Delete buttons.
- [x] On Dolibarr 18.0.10, validated invoice with no e-invoice yet: dropdown displays the "E-invoice" label, opens the sub-actions (Generate, Send to PDP, etc.).
- [x] On Dolibarr 22.0.4: rendering unchanged (still displays the "E-invoice" label, still hidden on drafts).
- [ ] Verify on Dolibarr 19 (no instance at hand; code path is the same as on 18).

## Notes

This is purely a UX defect of the module hook output; no functional behavior is changed.

---

*Generated with the help of Claude Code, reviewed and tested by a human*