### PR TITLE
ci: skip autoassign job on forks

### DIFF
--- a/.github/workflows/ci-pr-autoassign.yml
+++ b/.github/workflows/ci-pr-autoassign.yml
@@ -33,6 +33,10 @@ permissions:
 
 jobs:
   assign-and-label:
+    # Only run on the upstream repo where the GitHub App secrets/vars exist.
+    # On forks PR18_APP_ID / PR18_SECRET_KEY are unset, so the token step fails;
+    # skip the whole job there to avoid a red (but harmless) run.
+    if: ${{ github.repository == 'Dolibarr/dolibarr-community-modules' }}
     runs-on: ubuntu-latest
 
     # Mergeers / reviewers list: edit here as needed (comma-separated)


### PR DESCRIPTION
Petit fix tranquille : le job d'autoassign/label a besoin du secret `PR18_SECRET_KEY` et de la var `PR18_APP_ID`, qui n'existent que sur le repo upstream. Du coup sur un fork l'étape « Generate GitHub App token » plante et affiche un run rouge.

J'ajoute une garde `if: github.repository == 'Dolibarr/dolibarr-community-modules'` pour que le job ne tourne que sur l'upstream. Ça m'embête d'avoir du rouge sur mon fork pour un truc inoffensif. 😉
