### PR TITLE
fix(einvoicing): einvoicing_call.entity must be integer, not varchar (#259)

### DIFF
--- a/einvoicing/class/call.class.php
+++ b/einvoicing/class/call.class.php
@@ -148,7 +148,7 @@ class Call extends CommonObject
 		"status" => array("type" => "integer", "label" => "Status", "enabled" => "1", 'position' => 2000, 'notnull' => 1, "visible" => "1", "index" => "1", "arrayofkeyval" => array("0" => "success", "1" => "error", "9" => "warning"), "validate" => "1",),
 		"request_body" => array("type" => "text", "label" => "Request", "enabled" => "1", 'position' => 200, 'notnull' => 0, "visible" => "-1", "comment" => "Request body (JSON)"),
 		"response" => array("type" => "text", "label" => "RetreivedMessage", "enabled" => "1", 'position' => 201, 'notnull' => 0, "visible" => "-1", "comment" => "Full response body (JSON)", "help" => "Saved only if Debug mode is on"),
-		"entity" => array("type" => "varchar(50)", "label" => "entity", "enabled" => "1", 'position' => 1900, 'notnull' => 0, "visible" => "0", "comment" => "Multi-entity support"),
+		"entity" => array("type" => "integer", "label" => "entity", "enabled" => "1", 'position' => 1900, 'notnull' => 0, "visible" => "0", "comment" => "Multi-entity support"),
 	);
 	public $rowid;
 	public $call_id;

--- a/einvoicing/sql/llx_einvoicing_call.sql
+++ b/einvoicing/sql/llx_einvoicing_call.sql
@@ -34,6 +34,6 @@ CREATE TABLE llx_einvoicing_call(
 	response text, 
 	processing_result text, 
 	provider varchar(50) NOT NULL, 
-	entity varchar(50) DEFAULT 1
+	entity integer DEFAULT 1
 	-- END MODULEBUILDER FIELDS
 ) ENGINE=innodb;

--- a/einvoicing/sql/update_v1.0.3.sql
+++ b/einvoicing/sql/update_v1.0.3.sql
@@ -7,3 +7,13 @@ UPDATE llx_einvoicing_document SET fk_element_type = 'invoice_supplier' WHERE fk
 
 UPDATE llx_einvoicing_extlinks SET element_type = 'facture' WHERE element_type = 'Facture';
 UPDATE llx_einvoicing_extlinks SET element_type = 'invoice_supplier' WHERE element_type = 'FactureFournisseur';
+
+-- Issue #259: llx_einvoicing_call.entity was created as varchar(50) but is queried as an integer
+-- (WHERE entity IN (n)), which breaks on PostgreSQL. Normalize it to integer like
+-- llx_einvoicing_document.entity. Done in place to preserve existing data and indexes.
+-- One of the two statements below applies per database driver, the other is a harmless no-op:
+--   - MySQL/MariaDB accept the plain MODIFY and cast varchar -> int implicitly.
+--   - PostgreSQL (via Dolibarr's SQL converter) needs the explicit USING cast.
+ALTER TABLE llx_einvoicing_call MODIFY COLUMN entity integer DEFAULT 1;
+ALTER TABLE llx_einvoicing_call MODIFY COLUMN entity integer USING (entity::integer);
+ALTER TABLE llx_einvoicing_call ALTER COLUMN entity SET DEFAULT 1;

--- a/einvoicing/sql/update_v1.0.3.sql
+++ b/einvoicing/sql/update_v1.0.3.sql
@@ -14,6 +14,6 @@ UPDATE llx_einvoicing_extlinks SET element_type = 'invoice_supplier' WHERE eleme
 -- One of the two statements below applies per database driver, the other is a harmless no-op:
 --   - MySQL/MariaDB accept the plain MODIFY and cast varchar -> int implicitly.
 --   - PostgreSQL (via Dolibarr's SQL converter) needs the explicit USING cast.
-ALTER TABLE llx_einvoicing_call MODIFY COLUMN entity integer DEFAULT 1;
-ALTER TABLE llx_einvoicing_call MODIFY COLUMN entity integer USING (entity::integer);
+-- VMYSQL4.3 ALTER TABLE llx_einvoicing_call MODIFY COLUMN entity integer DEFAULT 1;
+-- VPGSQL8.2 ALTER TABLE llx_einvoicing_call MODIFY COLUMN entity integer USING (entity::integer);
 ALTER TABLE llx_einvoicing_call ALTER COLUMN entity SET DEFAULT 1;


### PR DESCRIPTION
Fixes #259.

`llx_einvoicing_call.entity` was created as `varchar(50)` but is queried as an integer (`WHERE entity IN (n)`), which fails on PostgreSQL with `operator does not exist: character varying = integer`. `llx_einvoicing_document.entity` is already `integer`.

- Fix the `CREATE TABLE` DDL and the `call` object field type.
- In-place migration in `update_v1.0.3.sql`, preserving data and indexes on both MySQL/MariaDB and PostgreSQL (via Dolibarr's `MODIFY` → `ALTER COLUMN` converter; one statement applies per driver, the other is a harmless no-op).

Tested on throwaway MariaDB 11 and PostgreSQL 16: the failing query works after migration, data and the `uk_einvoicing_call_callid` unique index are preserved.
