### PR TITLE
fix(einvoicing): use CAST AS SIGNED for call_id maxref (PostgreSQL compat)

### DIFF
--- a/einvoicing/class/call.class.php
+++ b/einvoicing/class/call.class.php
@@ -1226,7 +1226,7 @@ class Call extends CommonObject
 
 		$prefix = 'Call-';
 
-		$sql = "SELECT MAX(CAST(SUBSTRING(call_id, ".(strlen($prefix) + 1).") AS UNSIGNED)) AS maxref";
+		$sql = "SELECT MAX(CAST(SUBSTRING(call_id, ".(strlen($prefix) + 1).") AS SIGNED)) AS maxref";
 		$sql .= " FROM ".MAIN_DB_PREFIX.$this->table_element;
 		$sql .= " WHERE call_id LIKE '".$db->escape($prefix)."%'";
 


### PR DESCRIPTION
## What

`Call::getNextCallId()` builds its maxref query with `CAST(... AS UNSIGNED)`, which is MySQL-only syntax and raises an error on PostgreSQL.

Dolibarr's pgsql driver (`convertSQLFromMysql`) rewrites `CAST(... AS SIGNED)` to `AS integer`, but leaves `UNSIGNED` untouched. So the cross-DB fix is to use `SIGNED` — which is exactly what Dolibarr core uses for every other ref-numbering query (propale, contract, partnership, supplier_payment…).

The `call_id` numeric suffix is always positive, so SIGNED vs UNSIGNED is functionally equivalent here.

Fixes #251

## Test

`SELECT MAX(CAST(SUBSTRING(call_id, 6) AS SIGNED)) ...` verified on MariaDB.
