### PR TITLE
[Einvoicing] NEW can't delete doc if e-invoice linked to Dol supplier invoice

### DIFF
--- a/einvoicing/class/helpers/SupplierInvoiceHelper.class.php
+++ b/einvoicing/class/helpers/SupplierInvoiceHelper.class.php
@@ -4,6 +4,7 @@ use horstoeko\zugferd\ZugferdDocumentPdfReaderExt;
 
 dol_include_once('einvoicing/class/protocols/ProtocolManager.class.php');
 dol_include_once('einvoicing/class/document.class.php');
+dol_include_once('fourn/class/fournisseur.facture.class.php');
 
 /**
  * \file    einvoicing/class/helpers/SupplierInvoiceHelper.class.php
@@ -252,10 +253,11 @@ class SupplierInvoiceHelper
 	 * Allow to known if a supplier invoice is an e-invoice or not
 	 *
 	 * @param int $supplierInvoiceId The id of the supplier invoice
+	 * @param bool $checkLinkedDolObjectExistance Also check if linked Dol object really exists or not
 	 * @throws Exception
 	 * @return bool
 	 */
-	public static function isEInvoice(int $supplierInvoiceId): bool
+	public static function isEInvoice(int $supplierInvoiceId, bool $checkLinkedDolObjectExistance = false): bool
 	{
 		global $db;
 
@@ -267,7 +269,10 @@ class SupplierInvoiceHelper
 		$resql = $db->query($sql);
 		if ($resql) {
 			if ($db->num_rows($resql) == 1) {
-				return true;
+				$factureFournisseur = new FactureFournisseur($db);
+				if ($checkLinkedDolObjectExistance && $factureFournisseur->fetch((int) $supplierInvoiceId) > 0) {
+					return true;
+				}
 			} elseif ($db->num_rows($resql) > 1) {
 				throw new Exception('Duplicate entry in einvoicing_document for supplier invoice with id '.$supplierInvoiceId);
 			}

--- a/einvoicing/core/triggers/interface_99_modEInvoicing_EInvoicingTriggers.class.php
+++ b/einvoicing/core/triggers/interface_99_modEInvoicing_EInvoicingTriggers.class.php
@@ -238,6 +238,14 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 			}
 		}
 
+		// EINVOICING DOCUMENTS
+		if ($action == 'DOCUMENT_DELETE') {
+			if ($object->fk_element_type == 'invoice_supplier' && SupplierInvoiceHelper::isEInvoice($object->fk_element_id, true)) {
+				$this->errors[] = $langs->trans('EinvoicingCantDeleteADocumentLinkedToAnExistingSupplierInvoice', $object->id, $object->fk_element_id);
+				return -1;
+			}
+		}
+
 		return 0;
 	}
 }

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -326,6 +326,7 @@ SupplierInvoiceComparisonVatBasisDifference=Difference in VAT basis amount %s%% 
 SupplierInvoiceComparisonVatRateDifference=Difference in VAT amount %s%% (e-invoice: %s / Dolibarr invoice: %s)
 SupplierInvoiceComparisonVatRateNotFound=VAT rate of %s%% not found in the Dolibarr invoice
 SupplierInvoiceComparisonSuggestVatCalculationMode=recalculate invoice using Mode %s to get VAT amounts corresponding to e-invoice
+EinvoicingCantDeleteADocumentLinkedToAnExistingSupplierInvoice=Document n° %s can't be deleted because it is linked to the Dolibarr supplier invoice n° %s
 
 EINVOICING_CLIENT_ID=Client ID
 EINVOICING_CLIENT_SECRET=Client secret

--- a/einvoicing/langs/fr_FR/einvoicing.lang
+++ b/einvoicing/langs/fr_FR/einvoicing.lang
@@ -315,6 +315,7 @@ SupplierInvoiceComparisonVatBasisDifference=différence de montant de base pour 
 SupplierInvoiceComparisonVatRateDifference=différence de montant de TVA %s%% (e-facture : %s / facture Dolibarr : %s)
 SupplierInvoiceComparisonVatRateNotFound=taux de TVA à %s%% non trouvé dans la facture Dolibarr
 SupplierInvoiceComparisonSuggestVatCalculationMode=recalculer la TVA en Mode %s pour avoir des montants de TVA correspondant à l'e-facture d'origine
+EinvoicingCantDeleteADocumentLinkedToAnExistingSupplierInvoice=Le document n° %s ne peut pas être supprimé car il est lié à la facture fournisseur Dolibarr n° %s
 
 EINVOICING_CLIENT_ID=Client ID
 EINVOICING_CLIENT_SECRET=Client Secret


### PR DESCRIPTION
A document linked to an existing Dolibarr supplier invoice must not be deleted

:warning: Requires fix from PR #270 to work properly