### PR TITLE
fix(einvoicing): drop inline COMMENT in xml_data migration (PostgreSQL compat)

### DIFF
--- a/einvoicing/sql/update_v1.0.2.sql
+++ b/einvoicing/sql/update_v1.0.2.sql
@@ -2,4 +2,4 @@
 -- Script run when module is reloaded. Whatever is the Dolibarr version.
 --
 
-ALTER TABLE llx_einvoicing_document ADD COLUMN xml_data MEDIUMTEXT DEFAULT null COMMENT 'Full XML invoice data';
+ALTER TABLE llx_einvoicing_document ADD COLUMN xml_data MEDIUMTEXT DEFAULT null;


### PR DESCRIPTION
## What

`sql/update_v1.0.2.sql` adds `xml_data` with an inline `COMMENT 'Full XML invoice data'` clause:

```sql
ALTER TABLE llx_einvoicing_document ADD COLUMN xml_data MEDIUMTEXT DEFAULT null COMMENT 'Full XML invoice data';
```

PostgreSQL does not support an inline `COMMENT` in `ALTER TABLE ADD COLUMN` and fails with `syntax error at or near "COMMENT"`. (Dolibarr's pgsql driver already maps `MEDIUMTEXT` → `text`, but it does not strip inline `COMMENT`, and core migrations never use one.)

This drops the `COMMENT` clause — it is non-functional metadata.

`MEDIUMTEXT` is kept on purpose: on MySQL/MariaDB it preserves the 16 MB capacity needed for full invoice XML (plain `TEXT` would cap at 64 KB), while the pgsql driver maps it to `text` (up to 1 GB). This is also why I did not adopt the `COMMENT ON COLUMN` form from the issue — that syntax would in turn break MySQL.

Fixes #250

## Test

On a disposable `postgres:16`, after the driver's `MEDIUMTEXT`→`text` rewrite:
- with the `COMMENT` clause → `ERROR: syntax error at or near "COMMENT"`
- without it → `ALTER TABLE` succeeds

Statement also verified on MariaDB (dd1).
