### PR TITLE
Fix #302: [einvoicing] carry customer reference (Réf. client) into BT-13

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -1490,6 +1490,18 @@ class CIIProtocol extends AbstractProtocol
 
 		$this->buildParty($doc, $agreement, $invoiceData, 'buyer');
 
+		// Buyer order reference (BT-13): customer purchase order number (Dolibarr "Réf. client").
+		// Emitted only when non-empty to avoid empty tags / cardinality issues. See issue #302.
+		// Position follows the CII schema sequence (after BuyerTradeParty).
+		if (!empty($invoiceData['orderReference'])) {
+			$comment = $doc->createComment('Buyer order reference (BT-13)');
+			$agreement->appendChild($comment);
+
+			$buyerOrderRef = $doc->createElement('ram:BuyerOrderReferencedDocument');
+			$agreement->appendChild($buyerOrderRef);
+			$buyerOrderRef->appendChild($doc->createElement('ram:IssuerAssignedID', htmlspecialchars($invoiceData['orderReference'])));
+		}
+
 
 		// DELIVERY
 

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -81,7 +81,8 @@ if (getDolGlobalInt('EINVOICING_USE_CHORUS')) {
 }
 $promise_code = $object->array_options['options_d4d_promise_code'] ?? '';
 if ($promise_code == '') {
-	$promise_code = $object->ref_customer ?? '';
+	// Dolibarr "Réf. client" (ref_client) holds the customer's purchase order number -> BT-13 (see issue #302)
+	$promise_code = $object->ref_client ?? '';
 }
 if ($promise_code == '' && !empty($customerOrderReferenceList)) {
 	$promise_code = $customerOrderReferenceList[0];

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -81,8 +81,9 @@ if (getDolGlobalInt('EINVOICING_USE_CHORUS')) {
 }
 $promise_code = $object->array_options['options_d4d_promise_code'] ?? '';
 if ($promise_code == '') {
-	// Dolibarr "Réf. client" (ref_client) holds the customer's purchase order number -> BT-13 (see issue #302)
-	$promise_code = $object->ref_client ?? '';
+	// Dolibarr "Réf. client" holds the customer's purchase order number -> BT-13 (see issue #302).
+	// The property is ref_client on recent versions and ref_customer on some older ones; accept both.
+	$promise_code = $object->ref_client ?? ($object->ref_customer ?? '');
 }
 if ($promise_code == '' && !empty($customerOrderReferenceList)) {
 	$promise_code = $customerOrderReferenceList[0];


### PR DESCRIPTION
## Summary

Closes #302.

On **emission**, the Dolibarr customer reference (*Réf. client* / `ref_client`, used here as the customer's purchase order number) was not written into the generated CII / Factur-X document, so `BT-13` (*Purchase order reference*) stayed empty even when *Réf. client* was filled.

This is the emission-side counterpart of inbound order auto-linking (#303): once `BT-13` is populated, the recipient can reconcile the invoice with their own purchase order.

## Root cause & fix

Two issues, both addressed:

1. **Wrong source field** — `lib/buildinvoicelines.inc.php` fed the order reference from `$object->ref_customer` (unset on invoices) instead of `$object->ref_client` (the field actually shown/edited on the invoice card). Now reads `ref_client`, keeping the existing priority:
   `d4d_promise_code` (Chorus engagement number) → `ref_client` → first linked customer order. This preserves the B2G/Chorus behaviour and fixes B2B.
2. **CII never emitted the element** — `CIIProtocol` generation did not output `BuyerOrderReferencedDocument` at all (Factur-X already emitted it via the horstoeko builder, so the source fix alone covers Factur-X). Added the element to `ApplicableHeaderTradeAgreement`, positioned right after `BuyerTradeParty` per the CII schema sequence, and only when the value is non-empty (no empty tags / cardinality issues).

## Field mapping

| Dolibarr field | EN 16931 | CII path |
|---|---|---|
| *Réf. client* (`ref_client`) | `BT-13` Purchase order reference | `ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID` |

`BT-10` (`BuyerReference`) is intentionally **not** populated, to avoid mixing it with the public-sector *code service* / *numéro d'engagement* semantics it carries in B2G.

## Resulting output

```xml
<ram:ApplicableHeaderTradeAgreement>
  ...
  <ram:BuyerOrderReferencedDocument>
    <ram:IssuerAssignedID>CMD-2026-0042</ram:IssuerAssignedID>
  </ram:BuyerOrderReferencedDocument>
</ram:ApplicableHeaderTradeAgreement>
```

## Tests

`php -l` clean; phan (`--quick`, 5.5.2, baseline) reports no new findings. No language changes (generation-only mapping).
