### PR TITLE
fix(einvoicing): progress (situation) invoices billed 100% per line instead of the progressed amount (#258)

### DIFF
--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -425,6 +425,24 @@ foreach ($object->lines as $line) {
 	$line_total_ttc = $line->total_ttc;
 	*/
 
+	// Progress / situation invoices (facture de situation): Dolibarr keeps the FULL (100%) line
+	// amount in subprice*qty, while the amount actually billed for THIS situation - already net of
+	// the progress billed by previous situations - lives in $line->total_ht (the value shown on the
+	// PDF). Without correction the e-invoice would bill 100% of every line (issue #258). We fold the
+	// progress fraction into the unit price (BT-146) and keep the real billed quantity (BT-129), so
+	// BT-146 * BT-129 stays consistent with the line net amount BT-131. Unit price and quantity are
+	// both emitted with 2 decimals, so scaling the price - not the quantity - preserves that
+	// consistency even for non-round progress percentages (e.g. 33.33%).
+	if ($object->type == $object::TYPE_SITUATION) {
+		$line_full_ht = $line_total_ht;	// = $line_unit_price_with_discount * $line->qty (100% of the line)
+		$progress_ratio = ($line_full_ht != 0.0) ? ((float) $line->total_ht / $line_full_ht) : 0.0;
+
+		$line_unit_price = price2num($line_unit_price * $progress_ratio, 2);
+		$line_total_ht   = price2num($line_unit_price_with_discount * $progress_ratio * $line->qty, 2);
+		$line_total_tva  = price2num($line_total_ht * ($line->tva_tx > 0 ? number_format($line->tva_tx, 2, '.', '') / 100 : 0), 2);
+		$line_total_ttc  = price2num($line_total_ht + $line_total_tva, 2);
+	}
+
 	// Add (or update) VAT rate to $taxBreakdown
 	if (!isset($taxBreakdown[$line->tva_tx.($line->vat_src_code ? ' ('.$line->vat_src_code.')' : '')])) {
 		$taxBreakdown[$line->tva_tx.($line->vat_src_code ? ' ('.$line->vat_src_code.')' : '')] = ['tva_tx' => '', 'vat_src_code' => '', 'categoryVAT' => '', 'ExemptionReasonCode' => '', 'ExemptionReason' => '', 'totalHT' => 0, 'totalTVA' => 0];

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -409,14 +409,15 @@ foreach ($object->lines as $line) {
 	}
 	$line_unit_price_with_discount = price2num($line_unit_price_with_discount, getDolGlobalString('MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY', 'MU'));
 
-	// We need to recalculate the total using the Unit price rounded after discount percent (netpriceamount)and the Quantity, and rounding all temporary calculations after to 2
+	// We need to recalculate the total using the Unit price rounded after discount percent (netpriceamount) and the quantity, and rounding all temporary calculations after to 2
 	// according to EN16931 rules. This is a not accurate rule but it is the rule to follow for e-invoice.
 	// This means we may get a different result than Dolibarr default calculation if:
 	// - There is a discount percent AND the option MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY was not set or set to a value != MU
 	// or if
 	// - There is no discount percent but currency accuracy for total (MAIN_MAX_DECIMALS_UNIT) was not set to 2.
+	// TODO Use calculate_price() with a mode to round to 2 after each temporary calculation.
 	$line_total_ht = price2num($line_unit_price_with_discount * $line->qty, 2);				// Need to round to 2 as defined by EN16931 rules after each calculation.
-	$line_total_tva = price2num($line_unit_price_with_discount * $line->qty * ($line->tva_tx > 0 ? number_format($line->tva_tx, 2, '.', '') / 100 : 0), 2);
+	$line_total_tva = price2num($line_unit_price_with_discount * $line->qty * ($line->tva_tx > 0 ? $line->tva_tx / 100 : 0), 2);
 	$line_total_ttc = price2num($line_total_ht + $line_total_tva, 2);
 
 	// Uncomment for test using the most accurate possible calculation (but not following the e-invoice rule to round to 2 digit at each step of calculation)

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -404,7 +404,7 @@ foreach ($object->lines as $line) {
 	if ($line->remise_percent) {
 		$line_unit_price_with_discount = $line_unit_price * (1 - $line->remise_percent / 100);
 	}
-	if ($object->type == $object::TYPE_SITUATION && getDolGlobalString('INVOICE_USE_SITUATION') == 2 && $line->situation_percent) {
+	if ($object->type == $object::TYPE_SITUATION && $line->situation_percent) {
 		$line_unit_price_with_discount = $line_unit_price_with_discount * $line->situation_percent / 100;
 	}
 	$line_unit_price_with_discount = price2num($line_unit_price_with_discount, getDolGlobalString('MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY', 'MU'));

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -422,7 +422,7 @@ foreach ($object->lines as $line) {
 	// Uncomment for test using the most accurate possible calculation (but not following the e-invoice rule to round to 2 digit at each step of calculation)
 	if (getDolGlobalInt('EINVOICING_USE_DOLIBARR_ALREADY_CALCULATED_AMOUNTS')) {
 		$line_unit_price = $line->subprice;								// Note, 4 digits seems common accuracy for unit price with einvoice but default dolibarr setup is 5.
-		$line_unit_price_with_discount = price2num($line->subprice * (1 - $line->remise_percent / 100), 'MU');
+		$line_unit_price_with_discount = price2num($line->subprice * (1 - $line->remise_percent / 100) * ($line->situation_percent ? $line->situation_percent / 100 : 1), 'MU');
 		$line_total_ht = $line->total_ht;
 		$line_total_tva = $line->total_tva;
 		$line_total_ttc = $line->total_ttc;

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -402,8 +402,12 @@ foreach ($object->lines as $line) {
 
 	$line_unit_price_with_discount = $line_unit_price;
 	if ($line->remise_percent) {
-		$line_unit_price_with_discount = price2num($line_unit_price * (1 - $line->remise_percent / 100), getDolGlobalString('MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY', 'MU'));
+		$line_unit_price_with_discount = $line_unit_price * (1 - $line->remise_percent / 100);
 	}
+	if ($object->type == $object::TYPE_SITUATION && getDolGlobalString('INVOICE_USE_SITUATION') == 2) {
+		$line_unit_price_with_discount = $line_unit_price_with_discount * $line->situation_percent / 100;
+	}
+	$line_unit_price_with_discount = price2num($line_unit_price_with_discount, getDolGlobalString('MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY', 'MU'));
 
 	// We need to recalculate the total using the Unit price rounded after discount percent (netpriceamount)and the Quantity, and rounding all temporary calculations after to 2
 	// according to EN16931 rules. This is a not accurate rule but it is the rule to follow for e-invoice.
@@ -422,24 +426,6 @@ foreach ($object->lines as $line) {
 		$line_total_ht = $line->total_ht;
 		$line_total_tva = $line->total_tva;
 		$line_total_ttc = $line->total_ttc;
-	}
-
-	// Progress / situation invoices (facture de situation): Dolibarr keeps the FULL (100%) line
-	// amount in subprice*qty, while the amount actually billed for THIS situation - already net of
-	// the progress billed by previous situations - lives in $line->total_ht (the value shown on the
-	// PDF). Without correction the e-invoice would bill 100% of every line (issue #258). We fold the
-	// progress fraction into the unit price (BT-146) and keep the real billed quantity (BT-129), so
-	// BT-146 * BT-129 stays consistent with the line net amount BT-131. Unit price and quantity are
-	// both emitted with 2 decimals, so scaling the price - not the quantity - preserves that
-	// consistency even for non-round progress percentages (e.g. 33.33%).
-	if ($object->type == $object::TYPE_SITUATION && getDolGlobalString('INVOICE_USE_SITUATION') == 2) {
-		$progress_ratio = (float) $line->situation_percent / 100;
-
-		$line_unit_price_with_discount_and_situation = price2num($line_unit_price_with_discount * $progress_ratio, 'MU');
-		// $line_unit_price = price2num($line_unit_price_with_discount * $progress_ratio, 4);		// Note, 4 digits seems common accuracy for unit price with einvoice, but default dolibarr setup is 'MU' so 5.
-		$line_total_ht   = price2num($line_unit_price_with_discount_and_situation * $line->qty, 2);
-		$line_total_ttc  = price2num($line_total_ht + $line_total_tva, 2);
-		$line_total_tva  = price2num($line_total_ttc - $line_total_ht, 2);
 	}
 
 	// Add (or update) VAT rate to $taxBreakdown

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -395,10 +395,10 @@ foreach ($object->lines as $line) {
 	// Set amounts for the line
 
 	$line_unit_price = $line->subprice;
-	//$line_unit_price = price2num($line_unit_price, 4);			// Note, 4 digits seems common accuracy for unit price with einvoice, but default dolibarr setup is 5.
+	//$line_unit_price = price2num($line_unit_price, 4);			// Note, 4 digits seems common accuracy for unit price with einvoice, but default dolibarr setup is 'MU' so 5.
 
 	$line_unit_price_ttc = $line->subprice_ttc;
-	//$line_unit_price_ttc = price2num($line_unit_price_ttc, 4);	// Note, 4 digits seems common accuracy for unit price with einvoice, but default dolibarr setup is 5.
+	//$line_unit_price_ttc = price2num($line_unit_price_ttc, 4);	// Note, 4 digits seems common accuracy for unit price with einvoice, but default dolibarr setup is 'MU' so 5.
 
 	$line_unit_price_with_discount = $line_unit_price;
 	if ($line->remise_percent) {
@@ -432,14 +432,14 @@ foreach ($object->lines as $line) {
 	// BT-146 * BT-129 stays consistent with the line net amount BT-131. Unit price and quantity are
 	// both emitted with 2 decimals, so scaling the price - not the quantity - preserves that
 	// consistency even for non-round progress percentages (e.g. 33.33%).
-	if ($object->type == $object::TYPE_SITUATION) {
-		$line_full_ht = $line_total_ht;	// = $line_unit_price_with_discount * $line->qty (100% of the line)
-		$progress_ratio = ($line_full_ht != 0.0) ? ((float) $line->total_ht / $line_full_ht) : 0.0;
+	if ($object->type == $object::TYPE_SITUATION && getDolGlobalString('INVOICE_USE_SITUATION') == 2) {
+		$progress_ratio = (float) $line->situation_percent / 100;
 
-		$line_unit_price = price2num($line_unit_price * $progress_ratio, 2);
-		$line_total_ht   = price2num($line_unit_price_with_discount * $progress_ratio * $line->qty, 2);
-		$line_total_tva  = price2num($line_total_ht * ($line->tva_tx > 0 ? number_format($line->tva_tx, 2, '.', '') / 100 : 0), 2);
+		$line_unit_price_with_discount_and_situation = price2num($line_unit_price_with_discount * $progress_ratio, 'MU');
+		// $line_unit_price = price2num($line_unit_price_with_discount * $progress_ratio, 4);		// Note, 4 digits seems common accuracy for unit price with einvoice, but default dolibarr setup is 'MU' so 5.
+		$line_total_ht   = price2num($line_unit_price_with_discount_and_situation * $line->qty, 2);
 		$line_total_ttc  = price2num($line_total_ht + $line_total_tva, 2);
+		$line_total_tva  = price2num($line_total_ttc - $line_total_ht, 2);
 	}
 
 	// Add (or update) VAT rate to $taxBreakdown

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -404,7 +404,7 @@ foreach ($object->lines as $line) {
 	if ($line->remise_percent) {
 		$line_unit_price_with_discount = $line_unit_price * (1 - $line->remise_percent / 100);
 	}
-	if ($object->type == $object::TYPE_SITUATION && getDolGlobalString('INVOICE_USE_SITUATION') == 2) {
+	if ($object->type == $object::TYPE_SITUATION && getDolGlobalString('INVOICE_USE_SITUATION') == 2 && $line->situation_percent) {
 		$line_unit_price_with_discount = $line_unit_price_with_discount * $line->situation_percent / 100;
 	}
 	$line_unit_price_with_discount = price2num($line_unit_price_with_discount, getDolGlobalString('MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY', 'MU'));


### PR DESCRIPTION
Fixes #258

### Bug
On a progress / situation invoice (`Facture::TYPE_SITUATION`), the generated CII / Factur-X XML billed **100 % of every line**, ignoring the per-line progress. The PDF was correct (it uses `$line->total_ht`) but the e-invoice shipped the full amounts in `LineTotalAmount`, `TaxBasisTotalAmount` and `GrandTotalAmount`.

Example — two lines at 15 % and 5 % progress (1000 € and 500 € HT):

| | before | after |
|---|---|---|
| Line A `LineTotalAmount` | `1000.00` | `150.00` |
| Line B `LineTotalAmount` | `500.00` | `25.00` |
| `TaxBasisTotalAmount` | `1500.00` | `175.00` |
| `GrandTotalAmount` | `1800.00` | `210.00` |

### Fix
For `TYPE_SITUATION` invoices, fold the progress fraction — derived from the authoritative `$line->total_ht`, which already nets out the progress billed by previous situations — into the unit price (BT-146) while keeping the real billed quantity (BT-129). So `BT-146 × BT-129` stays consistent with the line net amount (BT-131), and the header totals recompute from the prorated line amounts (BR-CO-10 / BR-CO-13 stay satisfied). Shared by both the CII and Factur-X builders (`lib/buildinvoicelines.inc.php`).

Verified end-to-end on Dolibarr 23.0.3: regenerated XML matches the PDF.