### PR TITLE
Fix bad socid property

### DIFF
--- a/einvoicing/core/triggers/interface_99_modEInvoicing_EInvoicingTriggers.class.php
+++ b/einvoicing/core/triggers/interface_99_modEInvoicing_EInvoicingTriggers.class.php
@@ -69,7 +69,7 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 			/** @var Societe $object */
 			$einvoicing = new EInvoicing($this->db);
 
-			$socId = $object->socid;
+			$socId = $object->id;
 
 			// Thirdparty routing ID
 			$routingId = GETPOST('routing_id', 'alphanohtml');


### PR DESCRIPTION
`$object` is an instance of `Societe`, therefore `$socid `value is `$object->id` and not `$object->socid`