### PR TITLE
Fix HelloAsso adherent creation login conversion

### DIFF
--- a/helloasso/class/helloassomemberutils.class.php
+++ b/helloasso/class/helloassomemberutils.class.php
@@ -740,7 +740,8 @@ class HelloAssoMemberUtils
 		}
 		// Login creation for member
 		if (empty($createmember->login)) {
-			$login = strtolower($newmember->user->firstName).strtolower($newmember->user->lastName);
+			$login = $newmember->user->firstName.$newmember->user->lastName;
+			$login = mb_strtolower($login);
 			$sql = "SELECT COUNT(rowid) as nbmembers";
 			$sql .= " FROM ".MAIN_DB_PREFIX."adherent";
 			$sql .= " WHERE entity IN (".((int) getEntity($createmember->element)).")";


### PR DESCRIPTION
Fix an error when converting a member name to login that do not convert all UTF-8 chars
Example : AZÈS -> azÈs 
Fix AZÈS -> azès