### PR TITLE
[pdpconnectfr] Fix Fatal error "Cannot redeclare pdfExtractMetadata()" on Dolibarr v22+

### DIFF
--- a/pdpconnectfr/lib/pdpconnectfr.lib.php
+++ b/pdpconnectfr/lib/pdpconnectfr.lib.php
@@ -550,8 +550,14 @@ if (!method_exists('Societe', 'findNearest')) {
 	}
 }
 
-if (!function_exists('pdfExtractMetadata'))
-{
+// Force-load core's pdf.lib.php on versions where pdfExtractMetadata exists in core,
+// otherwise function_exists() returns false here (core lib not loaded yet) and the
+// polyfill below is declared, then core's later require_once redeclares it -> fatal.
+if (file_exists(DOL_DOCUMENT_ROOT . '/core/lib/pdf.lib.php')) {
+	require_once DOL_DOCUMENT_ROOT . '/core/lib/pdf.lib.php';
+}
+
+if (!function_exists('pdfExtractMetadata')) {
 	/**
 	 * Function to extract metadata from a PDF file by doing a binary parsing of the PDF file
 	 *

--- a/pdpconnectfr/lib/pdpconnectfr.lib.php
+++ b/pdpconnectfr/lib/pdpconnectfr.lib.php
@@ -334,8 +334,7 @@ if (!function_exists("GETPOSTFLOAT")) {
 	}
 }
 
-if (!function_exists('dolPrintHTML'))
-{
+if (!function_exists('dolPrintHTML')) {
 	/**
 	 * Return a string ready to be output on HTML page
 	 * To use text inside an attribute, use can use only dol_escape_htmltag()
@@ -570,14 +569,14 @@ if (!function_exists('pdfExtractMetadata')) {
 		if (!dol_is_file($file)) {
 			return "ERROR: FILE NOT FOUND OR NOT VALID";
 		}
-	
+
 		// Get content of PDF file
 		$content = file_get_contents(dol_osencode($file));
-	
+
 		// Use a regex to capture the metadata
 		if ($content) {
 			$matches = array();
-	
+
 			// Remove non printablecaracters
 			$content = preg_replace('/[^(\x20-\x7F)]*/', '', $content);
 			if (preg_match('/\/' . preg_quote($field, '/') . '\s*\((.*?)\)/', $content, $matches)) {


### PR DESCRIPTION
## Summary

- Fixes #191.
- Force-loads `core/lib/pdf.lib.php` before the `function_exists('pdfExtractMetadata')` guard in `pdpconnectfr/lib/pdpconnectfr.lib.php`, so the guard correctly detects the function on Dolibarr versions where core provides it (v22+) and the polyfill is skipped.

## Why

On Dolibarr v22, the polyfill in the module collides with core's own `pdfExtractMetadata()` because `pdpconnectfr.lib.php` is loaded before `core/lib/pdf.lib.php`: the `function_exists()` guard returns false, the polyfill declares the function, and core's later `require_once` triggers `Fatal error: Cannot redeclare function pdfExtractMetadata()`. Validating any invoice 500s as a result.

## Compatibility

- v22+: `pdfExtractMetadata()` exists in core -> the forced `require_once` loads it first, the polyfill is skipped.
- v18-v21: `pdfExtractMetadata()` doesn't exist in core but `core/lib/pdf.lib.php` is still present -> the polyfill still declares as before.
- `require_once` is idempotent; the `file_exists()` probe is paranoia for unusual install layouts.

## Test plan

- [x] Reproduce the fatal on v22 with the current `main`.
- [x] Apply the patch -> invoice validation succeeds, no fatal in logs.
- [x] Smoke-test on v18 / v20 to confirm the polyfill is still active where needed.

---

*Generated with the help of Claude Code, reviewed and tested by a human*