### PR TITLE
Fix #309: [einvoicing] warn on supplier name mismatch for inbound e-invoices

### DIFF
--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -422,6 +422,10 @@ trait CommonProtocol
 		$thirdparty = new Societe($db);
 		$einvoicing = new EInvoicing($db);
 		$thirdpartyId = -1;
+		// True when the third party was resolved through a structured identifier (SIREN/SIRET/routing/VAT)
+		// and not through a fuzzy name match (findNearest). Used to raise a non-blocking name-mismatch
+		// warning only when identification did not rely on the (descriptive) name itself. See issue #309.
+		$matchedByStructuredIdentifier = false;
 
 		$sellerCountryCode = $sellerInfo['sellercountry'] ?? '';
 
@@ -468,6 +472,7 @@ trait CommonProtocol
 
 						if ($result > 0) {
 							$thirdpartyId = $thirdparty->id;
+							$matchedByStructuredIdentifier = true;
 							dol_syslog(get_class($this) . '::_syncOrCreateThirdpartyFromEInvoiceSeller Found thirdparty by ' . $idScheme . ': ' . $thirdpartyId);
 							break;
 						}
@@ -497,6 +502,7 @@ trait CommonProtocol
 						$result = $thirdparty->fetch($obj->rowid);
 						if ($result > 0) {
 							$thirdpartyId = $thirdparty->id;
+							$matchedByStructuredIdentifier = true;
 							dol_syslog(get_class($this) . '::_syncOrCreateThirdpartyFromEInvoiceSeller Found thirdparty by VAT number: ' . $thirdpartyId);
 						}
 					}
@@ -545,6 +551,28 @@ trait CommonProtocol
 			}
 		}
 
+		// Identifier-based match: raise a NON-BLOCKING warning when the descriptive name carried by the
+		// e-invoice does not match the linked third party. Under EN 16931 / the French CTC framework, a
+		// supplier is identified and routed by its structured identifier (SIREN 0002, SIRET 0009, routing
+		// 0225) and VAT number, never by name. Seller name (BT-27) and trading name (BT-28) are descriptive
+		// fields, so a mismatch must not block import or routing, but it is a legitimate data-quality /
+		// mis-attachment / fraud signal worth surfacing. See issue #309.
+		$nameMismatchWarning = '';
+		if ($thirdpartyId > 0 && $matchedByStructuredIdentifier) {
+			$invoiceNames = array($sellerInfo['sellername'] ?? '', $sellerInfo['sellerTradingName'] ?? '');
+			$dolibarrNames = array($thirdparty->name, $thirdparty->name_alias);
+			if (!$this->_companyNamesAreConsistent($invoiceNames, $dolibarrNames)) {
+				$invoiceName = trim($sellerInfo['sellername'] ?? '');
+				if ($invoiceName === '') {
+					$invoiceName = trim($sellerInfo['sellerTradingName'] ?? '');
+				}
+				$nameMismatchWarning = $langs->trans('EInvoiceSupplierNameMismatchWarning', $invoiceName, $thirdparty->name);
+				dol_syslog(get_class($this) . '::_syncOrCreateThirdpartyFromEInvoiceSeller ' . $nameMismatchWarning, LOG_WARNING);
+				dol_syslog(get_class($this) . '::_syncOrCreateThirdpartyFromEInvoiceSeller ' . $nameMismatchWarning, LOG_WARNING, 0, '_einvoicing');
+				setEventMessages($nameMismatchWarning, null, 'warnings');
+			}
+		}
+
 		// Step 3: Create or update thirdparty
 
 		//$thirdpartyId = -2; // For testing
@@ -556,7 +584,7 @@ trait CommonProtocol
 				dol_syslog(get_class($this) . '::_syncOrCreateThirdpartyFromEInvoiceSeller Complete info disabled, returning existing thirdparty: ' . $thirdpartyId);
 				return array(
 					'res' => $thirdpartyId,
-					'message' => 'Existing thirdparty used without update: ' . $thirdpartyId
+					'message' => 'Existing thirdparty used without update: ' . $thirdpartyId . ($nameMismatchWarning !== '' ? ' - ' . $nameMismatchWarning : '')
 				);
 			}
 
@@ -668,7 +696,7 @@ trait CommonProtocol
 				dol_syslog(get_class($this) . '::_syncOrCreateThirdpartyFromEInvoiceSeller Updated thirdparty: ' . $thirdpartyId);
 				return array(
 					'res' => $thirdpartyId,
-					'message' => 'Thirdparty ' . $thirdparty->name . ' updated successfully.'
+					'message' => 'Thirdparty ' . $thirdparty->name . ' updated successfully.' . ($nameMismatchWarning !== '' ? ' - ' . $nameMismatchWarning : '')
 				);
 			}
 		}
@@ -1108,6 +1136,90 @@ trait CommonProtocol
 		];
 
 		return $map[$scheme] ?? '';
+	}
+
+
+	/**
+	 * Normalize a company name for tolerant comparison.
+	 *
+	 * Applies the normalization recommended for e-invoicing name checks so that purely descriptive
+	 * differences do not raise false positives: strip accents, lowercase, drop common legal forms
+	 * (SARL, SAS, GmbH, Ltd...) and collapse everything that is not a letter or a digit. The result is a
+	 * comparison key, not a displayable name.
+	 *
+	 * @param 	string 	$name 	Raw company name
+	 * @return 	string 			Normalized comparison key (may be an empty string)
+	 */
+	private function _normalizeCompanyNameForComparison($name)
+	{
+		$name = trim((string) $name);
+		if ($name === '') {
+			return '';
+		}
+
+		// Strip accents then lowercase so "Société" and "SOCIETE" compare equal
+		$name = strtolower(dol_string_unaccent($name));
+
+		// Remove common legal forms (whole words only) to avoid false positives on suffixes
+		$legalForms = array(
+			'sarl', 'sas', 'sasu', 'sa', 'eurl', 'sci', 'snc', 'scop', 'scs', 'sca', 'gie', 'ei',
+			'societe', 'ste', 'ets', 'etablissements', 'cie', 'gmbh', 'ug', 'ag', 'kg', 'ohg',
+			'ltd', 'limited', 'llc', 'inc', 'corp', 'co', 'plc', 'bv', 'nv', 'srl', 'spa', 'sl',
+		);
+		$name = preg_replace('/\b(' . implode('|', $legalForms) . ')\b/', ' ', $name);
+
+		// Keep only alphanumeric characters (drops punctuation, spaces, &, -, etc.)
+		$name = preg_replace('/[^a-z0-9]/', '', (string) $name);
+
+		return (string) $name;
+	}
+
+
+	/**
+	 * Check whether a name carried by an e-invoice is consistent with the linked third party.
+	 *
+	 * Each candidate name is normalized (see _normalizeCompanyNameForComparison) and a match is accepted
+	 * when any invoice name equals or is contained in any Dolibarr name (or vice versa), so that a trading
+	 * name vs. legal name difference does not trigger a warning. When either side has no usable name after
+	 * normalization, the comparison is inconclusive and the names are considered consistent (no false alarm).
+	 *
+	 * @param 	string[] 	$invoiceNames 	Candidate names from the e-invoice (e.g. BT-27 seller name, BT-28 trading name)
+	 * @param 	string[] 	$dolibarrNames 	Candidate names from the linked third party (e.g. nom, name_alias)
+	 * @return 	bool 						True if consistent (or not comparable), false on a genuine mismatch
+	 */
+	private function _companyNamesAreConsistent(array $invoiceNames, array $dolibarrNames)
+	{
+		$normInvoice = array();
+		foreach ($invoiceNames as $candidate) {
+			$key = $this->_normalizeCompanyNameForComparison($candidate);
+			if ($key !== '') {
+				$normInvoice[$key] = $key;
+			}
+		}
+		$normDolibarr = array();
+		foreach ($dolibarrNames as $candidate) {
+			$key = $this->_normalizeCompanyNameForComparison($candidate);
+			if ($key !== '') {
+				$normDolibarr[$key] = $key;
+			}
+		}
+
+		// Not enough data to compare -> do not raise a warning
+		if (empty($normInvoice) || empty($normDolibarr)) {
+			return true;
+		}
+
+		foreach ($normInvoice as $invoiceName) {
+			foreach ($normDolibarr as $dolibarrName) {
+				if ($invoiceName === $dolibarrName
+					|| strpos($invoiceName, $dolibarrName) !== false
+					|| strpos($dolibarrName, $invoiceName) !== false) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -91,6 +91,7 @@ FxCheckWarnSIRENClosed=The company associated with SIREN %s is closed according 
 FxCheckWarnNameMismatch=The company name on record (%s) does not match the name in the French national business registry (%s).
 FxCheckWarnZIPMismatch=The ZIP code on record (%s) does not match the one in the French national business registry (%s).
 FxCheckWarnTownMismatch=The town on record (%s) does not match the one in the French national business registry (%s).
+EInvoiceSupplierNameMismatchWarning=The supplier name on the received e-invoice (%s) does not match the linked third party (%s). The invoice was attached using the structured identifier (SIREN/SIRET/VAT); please check the attachment and update the third party if needed.
 FxCheckErrorCreditNoteNoSource=This credit note has no source invoice linked. Please link the source invoice before generating the e-invoice.
 InvoiceNotSentToPDPDueToThirdpartyIssues=The invoice was not sent to the Access Point due to errors in the third-party data
 EINVOICING_ENABLE_API_VALIDATION=Enable third-party data validation via government APIs (SIREN, VAT)

--- a/einvoicing/langs/fr_FR/einvoicing.lang
+++ b/einvoicing/langs/fr_FR/einvoicing.lang
@@ -91,6 +91,7 @@ FxCheckWarnSIRENClosed=L'entreprise associée à SIREN %s est fermée selon le r
 FxCheckWarnNameMismatch=Le nom de l'entreprise enregistré (%s) ne correspond pas au nom figurant dans le registre national des entreprises français (%s).
 FxCheckWarnZIPMismatch=Le code postal enregistré (%s) ne correspond pas à celui du registre national des entreprises français (%s).
 FxCheckWarnTownMismatch=La ville enregistrée (%s) ne correspond pas à celle du registre national des entreprises français (%s).
+EInvoiceSupplierNameMismatchWarning=Le nom du fournisseur figurant sur la facture électronique reçue (%s) ne correspond pas au tiers lié (%s). La facture a été rattachée via l'identifiant structuré (SIREN/SIRET/TVA) ; veuillez vérifier le rattachement et mettre à jour le tiers si nécessaire.
 FxCheckErrorCreditNoteNoSource=Cette note de crédit ne comporte aucune facture source. Veuillez ajouter la facture source avant de générer la facture électronique.
 InvoiceNotSentToPDPDueToThirdpartyIssues=La facture n'a pas été envoyée au point d'accès en raison d'erreurs dans les données tierces.
 EINVOICING_ENABLE_API_VALIDATION=Activer la validation des données des tiers via les API gouvernementales (SIREN, TVA)


### PR DESCRIPTION
## Summary

Closes #309.

When an inbound supplier invoice (CII / Factur-X) is resolved to a Dolibarr third party through a **structured identifier** (SIREN `0002`, SIRET `0009`, routing `0225` or VAT number), the descriptive seller name carried by the invoice was silently ignored. A genuinely different name — a mis-attachment, data-quality or fraud signal — went unreported.

This PR adds a **non-blocking warning**, raised at import time in `CommonProtocol::_syncOrCreateThirdpartyFromEInvoiceSeller()`, when **and only when**:

- the third party was matched by a **structured identifier** (not by the fuzzy `findNearest` name match), and
- the invoice name (BT-27 `SellerTradeParty/Name` / BT-28 `TradingBusinessName`) does **not** match the linked third party (`nom` / `name_alias`).

It never blocks import or routing — consistent with EN 16931 / the French CTC framework, where a party is *identified* by its structured identifier and BT-27/BT-28 are descriptive only.

## Implementation

- New `$matchedByStructuredIdentifier` flag set in the SIREN/SIRET/routing (idprof) and VAT lookup steps, left `false` for the `findNearest` name-based match.
- Two private helpers:
  - `_normalizeCompanyNameForComparison()` — trims, strips accents (`dol_string_unaccent`), lowercases, drops common legal forms (SARL, SAS, GmbH, Ltd…) and keeps alphanumerics only, to avoid false positives.
  - `_companyNamesAreConsistent()` — accepts an equality **or containment** match between any invoice name and any Dolibarr name, so legal-name vs. trading-name differences do not raise a warning; inconclusive when either side has no usable name (no false alarm).
- The mismatch is surfaced three ways: `setEventMessages(..., 'warnings')` (invoice card / interactive import), the import-log return message (automated PDP import), and `dol_syslog` (incl. the `_einvoicing` log channel).

## Behaviour example (from the issue)

| Source | Identifier (`0002`/`0225`) | Name |
|---|---|---|
| Dolibarr third party | `123456125` | `Societe MAUVAIS NOM` |
| Inbound CII invoice | `123456125` | `Societe BIDULE CHOUETTE` |

→ invoice is still attached by identifier, **plus** a non-blocking warning is shown.

## Translations

New key `EInvoiceSupplierNameMismatchWarning` added to `en_US` and `fr_FR` only (other languages are managed through Transifex).

## Tests

`php -l` clean; phan (`--quick`, 5.5.2, baseline) reports no new findings.
