### PR TITLE
[einvoicing] Fix HTTP 404 on supplier invoice status button (double DOL_URL_ROOT prefix)

### DIFF
--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -332,7 +332,7 @@ class ActionsEInvoicing extends CommonHookActions
 							'enabled' => 1,
 							'perm' => ($forcedisabling ? -1 : ((bool) $user->hasRight("facture", "creer") && empty($forcedisabling))),
 							'label' => (string) $label,
-							'url' => dol_buildpath('/fourn/facture/card.php?id=' . $object->id . '&action=sendStatusMessage&pdpstatuscode=' . $code . '&token=' . newToken(), 1)
+							'url' => '/fourn/facture/card.php?id=' . $object->id . '&action=sendStatusMessage&pdpstatuscode=' . $code . '&token=' . newToken()
 						);
 					}
 


### PR DESCRIPTION
## Problem
On a **supplier invoice** card, the einvoicing lifecycle "send status message" dropdown button generated a URL with a doubled `DOL_URL_ROOT` prefix → HTTP 404:

```
/dolibarr/dolibarr/fourn/facture/card.php?...&action=sendStatusMessage&pdpstatuscode=205
   ^^^^^^^^^^^^^^^^^  doubled -> "Primary script unknown" -> 404
```

## Cause
In `einvoicing/class/actions_einvoicing.class.php` (`addMoreActionsButtons`), the supplier-invoice button URL used `dol_buildpath(..., 1)`, which already prepends `DOL_URL_ROOT`. The button renderer (`dolGetButtonAction()` → `dolCompletUrlForDropdownButton()`) prepends `DOL_URL_ROOT` again to scheme-less URLs → doubled path.

The customer-invoice buttons in the same hook (`generate_einvoice`, `send_to_pdp`) already pass a root-relative path; this was the only inconsistent entry.

## Fix
```diff
- 'url' => dol_buildpath('/fourn/facture/card.php?id=' . $object->id . '&action=sendStatusMessage&pdpstatuscode=' . $code . '&token=' . newToken(), 1)
+ 'url' => '/fourn/facture/card.php?id=' . $object->id . '&action=sendStatusMessage&pdpstatuscode=' . $code . '&token=' . newToken()
```

## Tests
Rendered the button via `dolGetButtonAction()` on real instances:
- before: `href="/dolibarr/dolibarr/fourn/facture/card.php?..."` (404)
- after: `href="/dolibarr/fourn/facture/card.php?..."` (OK)

Verified on Dolibarr 18.0.10 and 22+/2026.

Closes #307


---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — reviewed and validated by a human (@pscoffoni-opendsi).