### PR TITLE
Fix #291 : [e-invoicing] manual send_invoice errors not logged in llx…

### DIFF
--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -370,6 +370,7 @@ class ActionsEInvoicing extends CommonHookActions
 		$outputlangs = $langs;
 
 		$error = 0;
+		$dbRollBackOnError = true;
 
 		$db->begin();
 
@@ -443,6 +444,7 @@ class ActionsEInvoicing extends CommonHookActions
 						$error++;
 						$this->error = $provider->error;
 						$this->errors = array_merge($this->errors, $provider->errors);
+						$dbRollBackOnError = false;
 					}
 				}
 			}
@@ -605,7 +607,11 @@ class ActionsEInvoicing extends CommonHookActions
 		}
 
 		if ($error) {
-			$db->rollback();
+			if ($dbRollBackOnError) {
+				$db->rollback();
+			} else {
+				$db->commit();
+			}
 			return -1;
 		} else {
 			$db->commit();


### PR DESCRIPTION
Fix #291 : [e-invoicing] manual send_invoice errors not logged in llx_einvoicing_call

Because in case of errors, a $db->rollback was occurring