### PR TITLE
[pdpconnectfr] Fix call/document forms invalid action URL

### DIFF
--- a/pdpconnectfr/call_card.php
+++ b/pdpconnectfr/call_card.php
@@ -280,7 +280,7 @@ if ($action == 'create') {
 
 	print load_fiche_titre($title, '', $object->picto);
 
-	print '<form method="POST" action="'.dol_buildpath($_SERVER["PHP_SELF"]).'">';
+	print '<form method="POST" action="'.dol_buildpath($_SERVER["PHP_SELF"], 1).'">';
 	print '<input type="hidden" name="token" value="'.newToken().'">';
 	print '<input type="hidden" name="action" value="add">';
 	if ($backtopage) {
@@ -319,7 +319,7 @@ if ($action == 'create') {
 if (($id || $ref) && $action == 'edit') {
 	print load_fiche_titre($langs->trans("pdpFeedback"), '', $object->picto);
 
-	print '<form method="POST" action="'.dol_buildpath($_SERVER["PHP_SELF"]).'">';
+	print '<form method="POST" action="'.dol_buildpath($_SERVER["PHP_SELF"], 1).'">';
 	print '<input type="hidden" name="token" value="'.newToken().'">';
 	print '<input type="hidden" name="action" value="update">';
 	print '<input type="hidden" name="id" value="'.$object->id.'">';

--- a/pdpconnectfr/document_card.php
+++ b/pdpconnectfr/document_card.php
@@ -277,7 +277,7 @@ if ($action == 'create') {
 
 	print load_fiche_titre($title, '', $object->picto);
 
-	print '<form method="POST" action="'.dol_buildpath($_SERVER["PHP_SELF"]).'">';
+	print '<form method="POST" action="'.dol_buildpath($_SERVER["PHP_SELF"], 1).'">';
 	print '<input type="hidden" name="token" value="'.newToken().'">';
 	print '<input type="hidden" name="action" value="add">';
 	if ($backtopage) {
@@ -316,7 +316,7 @@ if ($action == 'create') {
 if (($id || $ref) && $action == 'edit') {
 	print load_fiche_titre($langs->trans("Document"), '', $object->picto);
 
-	print '<form method="POST" action="'.dol_buildpath($_SERVER["PHP_SELF"]).'">';
+	print '<form method="POST" action="'.dol_buildpath($_SERVER["PHP_SELF"], 1).'">';
 	print '<input type="hidden" name="token" value="'.newToken().'">';
 	print '<input type="hidden" name="action" value="update">';
 	print '<input type="hidden" name="id" value="'.$object->id.'">';


### PR DESCRIPTION
Target actions generated by `dol_buildpath()` are using a local path but an URL is expected.