### PR TITLE
[PDPConnectfr] Fix TypeError on setKeywordTemplate(null) when generating Factur-X on Dolibarr v18-v19

### DIFF
--- a/pdpconnectfr/class/protocols/FacturXProtocol.class.php
+++ b/pdpconnectfr/class/protocols/FacturXProtocol.class.php
@@ -568,12 +568,19 @@ class FacturXProtocol extends AbstractProtocol
 			}
 
 			// Restore metadata from original PDF.
+			// horstoeko/zugferd setters require non-null strings, so default to '' for Dolibarr
+			// versions that do not ship pdfExtractMetadata() (v18 / v19); v22+ overwrites these
+			// with the actual values parsed from the source PDF.
+			$keywords = '';
+			$subject = '';
+			$author = '';
+			$creator = '';
 			if (function_exists('pdfExtractMetadata')) {	// From Dolibarr v22
 				// Now we get the metadata keywords from the $sourcefile PDF (by parsing the binary PDF file)
-				$keywords = pdfExtractMetadata($orig_pdf, 'Keywords');
-				$subject = pdfExtractMetadata($orig_pdf, 'Subject');
-				$author = pdfExtractMetadata($orig_pdf, 'Author');
-				$creator = pdfExtractMetadata($orig_pdf, 'Creator');
+				$keywords = (string) pdfExtractMetadata($orig_pdf, 'Keywords');
+				$subject = (string) pdfExtractMetadata($orig_pdf, 'Subject');
+				$author = (string) pdfExtractMetadata($orig_pdf, 'Author');
+				$creator = (string) pdfExtractMetadata($orig_pdf, 'Creator');
 			}
 
 			$merger = new ZugferdDocumentPdfMerger($xmlfile, $orig_pdf);


### PR DESCRIPTION
## Summary

Fixes #182.

`FacturXProtocol::generateInvoice()` reads source-PDF metadata (keywords, subject, author, creator) through the core `pdfExtractMetadata()` helper, which only exists from Dolibarr 20+. The four read assignments are correctly guarded by `if (function_exists('pdfExtractMetadata'))`, but the resulting variables are then passed to the `horstoeko/zugferd` `ZugferdDocumentPdfMerger` setters a few lines later without re-guarding.

On Dolibarr 18 / 19 the four variables are never assigned and remain `null`, so the typed `string` setters throw a fatal `TypeError`:

```
PHP Fatal error: Uncaught TypeError:
ZugferdDocumentPdfBuilderAbstract::setKeywordTemplate():
Argument #1 ($keywordTemplate) must be of type string, null given
```

The Factur-X PDF is still written to disk before that point, so the file is correctly produced, but the HTTP request returns 500 and any downstream chaining (lifecycle update, redirect) is aborted.

The fix initializes the four variables to `''` before the conditional block and casts the values returned by `pdfExtractMetadata()` to `(string)`. On v20+ the cast is a no-op (the function already returns strings) and the defaults are immediately overwritten — behavior is strictly unchanged. On v18 / v19 the merger receives empty strings, which the library accepts.

No `DOL_VERSION` gate is needed; the change is purely defensive.

## Test plan

- [x] On Dolibarr 18.0.10: regenerating a validated invoice no longer returns HTTP 500; the Factur-X PDF is correctly written and the lifecycle proceeds.
- [x] On Dolibarr 22.0.4: behavior strictly unchanged; the four metadata fields are still extracted from the source PDF and applied to the output.
- [ ] Verify on Dolibarr 19 (no instance at hand, code path identical to v18).

## Notes

Independent from the parallel PRs #177, #179, #181 — branched directly from `upstream/main`.

---

*Generated with the help of Claude Code, reviewed and tested by a human*