### PR TITLE
fix(einvoicing): robustness (qdt parse, null due date, SIRET, sync recap)

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -965,6 +965,8 @@ class CIIProtocol extends AbstractProtocol
 		$xpath->registerNamespace('rsm', 'urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100');
 		$xpath->registerNamespace('ram', 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100');
 		$xpath->registerNamespace('udt', 'urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100');
+		// qdt is used by some date paths (e.g. ram:FormattedIssueDateTime/qdt:DateTimeString); without it those xpath queries return empty.
+		$xpath->registerNamespace('qdt', 'urn:un:unece:uncefact:data:standard:QualifiedDataType:100');
 
 		return [$doc, $xpath];
 	}
@@ -1604,12 +1606,15 @@ class CIIProtocol extends AbstractProtocol
 
 		$terms->appendChild($doc->createElement('ram:Description', $invoiceData['paymentTermsText']));
 
-		$dtNode = $doc->createElement('ram:DueDateDateTime');
-		$str = $doc->createElement('udt:DateTimeString', $invoiceData['paymentDueDate']->format('Ymd'));
-		$str->setAttribute('format', '102');
-		$dtNode->appendChild($str);
+		// Due date is optional (e.g. immediate payment); guard against a null date to avoid a fatal on ->format().
+		if (!empty($invoiceData['paymentDueDate'])) {
+			$dtNode = $doc->createElement('ram:DueDateDateTime');
+			$str = $doc->createElement('udt:DateTimeString', $invoiceData['paymentDueDate']->format('Ymd'));
+			$str->setAttribute('format', '102');
+			$dtNode->appendChild($str);
 
-		$terms->appendChild($dtNode);
+			$terms->appendChild($dtNode);
+		}
 
 		// Totals
 

--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -1087,6 +1087,7 @@ trait CommonProtocol
 		$map = [
 			'0002' => 'idprof1',	// SIREN
 			'0225' => 'idprof1',	// SIREN
+			'0009' => 'idprof2',	// SIRET
 		];
 
 		return $map[$scheme] ?? '';

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -1135,7 +1135,7 @@ class SuperPDPProvider extends AbstractPDPProvider
 		$processingResult .= "<br>----------------------<br>" . implode("<br>", $messages);
 		$processingResult = "Processing result:<br>" . $processingResult;
 
-		// Save sync recap
+		// Save sync recap (only when this sync is attached to a Call row; otherwise $sql would be undefined/stale)
 		if ($call_id) {
 			$sql = "UPDATE " . MAIN_DB_PREFIX . "einvoicing_call";
 			$sql .= " SET totalflow = " . (is_null($totalFlows) ? "null" : ((int) $totalFlows)) . ",
@@ -1145,9 +1145,8 @@ class SuperPDPProvider extends AbstractPDPProvider
                 processing_result = '" . $db->escape($processingResult) . "',
                     fk_user_modif = " . ((int) $user->id) . "
             WHERE call_id = '" . $db->escape($call_id) . "'";
+			$db->query($sql);
 		}
-
-		$db->query($sql);
 
 		// Return result
 		// 'actions' contains the action to do (in case of business error)


### PR DESCRIPTION
Misc robustness fixes found while auditing the module against AFNOR XP Z12-013 / Factur-X (CII).

- `CIIProtocol::initXPath()` registered rsm/ram/udt but not `qdt`, while parse paths use `qdt:DateTimeString` (e.g. referenced-document issue date) → those queries silently returned empty. Register `qdt`.
- CII payment terms: `$invoiceData['paymentDueDate']->format('Ymd')` had no null guard → fatal when building an invoice with no due date (immediate payment).
- `_mapGlobalIdSchemeToIdprof()` missed scheme `0009` (SIRET) → a party identified only by SIRET could not be mapped to `idprof2`.
- `syncFlows()` ran `$db->query($sql)` outside the `if ($call_id)` block, re-executing a stale `$sql` when no Call row is attached. Move it inside.
