### PR TITLE
fix(einvoicing): seller contact email uses company, not logged-in user (#252)

### DIFF
--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -141,10 +141,12 @@ if (!empty($usercontacts) && $object->fetch_user($usercontacts[0]) > 0) {
 	$salerepresentative_office_fax    = $object->user->office_fax;
 	$salerepresentative_email         = $object->user->email;
 } else {
-	$salerepresentative_name          = $user->getFullName($outputlangs);
-	$salerepresentative_office_phone  = $user->office_phone;
-	$salerepresentative_office_fax    = $user->office_fax;
-	$salerepresentative_email         = $user->email;
+	// No sales representative assigned to the invoice: the seller contact (BG-6) must describe the
+	// seller, so fall back to the emitting company ($mysoc), not the logged-in user. See issue #252.
+	$salerepresentative_name          = $mysoc->name;
+	$salerepresentative_office_phone  = $mysoc->phone;
+	$salerepresentative_office_fax    = $mysoc->fax;
+	$salerepresentative_email         = $mysoc->email;
 }
 if (empty($salerepresentative_office_phone)) {
 	$salerepresentative_office_phone = $mysoc->phone;


### PR DESCRIPTION
Fixes #252.

When no sales representative (`SALESREPFOLL`) contact is assigned to the invoice, the seller contact (BG-6) fell back to the **logged-in user**'s name/phone/email. The generated CII/Factur-X then carried the operator's personal email as the seller contact email instead of the seller company's.

Fall back to `$mysoc` (the emitting company) instead. The case where a sales representative *is* assigned is unchanged.

Reproduced on a dev Dolibarr (CII output): seller `DefinedTradeContact/EmailURIUniversalCommunication` showed the logged-in user's email; after the fix it shows the company email.
