### PR TITLE
[Einvoicing] Fix #333

### DIFF
--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -394,7 +394,7 @@ class ActionsEInvoicing extends CommonHookActions
 						$url_button[] = array(
 							'lang' => 'einvoicing',
 							'enabled' => 1,
-							'perm' => ($forcedisabling ? -1 : ((bool) $user->hasRight("facture", "creer") && empty($forcedisabling))),
+							'perm' => ($forcedisabling ? -1 : ((bool) $user->hasRight("fournisseur", "facture", "creer") && empty($forcedisabling))),
 							'label' => (string) $label,
 							'url' => '/fourn/facture/card.php?id=' . $object->id . '&action=sendStatusMessage&pdpstatuscode=' . $code . '&token=' . newToken()
 						);


### PR DESCRIPTION
Closes #333 

User rights for Einvoincing actions on supplier invoice must be related to the rights defined on supplier invoices.