### PR TITLE
[e-invoicing] Fix e-invoice generation for ODT invoice templates

### DIFF
--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -132,7 +132,7 @@ class ActionsEInvoicing extends CommonHookActions
 						//setEventMessages($message, array(), $messagecss);
 					}
 
-					$result = $protocol->generateInvoice($invoiceObject, $outputlangs);		// Generate E-invoice
+					$result = $protocol->generateInvoice($invoiceObject, $outputlangs, $pdfPath);		// Generate E-invoice (embed into the real generated file)
 
 					if ($result >= 0) {
 						setEventMessages($message, array(), $messagecss);
@@ -191,6 +191,24 @@ class ActionsEInvoicing extends CommonHookActions
 		}
 
 		return 0;
+	}
+
+	/**
+	 * Hook called after an ODT/ODS document is created.
+	 *
+	 * Invoice templates rendered from an ODT model emit `afterODTCreation` (not `afterPDFCreation`),
+	 * so the e-invoice generation must be triggered here too. Same logic as afterPDFCreation:
+	 * $parameters['file'] then points to the .odt, and the protocol derives the matching PDF rendition.
+	 *
+	 * @param 	array   		$parameters 	Hook parameters
+	 * @param 	CommonObject 	$object 		The object related to the document (invoice, order, etc.)
+	 * @param 	string  		$action     	Current action
+	 * @param 	HookManager 	$hookmanager 	Hook manager instance
+	 * @return 	int    			0 or 1
+	 */
+	public function afterODTCreation($parameters, &$object, &$action, $hookmanager)
+	{
+		return $this->afterPDFCreation($parameters, $object, $action, $hookmanager);
 	}
 
 

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -306,9 +306,10 @@ class CIIProtocol extends AbstractProtocol
 	 *
 	 * @param 	int|Object 	$invoice_id    	Invoice ID or Invoice Object to be processed.
 	 * @param	?Translate	$outputlangs	Output language
+	 * @param	string		$sourceFilePath	Source document path (unused: CII output is a standalone XML, independent of the visual PDF). Kept for a uniform protocol signature.
 	 * @return 	-1|string       			-1 if ko, path if ok.
 	 */
-	public function generateInvoice($invoice_id, $outputlangs = null)
+	public function generateInvoice($invoice_id, $outputlangs = null, $sourceFilePath = '')
 	{
 		// Global variables declaration (typical for Dolibarr environment)
 		global $langs, $db;

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -419,9 +419,10 @@ class FacturXProtocol extends AbstractProtocol
 	 *
 	 * @param 	int|Object 	$invoice_id    	Invoice ID or Invoice Object to be processed.
 	 * @param	?Translate	$outputlangs	Output language
+	 * @param	string		$sourceFilePath	Full path of the source document produced by the doc generator (PDF, or ODT/ODS whose PDF rendition is reused). Empty = resolve from the output directory.
 	 * @return 	-1|string       			-1 if ko, path if ok.
 	 */
-	public function generateInvoice($invoice_id, $outputlangs = null)
+	public function generateInvoice($invoice_id, $outputlangs = null, $sourceFilePath = '')
 	{
 		// Global variables declaration (typical for Dolibarr environment)
 		global $langs, $db;
@@ -474,10 +475,53 @@ class FacturXProtocol extends AbstractProtocol
 
 		$filename = dol_sanitizeFileName($invoice->ref);
 		$filedir = getMultidirOutputCompat($invoice, '', 1);		// Example '/mydolibarr/documents/facture/FAYYMM-XXXX'
-		$orig_pdf = $filedir . '/' . $filename . '.pdf';
 
-		// Si le PDF source n'existe plus (supprimé manuellement), on le regénère avant d'embarquer le XML.
+		// Resolve the source PDF into which the Factur-X XML will be embedded.
+		// Priority:
+		//   1. $sourceFilePath provided by the generation hook (afterPDFCreation / afterODTCreation).
+		//      ODT/ODS models hand over the .odt path; the PDF rendition (MAIN_ODT_AS_PDF) shares the basename.
+		//   2. the most recent <ref>*.pdf already present in the output dir (manual generation, ODT output
+		//      like <ref>_Template.pdf for which last_main_doc is not maintained), excluding our own output.
+		//   3. legacy <ref>.pdf, regenerated with the default PDF model if missing.
+		$orig_pdf = '';
+		$fromodt = false;
+		if (!empty($sourceFilePath)) {
+			if (preg_match('/\.(odt|ods)$/i', $sourceFilePath)) {
+				$fromodt = true;
+				$orig_pdf = preg_replace('/\.(odt|ods)$/i', '.pdf', $sourceFilePath);
+			} else {
+				$orig_pdf = $sourceFilePath;
+			}
+		} else {
+			$candidates = dol_dir_list($filedir, 'files', 0, '', '', 'date', SORT_DESC);
+			foreach ($candidates as $cand) {
+				if (!preg_match('/\.pdf$/i', $cand['name'])) {
+					continue;
+				}
+				if (preg_match('/_facturx\.pdf$/i', $cand['name'])) {		// skip our own Factur-X output
+					continue;
+				}
+				if (strpos($cand['name'], $filename) !== 0) {				// must belong to this invoice ref
+					continue;
+				}
+				$orig_pdf = $cand['fullname'];								// list is sorted by date desc: newest first
+				break;
+			}
+		}
+		if (empty($orig_pdf)) {
+			$orig_pdf = $filedir . '/' . $filename . '.pdf';				// legacy default
+		}
+
+		// If the source PDF is missing, decide whether we can recover.
 		if (!file_exists($orig_pdf)) {
+			if ($fromodt && !getDolGlobalString('MAIN_ODT_AS_PDF')) {
+				// ODT invoice template without a PDF rendition: there is no PDF carrier for Factur-X.
+				dol_syslog(get_class($this) . "::generateInvoice ODT template without MAIN_ODT_AS_PDF, no PDF carrier for Factur-X, invoice id=" . $invoice_id, LOG_ERR);
+				$this->error = $langs->trans("ErrorEInvoiceRequiresPdfEnableMainOdtAsPdf");
+				$this->errors[] = $this->error;
+				return -1;
+			}
+			// Source PDF deleted or never generated: regenerate it with the default PDF model before embedding.
 			$modelname = getDolGlobalString('FACTURE_ADDON_PDF') ?: 'crabe';
 			$resultpdf = $invoice->generateDocument($modelname, $langs);
 			if ($resultpdf < 0) {
@@ -486,6 +530,7 @@ class FacturXProtocol extends AbstractProtocol
 				$this->errors[] = $this->error;
 				return -1;
 			}
+			$orig_pdf = $filedir . '/' . $filename . '.pdf';				// generateDocument writes <ref>.pdf
 		}
 
 		// Make a copy of the original PDF file

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -263,6 +263,7 @@ SelectStatusReason=Reason
 TryToIncreaseStartDateOrMax=No new flow processed. Try to increase the "%s"
 ErrorGeneratingXML=Error when generating the e-invoice XML file
 ErrorFailedToRegeneratePDF=The invoice PDF file is missing and could not be regenerated. Please regenerate the PDF from the invoice card before retrying e-invoice generation.
+ErrorEInvoiceRequiresPdfEnableMainOdtAsPdf=This invoice uses an ODT/ODS template but no PDF rendition was produced, so the Factur-X cannot be built. Enable the option MAIN_ODT_AS_PDF so the ODT template is also exported as PDF, or use a PDF invoice model.
 einvoicingLastSentStatus=Last sent status
 einvoicingInvoiceReason=E-invoicing status reason
 EINVOICING_PMT=Notice for recovery fees

--- a/einvoicing/langs/fr_FR/einvoicing.lang
+++ b/einvoicing/langs/fr_FR/einvoicing.lang
@@ -263,6 +263,7 @@ SelectStatusReason=Raison
 TryToIncreaseStartDateOrMax=Aucun nouveau flux traité. Essayez d'augmenter le paramètre « %s »
 ErrorGeneratingXML=Erreur lors de la génération du fichier XML
 ErrorFailedToRegeneratePDF=Le fichier PDF de la facture est introuvable et sa régénération a échoué. Veuillez regénérer le PDF depuis la fiche facture avant de relancer la génération de la facture électronique.
+ErrorEInvoiceRequiresPdfEnableMainOdtAsPdf=Cette facture utilise un modèle ODT/ODS mais aucun rendu PDF n'a été produit, le Factur-X ne peut donc pas être généré. Activez l'option MAIN_ODT_AS_PDF pour que le modèle ODT soit aussi exporté en PDF, ou utilisez un modèle de facture PDF.
 einvoicingLastSentStatus=Dernier statut d'envoi
 einvoicingInvoiceReason=Motif du statut de facturation électronique
 EINVOICING_PMT=Mention de frais de recouvrement


### PR DESCRIPTION
Fixes #305

## Problem
For invoices generated from an **ODT template** (`doc_generic_invoice_odt`):
1. The module only handled `afterPDFCreation`, while ODT models emit `afterODTCreation` → e-invoice generation was **never triggered** in ODT.
2. `FacturXProtocol` rebuilt the source path as `<ref>.pdf`, so it missed the real output `<ref>_<Template>.pdf` and fell back to regenerating a generic `crabe` PDF.

Note: enabling `MAIN_ODT_AS_PDF_OMIT_TEMPLATE_NAME` (23.0+) makes the ODT output `<ref>.pdf`, which masks defect #2 — but defect #1 (missing hook) still leaves the module doing nothing for ODT. Both are fixed here.

## Changes
- **`actions_einvoicing`**: add `afterODTCreation()` (delegates to `afterPDFCreation`); pass the real generated path `$parameters['file']` to the protocol.
- **`FacturXProtocol::generateInvoice($invoice, $outputlangs, $sourceFilePath = '')`**:
  - use the hook-provided path; derive `.odt/.ods → .pdf` (PDF rendition produced by `MAIN_ODT_AS_PDF`);
  - manual generation (no hook path): pick the most recent `<ref>*.pdf` in the output dir (excluding our own `_facturx.pdf`), since `last_main_doc` is not maintained by the ODT model;
  - fall back to legacy `<ref>.pdf` + regeneration otherwise;
  - **explicit error** (`ErrorEInvoiceRequiresPdfEnableMainOdtAsPdf`) when an ODT template is used without `MAIN_ODT_AS_PDF` (no PDF carrier for Factur-X).
- **`CIIProtocol`**: accepts the new optional argument but ignores it (CII output is standalone XML, independent of the visual PDF).
- New lang key (en_US/fr_FR).

## Compatibility
Hook behaviour verified in core **18.0, 23.0 and develop**: the invoice ODT model emits `afterODTCreation` (never `afterPDFCreation`) on all three.

## Testing
| Scenario | Dolibarr | Result |
|---|---|---|
| ODT invoice template, Factur-X, real-time (the fixed case) | 18.0.6 | e-invoice now embeds the actual ODT-rendered PDF |
| Standard PDF model (crabe), validation + manual generate — regression check | 18.0.10 | `<ref>_facturx.pdf` generated, no error |
| Standard PDF model (crabe), validation + manual generate — regression check | 22.0.4 | `<ref>_facturx.pdf` generated, no error |

CII protocol path unchanged (XML-only). No regression observed on the standard PDF flow.

---
*Implemented with the assistance of Claude (Anthropic), reviewed by a human.*
