### PR TITLE
Fix #226: [einvoicing] isolate inbound temp files so concurrent syncs cannot corrupt invoices

### DIFF
--- a/einvoicing/class/protocols/AbstractProtocol.class.php
+++ b/einvoicing/class/protocols/AbstractProtocol.class.php
@@ -125,4 +125,45 @@ abstract class AbstractProtocol
 			dol_syslog(get_class($this) . '::checkFileSizeLimit ' . basename($filepath) . ' size ' . number_format($sizeMB, 2) . ' MB exceeds configured limit of ' . number_format($maxMB, 2) . ' MB', LOG_WARNING);
 		}
 	}
+
+	/**
+	 * Clean up the per-call working temp files of an inbound invoice, while preserving the
+	 * "last invoice that could not be processed" diagnostic shown (and downloadable) in the
+	 * document list view.
+	 *
+	 * Each inbound sync writes the received document to its own unique working file, so two
+	 * concurrent syncs can no longer overwrite each other and parse the wrong invoice (#226).
+	 * On failure, the working file is promoted to the fixed diagnostic slot (overwriting the
+	 * previous one) so it stays downloadable; on success, the working files are simply removed.
+	 *
+	 * @param	string	$tempDir			Module temp directory
+	 * @param	string	$workFile			Unique working file for the received document
+	 * @param	string	$workReadable		Unique working file for the readable view (may not exist)
+	 * @param	string	$diagName			Fixed diagnostic filename for the received document
+	 * @param	string	$diagReadableName	Fixed diagnostic filename for the readable view
+	 * @param	bool	$failed				True if processing failed (keep the diagnostic), false otherwise
+	 * @return	void
+	 */
+	protected function cleanupIncomingTempFiles($tempDir, $workFile, $workReadable, $diagName, $diagReadableName, $failed)
+	{
+		if ($failed) {
+			// Keep the failed file(s) as the downloadable "last unprocessed invoice" diagnostic.
+			if (file_exists($workFile)) {
+				dol_delete_file($tempDir . '/' . $diagName);
+				dol_copy($workFile, $tempDir . '/' . $diagName, '0', 1);
+			}
+			if (file_exists($workReadable)) {
+				dol_delete_file($tempDir . '/' . $diagReadableName);
+				dol_copy($workReadable, $tempDir . '/' . $diagReadableName, '0', 1);
+			}
+		}
+
+		// Always drop the per-call working files.
+		if (file_exists($workFile)) {
+			dol_delete_file($workFile);
+		}
+		if (file_exists($workReadable)) {
+			dol_delete_file($workReadable);
+		}
+	}
 }

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -444,32 +444,54 @@ class CIIProtocol extends AbstractProtocol
 	 */
 	public function createSupplierInvoiceFromSource($file, $ReadableViewFile = null, $flowId = '')
 	{
-		global $conf, $db, $user;
+		global $conf;
 
-		$einvoicing = new EInvoicing($db);
-		$return_messages = array();
-
-		// Save uploaded file to temporary directory
 		$tempDir = $conf->einvoicing->dir_temp;
 		if (!dol_is_dir($tempDir)) {
 			dol_mkdir($tempDir);
 		}
 
-		// If tmp dir in not empty, clean it
-		$files = scandir($tempDir);
-		foreach ($files as $f) {
-			if ($f != '.' && $f != '..') {
-				dol_delete_file($tempDir . '/' . $f);
-			}
+		// Use a unique per-call working file so two concurrent syncs cannot overwrite each other and
+		// parse the wrong invoice (#226). The fixed einvoice.xml slot is only the downloadable
+		// "last invoice that could not be processed" diagnostic, managed in cleanupIncomingTempFiles().
+		$uid = bin2hex(random_bytes(8));
+		$tempFile = $tempDir . '/in_' . $uid . '.xml';
+		$tempFileReadableView = $tempDir . '/in_' . $uid . '_readable.pdf';
+
+		$result = ['res' => -1, 'message' => 'Unexpected error while creating supplier invoice'];
+		try {
+			$result = $this->doCreateSupplierInvoiceFromSource($file, $ReadableViewFile, $flowId, $tempFile, $tempFileReadableView);
+		} finally {
+			$failed = !is_array($result) || !isset($result['res']) || $result['res'] < 0;
+			$this->cleanupIncomingTempFiles($tempDir, $tempFile, $tempFileReadableView, 'einvoice.xml', 'einvoice_readable.pdf', $failed);
 		}
 
-		$tempFile = $tempDir . '/einvoice.xml';
+		return $result;
+	}
+
+	/**
+	 * Build the supplier invoice from a received CII document written to a per-call working file.
+	 * The temp-file lifecycle is owned by createSupplierInvoiceFromSource() (the public wrapper).
+	 *
+	 * @param  string			$file                 Raw CII XML content
+	 * @param  string|null		$ReadableViewFile     Optional readable view (PDP-generated readable PDF)
+	 * @param  string			$flowId               Source flow identifier
+	 * @param  string			$tempFile             Unique working file for the received XML
+	 * @param  string			$tempFileReadableView Unique working file for the readable view
+	 * @return array{res:int<-1,1>, message:string, action?:string|null}
+	 */
+	private function doCreateSupplierInvoiceFromSource($file, $ReadableViewFile, $flowId, $tempFile, $tempFileReadableView)
+	{
+		global $conf, $db, $user;
+
+		$einvoicing = new EInvoicing($db);
+		$return_messages = array();
+
 		if (file_put_contents($tempFile, $file) === false) {
 			return ['res' => -1, 'message' => 'Failed to save CII file to temporary location'];
 		}
 
 		if ($ReadableViewFile) {
-			$tempFileReadableView = $tempDir . '/einvoice_readable.pdf';
 			if (file_put_contents($tempFileReadableView, $ReadableViewFile) === false) {
 				return ['res' => -1, 'message' => 'Failed to save readable view file to temporary location'];
 			}

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -967,32 +967,54 @@ class FacturXProtocol extends AbstractProtocol
 	 */
 	public function createSupplierInvoiceFromSource($file, $ReadableViewFile = null, $flowId = '')
 	{
-		global $conf, $db, $user;
+		global $conf;
 
-		$einvoicing = new EInvoicing($db);
-		$return_messages = array();
-
-		// Save uploaded file to temporary directory
 		$tempDir = $conf->einvoicing->dir_temp;
 		if (!dol_is_dir($tempDir)) {
 			dol_mkdir($tempDir);
 		}
 
-		// If tmp dir in not empty, clean it
-		$files = scandir($tempDir);
-		foreach ($files as $f) {
-			if ($f != '.' && $f != '..') {
-				dol_delete_file($tempDir . '/' . $f);
-			}
+		// Use a unique per-call working file so two concurrent syncs cannot overwrite each other and
+		// parse the wrong invoice (#226). The fixed facturx.pdf slot is only the downloadable
+		// "last invoice that could not be processed" diagnostic, managed in cleanupIncomingTempFiles().
+		$uid = bin2hex(random_bytes(8));
+		$tempFile = $tempDir . '/in_' . $uid . '.pdf';
+		$tempFileReadableView = $tempDir . '/in_' . $uid . '_readable.pdf';
+
+		$result = ['res' => -1, 'message' => 'Unexpected error while creating supplier invoice'];
+		try {
+			$result = $this->doCreateSupplierInvoiceFromSource($file, $ReadableViewFile, $flowId, $tempFile, $tempFileReadableView);
+		} finally {
+			$failed = !is_array($result) || !isset($result['res']) || $result['res'] < 0;
+			$this->cleanupIncomingTempFiles($tempDir, $tempFile, $tempFileReadableView, 'facturx.pdf', 'facturx_readable.pdf', $failed);
 		}
 
-		$tempFile = $tempDir . '/facturx.pdf';
+		return $result;
+	}
+
+	/**
+	 * Build the supplier invoice from a received Factur-X document written to a per-call working file.
+	 * The temp-file lifecycle is owned by createSupplierInvoiceFromSource() (the public wrapper).
+	 *
+	 * @param  string			$file                 Raw Factur-X PDF content
+	 * @param  string|null		$ReadableViewFile     Optional readable view (PDP-generated readable PDF)
+	 * @param  string			$flowId               Source flow identifier
+	 * @param  string			$tempFile             Unique working file for the received PDF
+	 * @param  string			$tempFileReadableView Unique working file for the readable view
+	 * @return array{res:int<-1,1>, message:string, action?:string|null}
+	 */
+	private function doCreateSupplierInvoiceFromSource($file, $ReadableViewFile, $flowId, $tempFile, $tempFileReadableView)
+	{
+		global $conf, $db, $user;
+
+		$einvoicing = new EInvoicing($db);
+		$return_messages = array();
+
 		if (file_put_contents($tempFile, $file) === false) {
 			return ['res' => -1, 'message' => 'Failed to save Factur-X file to temporary location'];
 		}
 
 		if ($ReadableViewFile) {
-			$tempFileReadableView = $tempDir . '/facturx_readable.pdf';
 			if (file_put_contents($tempFileReadableView, $ReadableViewFile) === false) {
 				return ['res' => -1, 'message' => 'Failed to save readable view file to temporary location'];
 			}

--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -596,4 +596,26 @@ abstract class AbstractPDPProvider
 	 * @return array{res:int, message:string}       Returns array with 'res' (1 on success, -1 on failure) with a 'message'.
 	 */
 	abstract public function sendStatusMessage($object, $statusCode, $reasonCode = '');
+
+	/**
+	 * Clear the fixed "last invoice that could not be processed" diagnostic files at the start of a
+	 * sync run, so the diagnostic shown in the document list reflects the latest run. Each failed flow
+	 * during the run re-creates its slot (see AbstractProtocol::cleanupIncomingTempFiles()). Call this
+	 * from syncFlows() (the batch), not from syncFlow(), so a later flow does not erase an earlier
+	 * failure within the same run.
+	 *
+	 * @return void
+	 */
+	protected function clearIncomingDiagnosticFiles()
+	{
+		global $conf;
+
+		$tempDir = $conf->einvoicing->dir_temp;
+		$diagFiles = array('facturx.pdf', 'facturx_readable.pdf', 'einvoice.xml', 'einvoice_readable.pdf');
+		foreach ($diagFiles as $f) {
+			if (file_exists($tempDir . '/' . $f)) {
+				dol_delete_file($tempDir . '/' . $f);
+			}
+		}
+	}
 }

--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -792,6 +792,9 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 			$form = new Form($db);
 		}
 
+		// Start the run with a clean "last unprocessed invoice" diagnostic; failed flows re-create it.
+		$this->clearIncomingDiagnosticFiles();
+
 		$results_messages = array();	// result message (technical error)
 		$actions = array();				// business message (manual action to do)
 
@@ -1603,6 +1606,9 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 
 			// Call API to send CDAR
 			$response = $this->callApi("flows", "POSTALREADYFORMATED", $params, $extraHeaders, 'Send Status Message');
+
+			// The CDAR temp file was only needed for the upload above; drop it now (unique name, #226).
+			dol_delete_file($filepath);
 
 			if ($response['status_code'] == 200 || $response['status_code'] == 202) {
 				/**

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -1209,6 +1209,9 @@ class SuperPDPProvider extends AbstractPDPProvider
 			$form = new Form($db);
 		}
 
+		// Start the run with a clean "last unprocessed invoice" diagnostic; failed flows re-create it.
+		$this->clearIncomingDiagnosticFiles();
+
 		$results_messages = array();	// result message (technical error)
 		$actions = array();				// business message (manual action to do)
 

--- a/einvoicing/class/utils/CdarHandler.class.php
+++ b/einvoicing/class/utils/CdarHandler.class.php
@@ -317,7 +317,8 @@ class CdarHandler
 			dol_mkdir($tempDir);
 		}
 
-		$filename = $tempDir . '/cdar_' . $ProcessCondition . '.xml';
+		// Unique per-call name so two concurrent status sends of the same condition cannot collide (#226).
+		$filename = $tempDir . '/cdar_' . $ProcessCondition . '_' . bin2hex(random_bytes(8)) . '.xml';
 
 		$result = $this->saveToFile($data, $filename);
 		if ($result === false) {

--- a/einvoicing/document_list.php
+++ b/einvoicing/document_list.php
@@ -328,10 +328,8 @@ if ($action == 'confirm_sync' && getDolGlobalString('EINVOICING_PDP') && $confir
 			}
 			//setEventMessages($langs->trans("FailedToSyncADocument").($errortype ? '<br>'.$langs->trans("FailedToSyncADocumentMore") : ''), null, $errortype);
 		} else {
-			// If sync is successful, we delete the old cached files that could not be processed
-			dol_delete_file($filePathCII);
-			dol_delete_file($filePathFacturX);
-
+			// The "last invoice that could not be processed" diagnostic files are managed by the sync
+			// itself (cleared at the start of syncFlows(), re-created per failed flow), not here.
 			if (!empty($sync_result['syncedFlows']) && $sync_result['syncedFlows'] > 0) {
 				// If sync was successful and we processed 1 new record, we clear the submitted date so a new one will be suggested from the last record in db.
 				$syncfromdate = 0;


### PR DESCRIPTION
Addresses #226. Opened as **draft**: needs a reception test on a real sandbox flow before review.

## Problem

Inbound supplier-invoice reception wrote each received document into a **shared** module temp dir (`documents/einvoicing/temp/`) under a **fixed** name (`facturx.pdf` / `einvoice.xml`), **wiped the whole dir** before each write, then **read that same fixed file back** to parse the invoice.

Two concurrent syncs — two users clicking *Synchronize*, or the `cronSyncFlows` cron overlapping a manual sync — race: process B's wipe deletes process A's file between A's write and A's read, so A parses **B's document** and creates a supplier invoice with the **wrong supplier/amount**. Silent data corruption, no error raised. Same fixed-name hazard in `CdarHandler` (`cdar_<condition>.xml`).

## A — kill the race

- `FacturXProtocol` / `CIIProtocol::createSupplierInvoiceFromSource()` write to a **unique per-call** working file (`in_<random>.{pdf,xml}`). The 650-line body moved to a private `doCreateSupplierInvoiceFromSource()` receiving the paths; the public method owns the temp lifecycle via **`try/finally`** (robust against every early return and exceptions).
- The fixed `facturx.pdf` / `einvoice.xml` slot is now **only** the downloadable *"last invoice that could not be processed"* diagnostic shown in the list view: on failure the working file is promoted to it, on success the working files are removed (`AbstractProtocol::cleanupIncomingTempFiles()`).
- `CdarHandler::generateCdarFile()` uses a unique name; `EsalinkPDPProvider` deletes the CDAR temp right after the upload (its only consumer).

## B — separation of concerns

- `syncFlows()` clears the diagnostic slot **once at the start** of a run (`AbstractPDPProvider::clearIncomingDiagnosticFiles()`); failed flows re-create it.
- `document_list.php` no longer deletes temp files — it only displays the diagnostic download links.

## Behaviour

No change on the happy path. The *"last unprocessed invoice"* diagnostic + download links in the document list are preserved (now driven by the sync, not the list controller).

## Validation
- `dolics` (phpcs, repo ruleset) clean; `php -l` clean on all 8 files.
- ⚠️ **Not yet runtime-tested on a reception flow** — to validate on a sandbox PA before un-drafting.

## Not in scope (possible follow-up)
- C: parse fully in-memory (`readAndGuessFromContent` / `getInvoiceDocumentContentFromContent` exist; CII already parses from a string) to drop the working file for the happy path entirely. The diagnostic file must stay on disk for the UI download, so a temp never fully disappears.
