### PR TITLE
fix: load thirdparty on rebuilt invoice object in buildinvoicelines

### DIFF
--- a/pdpconnectfr/lib/buildinvoicelines.inc.php
+++ b/pdpconnectfr/lib/buildinvoicelines.inc.php
@@ -56,6 +56,9 @@ $this->sourceinvoice = $invoice;
 $tmpfacture = new Facture($db);
 $object = $tmpfacture->fetch($invoice->id) > 0 ? $tmpfacture : $invoice;
 
+if (!is_object($object->thirdparty)) {
+	$object->fetch_thirdparty();
+}
 
 // =====================================================================
 // Data collection into $invoiceData and $linesData arrays


### PR DESCRIPTION
## Problem

In `buildinvoicelines.inc.php`, the invoice object is rebuilt via `fetch()` into a new `$tmpfacture` object (line 57). This new object does not have `thirdparty` loaded, causing a fatal PHP warning on line 96:

    Warning: Attempt to read property "tva_assuj" on null

This warning also triggers "headers already sent" errors that break the invoice card page.

## Fix

Added a `fetch_thirdparty()` call on `$object` after the reconstruction, guarded by an `is_object()` check (consistent with the same check already done on `$invoice` at line 49).

```php
if (!is_object($object->thirdparty)) {
    $object->fetch_thirdparty();
}
