### PR TITLE
[pdpconnectfr] Fix synchronization abort: extend tracking_idref column to varchar(255)

### DIFF
--- a/pdpconnectfr/class/document.class.php
+++ b/pdpconnectfr/class/document.class.php
@@ -140,7 +140,7 @@ class Document extends CommonObject
 		"document_body" => array("type" => "text", "label" => "document_body", "enabled" => "1", 'position' => 110, 'notnull' => 0, "visible" => "0", "comment" => "Full document content XML"),
 		"fk_element_type" => array("type" => "varchar(100)", "label" => "fk_element_type", "enabled" => "1", 'position' => 120, 'notnull' => 0, "visible" => "1",),
 		"fk_element_id" => array("type" => "integer", "label" => "fk_element_id", "enabled" => "1", 'position' => 130, 'notnull' => 0, "visible" => "-1",),
-		"tracking_idref" => array("type" => "varchar(50)", "label" => "RefObject", "enabled" => "1", 'position' => 135, 'notnull' => 0, "visible" => "1", "comment" => "Document tracking identifier"),
+		"tracking_idref" => array("type" => "varchar(255)", "label" => "RefObject", "enabled" => "1", 'position' => 135, 'notnull' => 0, "visible" => "1", "comment" => "Document tracking identifier"),
 		"submittedat" => array("type" => "datetime", "label" => "submittedAt", "enabled" => "1", 'position' => 140, 'notnull' => 1, "visible" => "-1", "comment" => "submittedAt (PDP Date)"),
 		"updatedat" => array("type" => "datetime", "label" => "updatedAt", "enabled" => "1", 'position' => 150, 'notnull' => 0, "visible" => "1", "comment" => "updatedAt (PDP Date)"),
 		"entity" => array("type" => "integer", "label" => "entity", "enabled" => "1", 'position' => 170, 'notnull' => 0, "visible" => "0", "comment" => "Multi-entity support"),

--- a/pdpconnectfr/sql/dolibarr_allversions.sql
+++ b/pdpconnectfr/sql/dolibarr_allversions.sql
@@ -19,3 +19,5 @@ ALTER TABLE llx_pdpconnectfr_call MODIFY COLUMN totalflow integer NULL DEFAULT N
 ALTER TABLE llx_pdpconnectfr_routing ADD COLUMN routing_type varchar(12) NOT NULL DEFAULT 'thirdparty';
 
 ALTER TABLE llx_pdpconnectfr_extlinks ADD COLUMN override_routing_id varchar(255) NULL DEFAULT NULL;
+
+ALTER TABLE llx_pdpconnectfr_document MODIFY COLUMN tracking_idref varchar(255);

--- a/pdpconnectfr/sql/llx_pdpconnectfr_document.sql
+++ b/pdpconnectfr/sql/llx_pdpconnectfr_document.sql
@@ -24,7 +24,7 @@ CREATE TABLE llx_pdpconnectfr_document(
 	status integer NOT NULL DEFAULT 0, 
 	call_id varchar(50), 
 	flow_id varchar(255), 
-	tracking_idref varchar(50), 
+	tracking_idref varchar(255),
 	flow_type varchar(64), 
 	flow_direction varchar(10), 
 	flow_syntax varchar(50), 


### PR DESCRIPTION
## Summary

- Fixes #198.
- Bumps `llx_pdpconnectfr_document.tracking_idref` from `varchar(50)` to `varchar(255)` so the PDP synchronization can store the values the provider classes actually produce, including the `"ESALINK <uuid> (NOTFOUND)"` fallback (55+ chars) that currently overflows.

## Changes

- `sql/llx_pdpconnectfr_document.sql` — fresh installs get `varchar(255)`.
- `class/document.class.php` — `Document::$fields['tracking_idref']` type updated to match.
- `sql/dolibarr_allversions.sql` — `ALTER TABLE … MODIFY COLUMN tracking_idref varchar(255)` migration for existing installs.

`varchar(255)` matches the existing `flow_id` column, which carries the same kind of identifier and has not been a bottleneck.

## Test plan

- [x] Reproduce the failure on `main`: synchronization aborts on the first flow with `Data too long for column 'tracking_idref'`.
- [x] Apply the patch (manual `ALTER` on the running DB) — same synchronization completes; the flow record is created with the full `"ESALINK <uuid> (NOTFOUND)"` value.
- [ ] Smoke-test on a fresh install (no existing data) to confirm the new schema is applied.
- [ ] Smoke-test the migration on an install that already had data in `llx_pdpconnectfr_document`.

---

*Generated with the help of Claude Code, reviewed and tested by a human*