### PR TITLE
Fix #291 : [e-invoicing] log API calls on an independent DB connection

### DIFF
--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -50,6 +50,9 @@ abstract class AbstractPDPProvider
 	/** @var string Provider name */
 	public $providerName;
 
+	/** @var string Short provider code, defined by each concrete provider (e.g. 'SuperPDP', 'Esalink') */
+	public $name;
+
 	/** @var string Help message to guide users in obtaining credentials for this provider */
 	public $helpToGetCredentials;
 
@@ -528,6 +531,61 @@ abstract class AbstractPDPProvider
 		}
 
 		return $LastSyncDate;
+	}
+
+	/**
+	 * Log an API call into llx_einvoicing_call using a SEPARATE database connection.
+	 *
+	 * The call trace must survive even when the caller's main transaction is rolled
+	 * back on error (see issue #291): a failed send_invoice rolls back the doActions()
+	 * transaction, which would otherwise wipe the very log we need to diagnose it.
+	 * Writing the log through an independent connection ($dbhistory) decouples it from
+	 * the business transaction, so it is committed whether the action succeeds or fails,
+	 * without ever forcing a commit on the rest. Same approach as the webhook logging.
+	 *
+	 * @param   string                      $callType   Functional type of the call (empty = do not log)
+	 * @param   string                      $resource   API resource/endpoint (without leading slash)
+	 * @param   string                      $method     HTTP method (POSTALREADYFORMATED is normalized to POST)
+	 * @param   string|array<mixed>         $params     Request body
+	 * @param   string|array<mixed>         $response   Response payload
+	 * @param   int                         $statusCode HTTP status code of the response
+	 * @return  ?array{id:int,call_id:string}           Created log identifiers, or null if not logged
+	 */
+	protected function logCall($callType, $resource, $method, $params, $response, $statusCode)
+	{
+		global $conf, $user, $dolibarr_main_db_pass, $dbhistory;
+
+		if (empty($callType)) { // TODO : Add a parameter in module configuration to enable/disable logging
+			return null;
+		}
+
+		// Reuse a process-wide independent connection so the trace is not bound to the
+		// caller's transaction and persists even if that transaction is rolled back.
+		if (empty($dbhistory)) {
+			$dbhistory = getDoliDBInstance($conf->db->type, $conf->db->host, (string) $conf->db->user, $dolibarr_main_db_pass, (string) $conf->db->name, (int) $conf->db->port);
+		}
+
+		$dbhistory->begin();
+
+		$call = new Call($dbhistory);
+		$call->call_id = $call->getNextCallId();
+		$call->call_type = $callType;
+		$call->method = ($method == 'POSTALREADYFORMATED' ? 'POST' : $method);
+		$call->endpoint = '/' . $resource;
+		$call->request_body = is_array($params) ? json_encode($params) : $params;
+		$call->response = is_array($response) ? json_encode($response) : $response;
+		$call->provider = $this->name;
+		$call->entity = $conf->entity;
+		$call->status = ($statusCode == 200 || $statusCode == 202) ? 1 : 0;
+
+		if ($call->create($user) > 0) {
+			$dbhistory->commit();
+			return array('id' => $call->id, 'call_id' => $call->call_id);
+		}
+
+		$dbhistory->rollback();
+		dol_syslog(__METHOD__ . " Failed to log API call to PDP provider: " . $call->error . " - " . implode(',', $call->errors), LOG_ERR);
+		return null;
 	}
 
 	/**

--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -750,27 +750,12 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 			}
 		}
 
-		// Log the API call if we have the functional type
-		if (!empty($callType)) { // TODO : Add a parameter in module configuration to enable/disable logging
-			$call = new Call($this->db);
-			$call->call_id = $call->getNextCallId();
-			$call->call_type = $callType ?: '';
-			$call->method = ($method == 'POSTALREADYFORMATED' ? 'POST' : $method);
-			$call->endpoint = '/' . $resource;
-			$call->request_body = is_array($params) ? json_encode($params) : $params;
-			$call->response = is_array($returnarray['response']) ? json_encode($returnarray['response']) : $returnarray['response'];
-			$call->provider = $this->name;
-			$call->entity = $conf->entity;
-			$call->status = ($returnarray['status_code'] == 200 || $returnarray['status_code'] == 202) ? 1 : 0;
-
-			$result = $call->create($user);
-
-			if ($result > 0) {
-				$returnarray['id'] = $call->id;
-				$returnarray['call_id'] = $call->call_id;
-			} else {
-				dol_syslog(__METHOD__ . " Failed to log API call to PDP provider: " . $call->error . " - " . implode(',', $call->errors), LOG_ERR);
-			}
+		// Log the API call through an independent connection so the trace survives a
+		// rollback of the caller's transaction on error (see logCall(), issue #291).
+		$logged = $this->logCall($callType, $resource, $method, $params, $returnarray['response'], $returnarray['status_code']);
+		if ($logged !== null) {
+			$returnarray['id'] = $logged['id'];
+			$returnarray['call_id'] = $logged['call_id'];
 		}
 
 		return $returnarray;

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -1167,27 +1167,12 @@ class SuperPDPProvider extends AbstractPDPProvider
 			}
 		}
 
-		// Log the API call if we have the functional type
-		if (!empty($callType)) { // TODO : Add a parameter in module configuration to enable/disable logging
-			$call = new Call($this->db);
-			$call->call_id = $call->getNextCallId();
-			$call->call_type = $callType ?: '';
-			$call->method = ($method == 'POSTALREADYFORMATED' ? 'POST' : $method);
-			$call->endpoint = '/' . $resource;
-			$call->request_body = is_array($params) ? json_encode($params) : $params;
-			$call->response = is_array($returnarray['response']) ? json_encode($returnarray['response']) : $returnarray['response'];
-			$call->provider = $this->name;
-			$call->entity = $conf->entity;
-			$call->status = ($returnarray['status_code'] == 200 || $returnarray['status_code'] == 202) ? 1 : 0;
-
-			$result = $call->create($user);
-
-			if ($result > 0) {
-				$returnarray['id'] = $call->id;
-				$returnarray['call_id'] = $call->call_id;
-			} else {
-				dol_syslog(__METHOD__ . " Failed to log API call to PDP provider: " . $call->error . " - " . implode(',', $call->errors), LOG_ERR);
-			}
+		// Log the API call through an independent connection so the trace survives a
+		// rollback of the caller's transaction on error (see logCall(), issue #291).
+		$logged = $this->logCall($callType, $resource, $method, $params, $returnarray['response'], $returnarray['status_code']);
+		if ($logged !== null) {
+			$returnarray['id'] = $logged['id'];
+			$returnarray['call_id'] = $logged['call_id'];
 		}
 
 		return $returnarray;


### PR DESCRIPTION
Alternative to #292 — @eldy asked for a new PR.

Fixes #291. The call log was written on `$this->db` inside the caller's transaction, so a `$db->rollback()` on error dropped it. This writes it on a separate `$dbhistory` connection (eldy's suggestion): the trace survives a rollback for every flow (send_invoice, send_status, sync) and the main transaction is untouched. Logging is factored into one `logCall()` helper sur `AbstractPDPProvider`