### PR TITLE
fix(einvoicing): clean fresh symlink install

### DIFF
--- a/einvoicing/sql/llx_einvoicing_call.key.sql
+++ b/einvoicing/sql/llx_einvoicing_call.key.sql
@@ -19,7 +19,3 @@ ALTER TABLE llx_einvoicing_call ADD UNIQUE INDEX uk_einvoicing_call_callid (call
 ALTER TABLE llx_einvoicing_call ADD INDEX idx_einvoicing_call_date_creation (date_creation);
 ALTER TABLE llx_einvoicing_call ADD INDEX idx_einvoicing_call_status (status);
 -- END MODULEBUILDER INDEXES
-
---ALTER TABLE llx_einvoicing_call ADD UNIQUE INDEX uk_einvoicing_call_fieldxy(fieldx, fieldy);
-
---ALTER TABLE llx_einvoicing_call ADD CONSTRAINT llx_einvoicing_call_fk_field FOREIGN KEY (fk_field) REFERENCES llx_einvoicing_myotherobject(rowid);

--- a/einvoicing/sql/llx_einvoicing_document.key.sql
+++ b/einvoicing/sql/llx_einvoicing_document.key.sql
@@ -20,7 +20,3 @@ ALTER TABLE llx_einvoicing_document ADD INDEX idx_einvoicing_document_callid (ca
 ALTER TABLE llx_einvoicing_document ADD INDEX idx_einvoicing_document_date_creation (date_creation);
 ALTER TABLE llx_einvoicing_document ADD INDEX idx_einvoicing_document_status (status);
 -- END MODULEBUILDER INDEXES
-
---ALTER TABLE llx_einvoicing_document ADD UNIQUE INDEX uk_einvoicing_document_fieldxy(fieldx, fieldy);
-
---ALTER TABLE llx_einvoicing_document ADD CONSTRAINT llx_einvoicing_document_fk_field FOREIGN KEY (fk_field) REFERENCES llx_einvoicing_myotherobject(rowid);

--- a/einvoicing/sql/llx_einvoicing_document.sql
+++ b/einvoicing/sql/llx_einvoicing_document.sql
@@ -45,6 +45,7 @@ CREATE TABLE llx_einvoicing_document(
 	cdar_reason_code varchar(50), 
 	cdar_reason_desc varchar(255), 
 	cdar_reason_detail text,
-	response_for_debug text					-- To store response if debug is on
+	response_for_debug text,				-- To store response if debug is on
+	xml_data mediumtext DEFAULT NULL		-- Full XML invoice data (without PDF)
 	-- END MODULEBUILDER FIELDS
 ) ENGINE=innodb;

--- a/einvoicing/sql/migration_pdpconnectfr_to_einvoicing.sql
+++ b/einvoicing/sql/migration_pdpconnectfr_to_einvoicing.sql
@@ -1,6 +1,11 @@
 --
 -- Migration script: rename module from pdpconnectfr to einvoicing.
--- Run this script AFTER disabling the pdpconnectfr module and BEFORE enabling einvoicing.
+-- Run this script MANUALLY, AFTER disabling the pdpconnectfr module and BEFORE enabling einvoicing.
+--
+-- IMPORTANT: this file is intentionally NOT named update_*.sql so that Dolibarr's
+-- _load_tables() does NOT auto-run it on every module activation. The RENAME TABLE
+-- statements below would otherwise fail on a fresh install (no llx_pdpconnectfr_* tables).
+-- Only relevant when upgrading an existing pdpconnectfr installation.
 --
 
 -- Rename tables


### PR DESCRIPTION
Bug fixes found while deploying and running the module end-to-end against a real PDP (SuperPDP sandbox, PHP 8.4).

- Don't auto-run the pdpconnectfr→einvoicing rename migration on fresh installs (renamed out of `update_*.sql` so `_load_tables()` skips it; its `RENAME TABLE` of non-existent tables otherwise errors and aborts activation).
- Add missing `xml_data` column to the base `llx_einvoicing_document` table (it is used by the document class/helpers but was only created via `update_v1.0.2.sql`).
- Drop dead modulebuilder placeholder lines (commented FK to a non-existent `llx_einvoicing_myotherobject`).

Tested: fresh symlink install + module activation, no SQL errors.
