### PR TITLE
Fix #303: [einvoicing] link inbound supplier invoice to its purchase order (BT-13)

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -773,6 +773,13 @@ class CIIProtocol extends AbstractProtocol
 		if ($supplierInvoiceId < 0) {
 			return ['res' => -1, 'message' => 'Invoice creation error: ' . $supplierInvoice->error];
 		} else {
+			// Link the invoice to its purchase order (commande fournisseur) when the order reference
+			// (BT-13) matches a single order for the same supplier. Non-blocking. See issue #303.
+			$orderLinkMessage = $this->_linkSupplierInvoiceToPurchaseOrder($supplierInvoice, $socId, $parsedHeader['orderReference'] ?? '');
+			if ($orderLinkMessage !== '') {
+				$return_messages[] = $orderLinkMessage;
+			}
+
 			$create_deposit_line = 0;
 			$fk_remise_for_deposit = 0;
 			// --------------------------------------------------

--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -1494,4 +1494,84 @@ trait CommonProtocol
 		}
 		return 0;
 	}
+
+
+	/**
+	 * Link an inbound supplier invoice to its Dolibarr purchase order (commande fournisseur).
+	 *
+	 * Uses the purchase order reference (BT-13, BuyerOrderReferencedDocument/IssuerAssignedID) carried by
+	 * the invoice. The lookup is reference-exact (after trimming) AND scoped to the resolved supplier, so a
+	 * matching reference belonging to another supplier is never linked. The link is only created on a single
+	 * unambiguous match; several matches are flagged (no auto-link) and the absence of a match is silent.
+	 *
+	 * This is internal ERP reconciliation logic and must NEVER block import. See issue #303.
+	 *
+	 * @param 	FactureFournisseur 	$supplierInvoice 	Freshly created supplier invoice (must expose ->id)
+	 * @param 	int 				$socId 				Resolved supplier third party id
+	 * @param 	string 				$orderReference 	BT-13 purchase order reference carried by the invoice
+	 * @return 	string 									Status message for the import log ('' when nothing was done)
+	 */
+	private function _linkSupplierInvoiceToPurchaseOrder($supplierInvoice, $socId, $orderReference)
+	{
+		global $db, $langs;
+
+		$orderReference = trim((string) $orderReference);
+		if ($orderReference === '' || empty($supplierInvoice->id) || (int) $socId <= 0) {
+			return '';
+		}
+
+		require_once DOL_DOCUMENT_ROOT . '/fourn/class/fournisseur.commande.class.php';
+
+		// Reference-exact, supplier-scoped, entity-aware lookup to avoid false positives
+		$sql = "SELECT rowid FROM " . MAIN_DB_PREFIX . "commande_fournisseur";
+		$sql .= " WHERE ref = '" . $db->escape($orderReference) . "'";
+		$sql .= " AND fk_soc = " . ((int) $socId);
+		$sql .= " AND entity IN (" . getEntity('supplier_order') . ")";
+
+		$resql = $db->query($sql);
+		if (!$resql) {
+			dol_syslog(get_class($this) . '::_linkSupplierInvoiceToPurchaseOrder DB error: ' . $db->lasterror(), LOG_ERR);
+			return '';
+		}
+
+		$num = $db->num_rows($resql);
+
+		if ($num == 0) {
+			// No order for this supplier. Surface a warning only if the reference exists for another supplier
+			// (likely mis-reference), otherwise stay silent (unchanged behaviour).
+			$sqlOther = "SELECT rowid FROM " . MAIN_DB_PREFIX . "commande_fournisseur";
+			$sqlOther .= " WHERE ref = '" . $db->escape($orderReference) . "'";
+			$sqlOther .= " AND fk_soc <> " . ((int) $socId);
+			$sqlOther .= " AND entity IN (" . getEntity('supplier_order') . ")";
+			$resqlOther = $db->query($sqlOther);
+			if ($resqlOther && $db->num_rows($resqlOther) > 0) {
+				$warn = $langs->trans('EInvoiceSupplierOrderRefWrongSupplier', $orderReference);
+				dol_syslog(get_class($this) . '::_linkSupplierInvoiceToPurchaseOrder ' . $warn, LOG_WARNING);
+				setEventMessages($warn, null, 'warnings');
+				return $warn;
+			}
+			dol_syslog(get_class($this) . '::_linkSupplierInvoiceToPurchaseOrder No supplier order "' . $orderReference . '" for socid ' . ((int) $socId), LOG_DEBUG);
+			return '';
+		}
+
+		if ($num > 1) {
+			// Ambiguous: do not auto-link, flag for manual resolution
+			$warn = $langs->trans('EInvoiceSupplierOrderLinkAmbiguous', $orderReference);
+			dol_syslog(get_class($this) . '::_linkSupplierInvoiceToPurchaseOrder ' . $warn, LOG_WARNING);
+			setEventMessages($warn, null, 'warnings');
+			return $warn;
+		}
+
+		$orderId = (int) $db->fetch_object($resql)->rowid;
+
+		$res = $supplierInvoice->add_object_linked('order_supplier', $orderId);
+		if ($res > 0) {
+			$msg = $langs->trans('EInvoiceSupplierInvoiceLinkedToOrder', $orderReference);
+			dol_syslog(get_class($this) . '::_linkSupplierInvoiceToPurchaseOrder ' . $msg, LOG_DEBUG);
+			return $msg;
+		}
+
+		dol_syslog(get_class($this) . '::_linkSupplierInvoiceToPurchaseOrder Failed to link order ' . $orderId . ' to invoice ' . $supplierInvoice->id . ': ' . $supplierInvoice->error, LOG_ERR);
+		return '';
+	}
 }

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -1460,6 +1460,13 @@ class FacturXProtocol extends AbstractProtocol
 		if ($supplierInvoiceId < 0) {
 			return ['res' => -1, 'message' => 'Invoice creation error: ' . $supplierInvoice->error];
 		} else {
+			// Link the invoice to its purchase order (commande fournisseur) when the order reference
+			// (BT-13) matches a single order for the same supplier. Non-blocking. See issue #303.
+			$orderLinkMessage = $this->_linkSupplierInvoiceToPurchaseOrder($supplierInvoice, $socId, $parsedHeader['orderReference'] ?? '');
+			if ($orderLinkMessage !== '') {
+				$return_messages[] = $orderLinkMessage;
+			}
+
 			$create_deposit_line = 0;
 			$fk_remise_for_deposit = 0;
 			// --------------------------------------------------

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -333,6 +333,9 @@ SupplierInvoiceComparisonVatRateDifference=Difference in VAT amount %s%% (e-invo
 SupplierInvoiceComparisonVatRateNotFound=VAT rate of %s%% not found in the Dolibarr invoice
 SupplierInvoiceComparisonSuggestVatCalculationMode=recalculate invoice using Mode %s to get VAT amounts corresponding to e-invoice
 EinvoicingCantDeleteADocumentLinkedToAnExistingSupplierInvoice=Document n° %s can't be deleted because it is linked to the Dolibarr supplier invoice n° %s
+EInvoiceSupplierInvoiceLinkedToOrder=The supplier invoice was automatically linked to purchase order %s (matching order reference BT-13).
+EInvoiceSupplierOrderLinkAmbiguous=Several purchase orders match the order reference %s for this supplier; the invoice was not auto-linked. Please link it manually.
+EInvoiceSupplierOrderRefWrongSupplier=A purchase order with reference %s exists but belongs to a different supplier; the invoice was not linked.
 WarningEinvoicingInvoiceStatusDifferentProvider=Invoice generated or sent for another Access Point %s.
 
 EINVOICING_CLIENT_ID=Client ID

--- a/einvoicing/langs/fr_FR/einvoicing.lang
+++ b/einvoicing/langs/fr_FR/einvoicing.lang
@@ -331,6 +331,9 @@ SupplierInvoiceComparisonVatRateDifference=différence de montant de TVA %s%% (e
 SupplierInvoiceComparisonVatRateNotFound=taux de TVA à %s%% non trouvé dans la facture Dolibarr
 SupplierInvoiceComparisonSuggestVatCalculationMode=recalculer la TVA en Mode %s pour avoir des montants de TVA correspondant à l'e-facture d'origine
 EinvoicingCantDeleteADocumentLinkedToAnExistingSupplierInvoice=Le document n° %s ne peut pas être supprimé car il est lié à la facture fournisseur Dolibarr n° %s
+EInvoiceSupplierInvoiceLinkedToOrder=La facture fournisseur a été automatiquement liée à la commande fournisseur %s (référence de commande BT-13 correspondante).
+EInvoiceSupplierOrderLinkAmbiguous=Plusieurs commandes fournisseur correspondent à la référence de commande %s pour ce fournisseur ; la facture n'a pas été liée automatiquement. Veuillez la lier manuellement.
+EInvoiceSupplierOrderRefWrongSupplier=Une commande fournisseur portant la référence %s existe mais appartient à un autre fournisseur ; la facture n'a pas été liée.
 
 EINVOICING_CLIENT_ID=Client ID
 EINVOICING_CLIENT_SECRET=Client Secret


### PR DESCRIPTION
## Summary

Closes #303.

When an inbound supplier invoice (CII / Factur-X) carries a **purchase order reference** (`BT-13`, `ApplicableHeaderTradeAgreement/BuyerOrderReferencedDocument/ram:IssuerAssignedID`), it is now automatically linked to the matching Dolibarr purchase order (*commande fournisseur*) at import time — instead of requiring a manual link.

## Implementation

New shared helper `CommonProtocol::_linkSupplierInvoiceToPurchaseOrder($supplierInvoice, $socId, $orderReference)`, called from **both** import paths (`CIIProtocol` and `FacturXProtocol`) right after the supplier invoice is created.

The order lookup is:
- **reference-exact** (after trimming),
- **supplier-scoped** (`fk_soc` = resolved supplier) so a matching reference belonging to another supplier is never linked,
- **entity-aware** (`getEntity('supplier_order')`).

On a single unambiguous match it creates the standard Dolibarr object link (`add_object_linked('order_supplier', $orderId)` → `commande_fournisseur` ↔ `facture_fournisseur`).

## Behaviour (issue edge cases)

| Case | Result |
|---|---|
| Exactly one order with that ref for the supplier | ✅ link created |
| No order reference in the invoice | no link (unchanged, silent) |
| Reference present but no matching order | no link (silent, debug log) |
| Reference matches an order of a **different** supplier | ❌ no link + warning |
| **Several** matching orders | ❌ no link + warning (ambiguous, manual resolution) |

Linking **never blocks import** — it is internal ERP reconciliation, consistent with but not mandated by EN 16931 / the French CTC framework (`BT-13` is transported by the specs, which do not prescribe reconciliation). Outcomes are surfaced via the import log, `dol_syslog`, and `setEventMessages(..., 'warnings')` for the warning cases.

## Translations

New keys added to `en_US` and `fr_FR` only (other languages are Transifex-managed): `EInvoiceSupplierInvoiceLinkedToOrder`, `EInvoiceSupplierOrderLinkAmbiguous`, `EInvoiceSupplierOrderRefWrongSupplier`.

## Notes

- `BT-13` was already parsed by `CIIProtocol::parseInvoiceHeader()` as `orderReference`; Factur-X reuses the same parser, so the field is available on both paths.

## Tests

`php -l` clean on the three modified PHP files; phan (`--quick`, 5.5.2, baseline) reports no new findings.
