### PR TITLE
fix(einvoicing): inbound flow reception fixes

### DIFF
--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -421,6 +421,18 @@ trait CommonProtocol
 
 		$sellerCountryCode = $sellerInfo['sellercountry'] ?? '';
 
+		// The legal id (e.g. SIREN) is often carried only in the SpecifiedLegalOrganization
+		// (sellerLegalOrgId/Scheme) and left out of sellerGlobalIds. Merge it in so the lookup,
+		// update and creation steps below all populate the matching idprof field (e.g. idprof1).
+		if (!empty($sellerInfo['sellerLegalOrgId']) && !empty($sellerInfo['sellerLegalOrgScheme'])) {
+			if (empty($sellerInfo['sellerGlobalIds']) || !is_array($sellerInfo['sellerGlobalIds'])) {
+				$sellerInfo['sellerGlobalIds'] = array();
+			}
+			if (empty($sellerInfo['sellerGlobalIds'][$sellerInfo['sellerLegalOrgScheme']])) {
+				$sellerInfo['sellerGlobalIds'][$sellerInfo['sellerLegalOrgScheme']] = $sellerInfo['sellerLegalOrgId'];
+			}
+		}
+
 		// Step 1: Try to find thirdparty by global IDs
 		if (!empty($sellerInfo['sellerGlobalIds']) && is_array($sellerInfo['sellerGlobalIds'])) {
 			foreach ($sellerInfo['sellerGlobalIds'] as $idScheme => $globalId) {

--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -523,7 +523,8 @@ trait CommonProtocol
 			}
 
 			if ($result > 0) {
-				$thirdpartyId = $thirdparty->id;
+				// findNearest() RETURNS the rowid (it does not populate $thirdparty->id).
+				$thirdpartyId = $result;
 				dol_syslog(get_class($this) . '::_syncOrCreateThirdpartyFromEInvoiceSeller Found thirdparty by findNearest: ' . $thirdpartyId);
 			}
 		}

--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -518,7 +518,8 @@ abstract class AbstractPDPProvider
 		if (!isset($object->thirdparty->id)) {
 			$object->fetch_thirdparty();
 		}
-		$actioncomm->socid = $object->thirdparty->id;
+		// $object->thirdparty may still be null (e.g. document/flow with no resolvable socid)
+		$actioncomm->socid = is_object($object->thirdparty ?? null) ? $object->thirdparty->id : 0;
 		$actioncomm->label = $eventLabel;
 		$actioncomm->note_private = $eventMesg;
 		$actioncomm->fk_project = $object->fk_project;

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -1289,6 +1289,18 @@ class SuperPDPProvider extends AbstractPDPProvider
 				// --- Fetch received documents (Einvoice)
 				$document->fk_element_type = FactureFournisseur::class;
 
+				// AFNOR XP Z12-013: a supplier invoice to book is an INCOMING flow (issued by the
+				// platform to us). An outgoing/errored "SupplierInvoice" flow is NOT a received
+				// invoice and must not be imported as a facture fournisseur — otherwise lifecycle
+				// actions (e.g. a refusal) fail on the PDP side with "no matching invoices found".
+				if ($document->flow_direction !== 'In') {
+					$document->fk_element_id = 0;
+					$returnRes = 1;		// mark the flow as processed, just do not create an invoice
+					$returnMessage = "Skipped SupplierInvoice flow " . $flowId . " (flowDirection=" . ($document->flow_direction ?: 'null') . ", not an incoming invoice)";
+					dol_syslog(__METHOD__ . " " . $returnMessage, LOG_WARNING, 0, "_einvoicing");
+					break;
+				}
+
 				// Retrieve the PDF file converted by Access Point
 				$receivedFile = null;
 				/*

--- a/einvoicing/class/utils/CdarHandler.class.php
+++ b/einvoicing/class/utils/CdarHandler.class.php
@@ -384,6 +384,25 @@ class CdarHandler
 	// ==================== PRIVATE HELPERS ====================
 
 	/**
+	 * Register the known CDAR namespaces on the given element so that prefixed
+	 * XPath queries resolve. Must be done on every element (root AND sub-nodes
+	 * returned by xpath()), otherwise libxml raises "Undefined namespace prefix"
+	 * and the query silently returns false.
+	 *
+	 * @param  SimpleXMLElement $xml xml element
+	 * @return SimpleXMLElement       same element, for chaining
+	 */
+	private function registerNamespaces($xml)
+	{
+		if ($xml instanceof SimpleXMLElement) {
+			foreach ($this->namespaces as $prefix => $uri) {
+				$xml->registerXPathNamespace($prefix, $uri);
+			}
+		}
+		return $xml;
+	}
+
+	/**
 	 * getXpathValue
 	 *
 	 * @param  SimpleXmlElement $xml xml
@@ -393,6 +412,7 @@ class CdarHandler
 	 */
 	private function getXpathValue($xml, $path, $default = '')
 	{
+		$this->registerNamespaces($xml);
 		$result = $xml->xpath($path);
 
 		return !empty($result) ? (string) $result[0] : $default;
@@ -409,6 +429,7 @@ class CdarHandler
 	 */
 	private function getXpathAttribute($xml, $path, $attribute, $default = '')
 	{
+		$this->registerNamespaces($xml);
 		$result = $xml->xpath($path);
 
 		return !empty($result) ? (string) $result[0][$attribute] : $default;
@@ -584,13 +605,13 @@ class CdarHandler
 			]
 		];
 
-		$statusNodes = $xml->xpath('//ram:ReferenceReferencedDocument/ram:SpecifiedDocumentStatus');
+		$statusNodes = $this->registerNamespaces($xml)->xpath('//ram:ReferenceReferencedDocument/ram:SpecifiedDocumentStatus');
 		if (!empty($statusNodes)) {
 			$status = $statusNodes[0];
 			$result['StatusReasonCode'] = $this->getXpathValue($status, 'ram:ReasonCode');
 			$result['StatusReason'] = $this->getXpathValue($status, 'ram:Reason');
 
-			$seqResult = $status->xpath('ram:SequenceNumeric');
+			$seqResult = $this->registerNamespaces($status)->xpath('ram:SequenceNumeric');
 			if (!empty($seqResult)) {
 				$result['StatusSequenceNumeric'] = (int) $seqResult[0];
 			}
@@ -598,7 +619,7 @@ class CdarHandler
 			// Collect all note contents from all SpecifiedDocumentStatus nodes
 			$allContents = [];
 			foreach ($statusNodes as $statusNode) {
-				$contentNodes = $statusNode->xpath('ram:IncludedNote/ram:Content');
+				$contentNodes = $this->registerNamespaces($statusNode)->xpath('ram:IncludedNote/ram:Content');
 				if (!empty($contentNodes)) {
 					foreach ($contentNodes as $node) {
 						$content = trim((string) $node);


### PR DESCRIPTION
Fixes on the inbound flow reception path (supplier invoice import), found running against a real PDP (SuperPDP sandbox, PHP 8.4).

- CDAR/CII XPath: namespaces (ram/qdt/…) were only registered on the root element, so `xpath()` on sub-nodes raised "Undefined namespace prefix" and returned empty → lifecycle/status fields parsed empty. Register them on every queried element.
- Thirdparty matching: `findNearest()` returns the rowid (it does not populate `$thirdparty->id`); the code used `$thirdparty->id` → empty id, falling through to a misleading "auto-creation of thirdparties is disabled" error even with a matching thirdparty present.
- Populate SIREN from `SpecifiedLegalOrganization` (merge its id into the GlobalIds) so `idprof1` is set on imported/matched suppliers.
- Only import `flowType=SupplierInvoice` when `flowDirection=In` (per AFNOR XP Z12-013, Figure 1) → an outgoing/errored flow is no longer booked as a received supplier invoice (which later made a refusal CDAR fail PDP-side with "no matching invoices found").

Tested: inbound flow → supplier invoice created with thirdparty (SIREN/VAT) and products, on the SuperPDP sandbox.
