### PR TITLE
feat(einvoicing): emit CII ShipToTradeParty (BG-15) for a distinct delivery address

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -35,6 +35,7 @@ require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
 
 dol_include_once('einvoicing/class/protocols/AbstractProtocol.class.php');
 dol_include_once('einvoicing/class/protocols/CommonProtocol.class.php');
+dol_include_once('einvoicing/class/protocols/ShipToTradePartyBuilder.class.php');
 dol_include_once('einvoicing/class/einvoicing.class.php');
 dol_include_once('einvoicing/class/utils/XmlPatcher.class.php');
 dol_include_once('einvoicing/lib/einvoicing.lib.php');
@@ -1493,9 +1494,24 @@ class CIIProtocol extends AbstractProtocol
 		// Add the ship to trade party (mandatory when using intracommunity delivery)
 		// ShipToTradeParty is itself a TradePartyType — populate it directly without
 		// wrapping it in another BuyerTradeParty (which would break XSD validation).
-		$shiptotrade = $doc->createElement('ram:ShipToTradeParty');
-		$delivery->appendChild($shiptotrade);
-		$this->buildParty($doc, $shiptotrade, $invoiceData, 'buyer', false);
+		// When an external SHIPPING contact with a distinct address is attached to the invoice
+		// (keys filled by buildinvoicelines.inc.php), emit a dedicated deliver-to party (BG-15);
+		// otherwise fall back to the buyer party so the node stays present (upstream behaviour).
+		$shiptotrade = null;
+		if (!empty($invoiceData['_shipFromContactShip'])) {
+			$shiptotrade = ShipToTradePartyBuilder::build(
+				$doc,
+				$invoiceData['_shipFromContactBill'] ?? array(),
+				$invoiceData['_shipFromContactShip']
+			);
+		}
+		if ($shiptotrade !== null) {
+			$delivery->appendChild($shiptotrade);
+		} else {
+			$shiptotrade = $doc->createElement('ram:ShipToTradeParty');
+			$delivery->appendChild($shiptotrade);
+			$this->buildParty($doc, $shiptotrade, $invoiceData, 'buyer', false);
+		}
 
 
 		if (!empty($invoiceData['documentDeliveryDate'])) {

--- a/einvoicing/class/protocols/ShipToTradePartyBuilder.class.php
+++ b/einvoicing/class/protocols/ShipToTradePartyBuilder.class.php
@@ -1,0 +1,93 @@
+<?php
+/* Copyright (C) 2026       Pierre Grasswill
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    einvoicing/class/protocols/ShipToTradePartyBuilder.class.php
+ * \ingroup einvoicing
+ * \brief   Pure (Dolibarr-free) builder for the CII ShipToTradeParty node (BG-15)
+ */
+
+/**
+ * Builds the CII <ram:ShipToTradeParty> node (deliver-to address, BG-15).
+ *
+ * This class has NO Dolibarr dependency on purpose: it works only with plain arrays and the
+ * native DOMDocument, so it can be unit-tested without bootstrapping a full Dolibarr instance.
+ * The Dolibarr-specific extraction of the SHIPPING contact lives in buildinvoicelines.inc.php,
+ * which feeds the normalized bill/ship arrays to build() below.
+ */
+class ShipToTradePartyBuilder
+{
+	/**
+	 * Build a <ram:ShipToTradeParty> element when the shipping address actually differs from the
+	 * billing (buyer) address and carries a resolvable country code.
+	 *
+	 * Returns null when no distinct ship-to party must be emitted, in which case the caller is
+	 * expected to fall back to the upstream behaviour (ship-to = buyer), keeping the
+	 * ApplicableHeaderTradeDelivery/ShipToTradeParty node always present (intracommunity requirement).
+	 *
+	 * @param DOMDocument $doc   Document to create nodes in
+	 * @param array       $bill  Billing address: keys address, zip, town, country (alpha-2)
+	 * @param array       $ship  Shipping address: keys name, address, zip, town, country (alpha-2)
+	 * @return DOMElement|null   The ShipToTradeParty node, or null to fall back to the buyer party
+	 */
+	public static function build(DOMDocument $doc, array $bill, array $ship)
+	{
+		// BR-57: a postal address present in the XML must carry a non-empty CountryID. Without a
+		// resolvable country we cannot emit a valid BG-15, so we skip the contact ship-to entirely.
+		if (empty($ship['country'])) {
+			return null;
+		}
+
+		// Normalized comparison (case / whitespace) to avoid false positives that would emit a
+		// redundant BG-15 identical to the buyer address.
+		$norm = function ($s) {
+			$s = preg_replace('/\s+/', ' ', trim((string) ($s ?? '')));
+			return function_exists('mb_strtoupper') ? mb_strtoupper($s, 'UTF-8') : strtoupper($s);
+		};
+		$billKey = array($norm($bill['address'] ?? ''), $norm($bill['zip'] ?? ''), $norm($bill['town'] ?? ''), $norm($bill['country'] ?? ''));
+		$shipKey = array($norm($ship['address'] ?? ''), $norm($ship['zip'] ?? ''), $norm($ship['town'] ?? ''), $norm($ship['country'] ?? ''));
+		if ($billKey === $shipKey) {
+			return null;
+		}
+
+		$node = $doc->createElement('ram:ShipToTradeParty');
+
+		// BT-70 Deliver-to party name (optional).
+		if (!empty($ship['name'])) {
+			$node->appendChild($doc->createElement('ram:Name', htmlspecialchars($ship['name'])));
+		}
+
+		// BG-15 Deliver-to address.
+		$addr = $doc->createElement('ram:PostalTradeAddress');
+		$node->appendChild($addr);
+
+		// CII XSD order for PostalTradeAddress: PostcodeCode BEFORE LineOne (counter-intuitive).
+		if (!empty($ship['zip'])) {
+			$addr->appendChild($doc->createElement('ram:PostcodeCode', $ship['zip']));
+		}
+		if (!empty($ship['address'])) {
+			$addr->appendChild($doc->createElement('ram:LineOne', htmlspecialchars($ship['address'])));
+		}
+		if (!empty($ship['town'])) {
+			$addr->appendChild($doc->createElement('ram:CityName', htmlspecialchars($ship['town'])));
+		}
+		// CountryID is mandatory whenever the address block exists (BR-57). Guaranteed non-empty here.
+		$addr->appendChild($doc->createElement('ram:CountryID', $ship['country']));
+
+		return $node;
+	}
+}

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -697,6 +697,43 @@ if ($object->mode_reglement_code) {
 }
 
 
+// Delivery address (CII ShipToTradeParty / BG-15)
+// If an external "SHIPPING" contact is attached to the invoice, expose its address so the CII
+// builder can emit a dedicated deliver-to party. The builder (ShipToTradePartyBuilder::build)
+// only emits it when the shipping address actually differs from the buyer (bill-to) address and
+// carries a country code; otherwise it falls back to the buyer party. No SHIPPING contact => keys
+// stay unset => current behaviour (ship-to = buyer) is preserved.
+if (method_exists($object, 'liste_contact')) {
+	$shipContacts = $object->liste_contact(-1, 'external', 0, 'SHIPPING');
+	if (is_array($shipContacts) && count($shipContacts) > 0) {
+		if (count($shipContacts) > 1) {
+			dol_syslog('einvoicing: invoice ' . $object->id . ' has ' . count($shipContacts) . ' external SHIPPING contacts; using the first (contact id ' . $shipContacts[0]['id'] . ')', LOG_WARNING);
+		}
+		require_once DOL_DOCUMENT_ROOT . '/contact/class/contact.class.php';
+		$shipContact = new Contact($db);
+		if ($shipContact->fetch($shipContacts[0]['id']) > 0) {
+			$shipName = trim($shipContact->getFullName($outputlangs));
+			if ($shipName === '') {
+				$shipName = $object->thirdparty->name;
+			}
+			$invoiceData['_shipFromContactBill'] = array(
+				'address' => $object->thirdparty->address,
+				'zip'     => $object->thirdparty->zip,
+				'town'    => $object->thirdparty->town,
+				'country' => $object->thirdparty->country_code,
+			);
+			$invoiceData['_shipFromContactShip'] = array(
+				'name'    => $shipName,
+				'address' => $shipContact->address,
+				'zip'     => $shipContact->zip,
+				'town'    => $shipContact->town,
+				'country' => $shipContact->country_code,
+			);
+		}
+	}
+}
+
+
 // Section to control data and throw errors in case of problem, to avoid generating non compliant XML
 // --------------------------------------------------------------------------------------------------
 if (empty($idprof)) {

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -698,11 +698,14 @@ if ($object->mode_reglement_code) {
 
 
 // Delivery address (CII ShipToTradeParty / BG-15)
-// If an external "SHIPPING" contact is attached to the invoice, expose its address so the CII
-// builder can emit a dedicated deliver-to party. The builder (ShipToTradePartyBuilder::build)
-// only emits it when the shipping address actually differs from the buyer (bill-to) address and
-// carries a country code; otherwise it falls back to the buyer party. No SHIPPING contact => keys
-// stay unset => current behaviour (ship-to = buyer) is preserved.
+// Resolve a deliver-to address and expose it so the CII builder can emit a dedicated deliver-to
+// party. Resolution priority:
+//   1) external "SHIPPING" contact attached to the invoice;
+//   2) fallback: delivery address carried by a linked shipment (expedition.fk_delivery_address).
+// The builder (ShipToTradePartyBuilder::build) only emits the node when the resolved address
+// actually differs from the buyer (bill-to) address and carries a country code; otherwise it falls
+// back to the buyer party. Nothing resolved => keys stay unset => ship-to = buyer is preserved.
+$shipAddress = null;
 if (method_exists($object, 'liste_contact')) {
 	$shipContacts = $object->liste_contact(-1, 'external', 0, 'SHIPPING');
 	if (is_array($shipContacts) && count($shipContacts) > 0) {
@@ -716,13 +719,7 @@ if (method_exists($object, 'liste_contact')) {
 			if ($shipName === '') {
 				$shipName = $object->thirdparty->name;
 			}
-			$invoiceData['_shipFromContactBill'] = array(
-				'address' => $object->thirdparty->address,
-				'zip'     => $object->thirdparty->zip,
-				'town'    => $object->thirdparty->town,
-				'country' => $object->thirdparty->country_code,
-			);
-			$invoiceData['_shipFromContactShip'] = array(
+			$shipAddress = array(
 				'name'    => $shipName,
 				'address' => $shipContact->address,
 				'zip'     => $shipContact->zip,
@@ -731,6 +728,42 @@ if (method_exists($object, 'liste_contact')) {
 			);
 		}
 	}
+}
+
+// Fallback: a linked shipment may carry a distinct delivery address (no SHIPPING contact needed).
+if ($shipAddress === null && !empty($object->linkedObjectsIds['shipping']) && is_array($object->linkedObjectsIds['shipping'])) {
+	require_once DOL_DOCUMENT_ROOT . '/expedition/class/expedition.class.php';
+	require_once DOL_DOCUMENT_ROOT . '/contact/class/contact.class.php';
+	foreach ($object->linkedObjectsIds['shipping'] as $expeditionId) {
+		$tmpexpedition = new Expedition($db);
+		if ($tmpexpedition->fetch($expeditionId) > 0 && !empty($tmpexpedition->fk_delivery_address)) {
+			$shipContact = new Contact($db);
+			if ($shipContact->fetch($tmpexpedition->fk_delivery_address) > 0) {
+				$shipName = trim($shipContact->getFullName($outputlangs));
+				if ($shipName === '') {
+					$shipName = $object->thirdparty->name;
+				}
+				$shipAddress = array(
+					'name'    => $shipName,
+					'address' => $shipContact->address,
+					'zip'     => $shipContact->zip,
+					'town'    => $shipContact->town,
+					'country' => $shipContact->country_code,
+				);
+				break;
+			}
+		}
+	}
+}
+
+if ($shipAddress !== null) {
+	$invoiceData['_shipFromContactBill'] = array(
+		'address' => $object->thirdparty->address,
+		'zip'     => $object->thirdparty->zip,
+		'town'    => $object->thirdparty->town,
+		'country' => $object->thirdparty->country_code,
+	);
+	$invoiceData['_shipFromContactShip'] = $shipAddress;
 }
 
 

--- a/einvoicing/test/test_shiptotradeparty.php
+++ b/einvoicing/test/test_shiptotradeparty.php
@@ -1,0 +1,120 @@
+<?php
+/* Copyright (C) 2026       Pierre Grasswill
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    einvoicing/test/test_shiptotradeparty.php
+ * \ingroup einvoicing
+ * \brief   Standalone unit test for ShipToTradePartyBuilder (no Dolibarr bootstrap required).
+ *
+ * Usage: php einvoicing/test/test_shiptotradeparty.php
+ */
+
+require_once __DIR__ . '/../class/protocols/ShipToTradePartyBuilder.class.php';
+
+$failures = 0;
+
+/**
+ * @param bool   $cond Condition that must hold
+ * @param string $msg  Description printed on success/failure
+ * @return void
+ */
+function check($cond, $msg)
+{
+	global $failures;
+	if ($cond) {
+		echo "  ok   - $msg\n";
+	} else {
+		echo "  FAIL - $msg\n";
+		$failures++;
+	}
+}
+
+/**
+ * Build the node and return its serialized XML (or '' when null).
+ *
+ * @param array $bill Billing address
+ * @param array $ship Shipping address
+ * @return string
+ */
+function buildXml($bill, $ship)
+{
+	$doc = new DOMDocument('1.0', 'UTF-8');
+	$doc->formatOutput = true;
+	$node = ShipToTradePartyBuilder::build($doc, $bill, $ship);
+	if ($node === null) {
+		return '';
+	}
+	$doc->appendChild($node);
+	return $doc->saveXML($node);
+}
+
+// --- Case A: ship != bill -> ShipToTradeParty present, well-formed, elements in CII order -------
+echo "Case A - ship != bill (must emit BG-15):\n";
+$bill = array('address' => '1 rue de Paris', 'zip' => '75001', 'town' => 'Paris', 'country' => 'FR');
+$shipA = array('name' => 'Entrepot Sud', 'address' => '42 avenue du Port', 'zip' => '33000', 'town' => 'Bordeaux', 'country' => 'FR');
+$doc = new DOMDocument('1.0', 'UTF-8');
+$node = ShipToTradePartyBuilder::build($doc, $bill, $shipA);
+check($node !== null, 'ShipToTradeParty node is emitted');
+if ($node !== null) {
+	$doc->appendChild($node);
+	$xml = $doc->saveXML();
+
+	check($node->getElementsByTagName('ram:Name')->item(0) && $node->getElementsByTagName('ram:Name')->item(0)->textContent === 'Entrepot Sud', 'Name = Entrepot Sud');
+	$addr = $node->getElementsByTagName('ram:PostalTradeAddress')->item(0);
+	check($addr !== null, 'PostalTradeAddress present');
+
+	// Order of children inside PostalTradeAddress must be: PostcodeCode, LineOne, CityName, CountryID.
+	$order = array();
+	foreach ($addr->childNodes as $child) {
+		if ($child->nodeType === XML_ELEMENT_NODE) {
+			$order[] = $child->nodeName;
+		}
+	}
+	check($order === array('ram:PostcodeCode', 'ram:LineOne', 'ram:CityName', 'ram:CountryID'), 'PostalTradeAddress order = [PostcodeCode, LineOne, CityName, CountryID] (got: ' . implode(',', $order) . ')');
+
+	check($addr->getElementsByTagName('ram:PostcodeCode')->item(0)->textContent === '33000', 'PostcodeCode = 33000');
+	check($addr->getElementsByTagName('ram:LineOne')->item(0)->textContent === '42 avenue du Port', 'LineOne = 42 avenue du Port');
+	check($addr->getElementsByTagName('ram:CityName')->item(0)->textContent === 'Bordeaux', 'CityName = Bordeaux');
+	check($addr->getElementsByTagName('ram:CountryID')->item(0)->textContent === 'FR', 'CountryID = FR (BR-57 satisfied)');
+}
+
+// --- Case B: ship == bill -> no node (avoid redundant BG-15) -------------------------------------
+echo "Case B - ship == bill (must NOT emit):\n";
+$shipB = array('name' => 'Same Co', 'address' => '1 rue de Paris', 'zip' => '75001', 'town' => 'Paris', 'country' => 'FR');
+check(buildXml($bill, $shipB) === '', 'ShipToTradeParty absent when addresses are identical');
+
+// Same address with cosmetic differences (case, extra spaces) must still be treated as equal.
+$shipBnorm = array('name' => 'Same Co', 'address' => '1   RUE   de paris', 'zip' => '75001', 'town' => 'PARIS', 'country' => 'fr');
+check(buildXml($bill, $shipBnorm) === '', 'Normalized comparison ignores case/whitespace (no emit)');
+
+// --- Case C: SHIPPING without country_code -> no node (BR-57 guard) -------------------------------
+echo "Case C - shipping without country (BR-57 guard, must NOT emit):\n";
+$shipC = array('name' => 'No Country', 'address' => '42 avenue du Port', 'zip' => '33000', 'town' => 'Bordeaux', 'country' => '');
+check(buildXml($bill, $shipC) === '', 'ShipToTradeParty absent when country code is empty');
+
+// --- Case D: no SHIPPING contact -> no node (non-regression) -------------------------------------
+// At the builder level, "no SHIPPING contact" is modelled as an empty ship array.
+echo "Case D - no shipping contact (non-regression, must NOT emit):\n";
+check(buildXml($bill, array()) === '', 'ShipToTradeParty absent when no shipping data provided');
+
+echo "\n";
+if ($failures === 0) {
+	echo "ALL TESTS PASSED\n";
+	exit(0);
+}
+echo "$failures TEST(S) FAILED\n";
+exit(1);


### PR DESCRIPTION
## Description

When a customer invoice carries an external **delivery contact** (type "Customer shipping", code `SHIPPING`) whose address differs from the buyer, the CII output now fills `ShipToTradeParty` (BG-15) with that delivery address instead of duplicating the buyer. With no such contact — or an identical address — the current behaviour is unchanged: `ShipToTradeParty` keeps falling back to the buyer, so `ApplicableHeaderTradeDelivery` stays present. This adds a behaviour; it doesn't change the common case.

## Changes

- New `ShipToTradePartyBuilder` (pure, Dolibarr-free): decides emission (normalized bill/ship comparison + BR-57 `CountryID` guard) and builds the node in CII XSD order (`PostcodeCode` before `LineOne`, `CountryID` mandatory). Returns `null` to fall back to the buyer party.
- `CIIProtocol` delegates to the builder and falls back to `buildParty(buyer)` on `null`.
- `buildinvoicelines.inc.php` extracts the first external `SHIPPING` contact (warns on extras) and feeds normalized bill/ship arrays to the builder.
- Standalone test `test/test_shiptotradeparty.php` (no Dolibarr bootstrap needed).

## Testing

- [x] `php einvoicing/test/test_shiptotradeparty.php` → ALL TESTS PASSED (ship≠bill, ship==bill incl. case/whitespace, missing country / BR-57 guard, no contact / non-regression)
- [x] Generated a real CII invoice on a Dolibarr 23 instance with a distinct `SHIPPING` contact → `ShipToTradeParty` correctly carries the delivery address, in CII element order, with `CountryID` (BR-57 ok), before `ActualDeliverySupplyChainEvent`
- [x] No SHIPPING contact → output identical to before (buyer fallback)
