### PR TITLE
fix(einvoicing): make SuperPDP token renewal work (refresh_token grant + token endpoint routing)

### DIFF
--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -428,10 +428,37 @@ class SuperPDPProvider extends AbstractPDPProvider
 	 */
 	public function refreshAccessToken()
 	{
-		// Get access token from OAUth server and save it into database.
-		$result = $this->getAccessToken();
+		// OAuth 2.1: when a refresh_token is available (Authorization Code grant), renew the access token
+		// with grant_type=refresh_token instead of re-authenticating from scratch. A full re-auth opens a
+		// new session on the PA each time, whereas refreshing does not. The refresh token is rotated on each
+		// use, so we must persist the new one returned by the server.
+		if (!empty($this->tokenData['refresh_token'])) {
+			$providerconfig = $this->getConf();
 
-		return $result;
+			$param = array(
+				'grant_type'    => 'refresh_token',
+				'refresh_token' => $this->tokenData['refresh_token'],
+				'client_id'     => $providerconfig['client_id'],
+				'client_secret' => $providerconfig['client_secret'],
+			);
+			$paramstring = http_build_query($param);
+			$extraHeaders = array('Content-Type' => 'application/x-www-form-urlencoded');
+
+			$response = $this->callApi("token", "POST", $paramstring, $extraHeaders, 'refresh_access_token');
+			$status_code = $response['status_code'] ?? 0;
+			$body = $response['response'] ?? null;
+
+			if ($status_code == 200 && is_array($body) && isset($body['access_token']) && isset($body['expires_in'])) {
+				// Persist the rotated refresh_token (keep the previous one if the server did not rotate it).
+				$this->saveOAuthTokenDB($body['access_token'], $body['refresh_token'] ?? $this->tokenData['refresh_token'], $body['expires_in']);
+				$this->tokenData = $this->fetchOAuthTokenDB();
+				return $body['access_token'];
+			}
+			// Refresh failed (refresh token expired or already rotated away): fall through to a full re-auth.
+		}
+
+		// No refresh token (e.g. Client Credentials grant, which issues none) or refresh failed: re-authenticate.
+		return $this->getAccessToken();
 	}
 
 	/**

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -815,7 +815,9 @@ class SuperPDPProvider extends AbstractPDPProvider
 
 		require_once DOL_DOCUMENT_ROOT . '/core/lib/geturl.lib.php';
 
-		$url = $this->getApiUrl(($callType == 'get_access_token') ? 'auth' : 'api') . $resource;
+		// The OAuth token endpoint lives on the auth base (/oauth2/), not the Flow API base. This applies to
+		// every token grant: client_credentials, authorization_code and refresh_token.
+		$url = $this->getApiUrl(($resource == 'token' || $callType == 'get_access_token') ? 'auth' : 'api') . $resource;
 
 		if (!isset($extraHeaders['Content-Type'])) {
 			$httpheader[] = 'Content-Type: application/json';


### PR DESCRIPTION
Two fixes so SuperPDP access tokens renew via the OAuth 2.1 refresh token instead of re-authenticating from scratch — which opens a new PA session at every renewal (~every 30 min of activity).

- `refreshAccessToken()` only called `getAccessToken()` (full re-auth). It now uses `grant_type=refresh_token` when a refresh token is available, persists the rotated refresh token (OAuth 2.1 rotates it on each use), and falls back to a full re-auth otherwise (e.g. the Client Credentials grant, which issues none).
- `callApi()` routed only `callType=='get_access_token'` to the OAuth base (`/oauth2/`), so the refresh_token and authorization_code grants were sent to the Flow API base (`/afnor-flow/v1/token`) and returned HTTP 404. Route any call to the `token` resource to the auth base.

Benefits modes that obtain a refresh token (e.g. the SUPERPDPViaPartner proxy callback, which already stores one). Verified on a sandbox account over a ~1h wait: after expiry, an API call renews via `grant_type=refresh_token`, the refresh token rotates, and no new session is created.
