### PR TITLE
[NEW] (einvoicing) import supplier payment fields

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -583,6 +583,12 @@ class CIIProtocol extends AbstractProtocol
 		// Set import_key
 		$supplierInvoice->import_key = AbstractPDPProvider::$EINVOICING_LAST_IMPORT_KEY;
 
+		// Set payment due date, payment terms and payment method
+		$paymentInfoRes = $this->_applyPaymentInfoToSupplierInvoice($supplierInvoice, $parsedHeader);
+		if (!empty($paymentInfoRes['message'])) {
+			dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource ' . $paymentInfoRes['message'], LOG_DEBUG, 0, '_einvoicing');
+		}
+
 
 		$remise_already_used_line_level_ids = array();
 

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -574,7 +574,7 @@ class CIIProtocol extends AbstractProtocol
 		if ($supplierInvoice->type === '-1') {
 			return ['res' => -1, 'message' => 'Unfounded dolibarr corresponding Invoice code for document type code: ' . ($parsedHeader['documenttypecode'] ?? 'NA')];
 		}
-		$supplierInvoice->date = isset($parsedHeader['documentdate']) && $parsedHeader['documentdate'] instanceof DateTime ? $parsedHeader['documentdate']->format('Y-m-d') : null;
+		$supplierInvoice->date = !empty($parsedHeader['documentdate']) ? dol_stringtotime($parsedHeader['documentdate']) : null;
 
 
 		// Set currency

--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -1734,7 +1734,7 @@ trait CommonProtocol
 		// Payment Terms (derived from Invoice date <-> Payment due on)
 		//---------------------------------------------------------------
 		if ($dueDate && !empty($supplierInvoice->date)) {
-			$invoiceDateTimestamp = is_numeric($supplierInvoice->date) ? $supplierInvoice->date : dol_stringtotime((string)$supplierInvoice->date);
+			$invoiceDateTimestamp = is_numeric($supplierInvoice->date) ? $supplierInvoice->date : dol_stringtotime((string) $supplierInvoice->date);
 
 			if ($invoiceDateTimestamp) {
 				$nbDays = (int) round(($dueDate - $invoiceDateTimestamp) / 86400);

--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -1687,7 +1687,7 @@ trait CommonProtocol
 	/**
 	 * Map of UNTDID 4461 payment means codes (BT-81, ram:TypeCode under
 	 * SpecifiedTradeSettlementPaymentMeans) to Dolibarr's paiement.code.
-	 * @var array<string,string>
+	 * @var array<int|'ZZZ',string>
 	 */
 	private static $UNTDID4461_TO_DOLIBARR_PAIEMENT_CODE = [
 		'10' => 'LIQ',	// Cash
@@ -1734,7 +1734,7 @@ trait CommonProtocol
 		// Payment Terms (derived from Invoice date <-> Payment due on)
 		//---------------------------------------------------------------
 		if ($dueDate && !empty($supplierInvoice->date)) {
-			$invoiceDateTimestamp = is_int($supplierInvoice->date) ? $supplierInvoice->date : dol_stringtotime($supplierInvoice->date);
+			$invoiceDateTimestamp = is_numeric($supplierInvoice->date) ? $supplierInvoice->date : dol_stringtotime((string)$supplierInvoice->date);
 
 			if ($invoiceDateTimestamp) {
 				$nbDays = (int) round(($dueDate - $invoiceDateTimestamp) / 86400);

--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -1683,4 +1683,111 @@ trait CommonProtocol
 		dol_syslog(get_class($this) . '::_linkSupplierInvoiceToPurchaseOrder Failed to link order ' . $orderId . ' to invoice ' . $supplierInvoice->id . ': ' . $supplierInvoice->error, LOG_ERR);
 		return '';
 	}
+
+	/**
+	 * Map of UNTDID 4461 payment means codes (BT-81, ram:TypeCode under
+	 * SpecifiedTradeSettlementPaymentMeans) to Dolibarr's paiement.code.
+	 * @var array<string,string>
+	 */
+	private static $UNTDID4461_TO_DOLIBARR_PAIEMENT_CODE = [
+		'10' => 'LIQ',	// Cash
+		'20' => 'CHQ',	// Check
+		'23' => 'TRA',	// Banque check
+		'30' => 'VIR',	// Bank transfer
+		'45' => 'TIP',	// Referenced home-banking credit transfer
+		'54' => 'CB',	// Credit card
+		'59' => 'PRE',	// SEPA direct debit
+		'68' => 'VAD',	// Online payment
+		'1' => 'FAC',	// local payment method | not defined
+	];
+
+	/**
+	 * Fill Payment due on (date_echeance), Payment Terms (cond_reglement_id) and
+	 * Payment method (mode_reglement_id) on a Dolibarr supplier invoice from data parsed
+	 * out of a received CII/Factur-X document.
+	 *
+	 * @param  FactureFournisseur 	$supplierInvoice 	Supplier invoice being built (modified by reference)
+	 * @param  array 				$parsedHeader 		Parsed CII header data (see CIIProtocol::parseInvoiceHeader())
+	 * @return array{message:string} 					Informational messages about what could/could not be applied (never blocking)
+	 */
+	private function _applyPaymentInfoToSupplierInvoice(FactureFournisseur $supplierInvoice, array $parsedHeader)
+	{
+		global $db;
+
+		$messages = array();
+
+		//------------------------
+		// Payment due on (BT-9)
+		//------------------------
+		$dueDate = null;
+		if (!empty($parsedHeader['paymentDueDate'])) {
+			$dueDateTimestamp = dol_stringtotime($parsedHeader['paymentDueDate']);
+			if ($dueDateTimestamp) {
+				$dueDate = $dueDateTimestamp;
+				$supplierInvoice->date_echeance = $dueDate;
+			} else {
+				$messages[] = 'Payment due date "' . $parsedHeader['paymentDueDate'] . '" could not be parsed, left empty.';
+			}
+		}
+
+		//---------------------------------------------------------------
+		// Payment Terms (derived from Invoice date <-> Payment due on)
+		//---------------------------------------------------------------
+		if ($dueDate && !empty($supplierInvoice->date)) {
+			$invoiceDateTimestamp = is_int($supplierInvoice->date) ? $supplierInvoice->date : dol_stringtotime($supplierInvoice->date);
+
+			if ($invoiceDateTimestamp) {
+				$nbDays = (int) round(($dueDate - $invoiceDateTimestamp) / 86400);
+
+				if ($nbDays >= 0) {
+					$sql = "SELECT rowid FROM " . MAIN_DB_PREFIX . "c_payment_term";
+					$sql .= " WHERE nbjour = " . ((int) $nbDays);
+					$sql .= " AND type_cdr = 0"; // fixed number of days only (no end of month)
+					$sql .= " AND active = 1";
+					$sql .= " ORDER BY rowid ASC"; // deterministic pick if duplicates
+					$sql .= " LIMIT 1";
+
+					$resql = $db->query($sql);
+					if ($resql && $db->num_rows($resql) == 1) {
+						$obj = $db->fetch_object($resql);
+						$supplierInvoice->cond_reglement_id = (int) $obj->rowid;
+						$messages[] = 'Payment Terms matched dictionary entry for ' . $nbDays . ' day(s).';
+					} else {
+						$messages[] = 'No matching Payment Terms dictionary entry found for ' . $nbDays . ' day(s) between invoice date and due date, left empty.';
+					}
+				} else {
+					$messages[] = 'Payment due date is before invoice date, cannot derive Payment Terms, left empty.';
+				}
+			}
+		}
+
+		//-------------------------------------
+		// Payment method (BT-81, UNTDID 4461)
+		// ------------------------------------
+		if (!empty($parsedHeader['paymentMeansCode'])) {
+			$untdidCode = trim((string) $parsedHeader['paymentMeansCode']);
+
+			if (isset(self::$UNTDID4461_TO_DOLIBARR_PAIEMENT_CODE[$untdidCode])) {
+				$dolibarrPaymentCode = self::$UNTDID4461_TO_DOLIBARR_PAIEMENT_CODE[$untdidCode];
+
+				$sql = "SELECT id FROM " . MAIN_DB_PREFIX . "c_paiement";
+				$sql .= " WHERE code = '" . $db->escape($dolibarrPaymentCode) . "'";
+				$sql .= " AND active = 1";
+				$sql .= " LIMIT 1";
+
+				$resql = $db->query($sql);
+				if ($resql && $db->num_rows($resql) == 1) {
+					$obj = $db->fetch_object($resql);
+					$supplierInvoice->mode_reglement_id = (int) $obj->id;
+					$messages[] = 'Payment method mapped from UNTDID 4461 code ' . $untdidCode . ' to Dolibarr code ' . $dolibarrPaymentCode . '.';
+				} else {
+					$messages[] = 'Payment method code ' . $dolibarrPaymentCode . ' (from UNTDID 4461 code ' . $untdidCode . ') not found or not active in Dolibarr dictionary, left empty.';
+				}
+			} else {
+				$messages[] = 'UNTDID 4461 payment means code ' . $untdidCode . ' has no known Dolibarr mapping, left empty.';
+			}
+		}
+
+		return array('message' => implode("<br>\n", $messages));
+	}
 }

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -1290,6 +1290,12 @@ class FacturXProtocol extends AbstractProtocol
 		// Set import_key
 		$supplierInvoice->import_key = AbstractPDPProvider::$EINVOICING_LAST_IMPORT_KEY;
 
+		// Set payment due date, payment terms and payment method
+		$paymentInfoRes = $this->_applyPaymentInfoToSupplierInvoice($supplierInvoice, $parsedHeader);
+		if (!empty($paymentInfoRes['message'])) {
+			dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource ' . $paymentInfoRes['message'], LOG_DEBUG, 0, '_einvoicing');
+		}
+
 
 		$remise_already_used_line_level_ids = array();
 


### PR DESCRIPTION
## Summary

When a supplier invoice (CII or Factur-X) is imported via **EInvoice synchronization** page, the following header fields from the received XML are parsed but currently **not** transferred to the created Dolibarr supplier invoice:

- Payment due on
- Payment Terms 
- Payment method

This PR fills them in, using data already extracted by `parseInvoiceHeader()`  
It also fixes a bug that left **Invoice date** unset in CIIProtocol.

## What changed

### 1. Bug fix: Invoice date was never actually set (CIIProtocol)

```php
// Before
$supplierInvoice->date = isset($parsedHeader['documentdate'])
    && $parsedHeader['documentdate'] instanceof DateTime
        ? $parsedHeader['documentdate']->format('Y-m-d') : null;
```

ParseInvoiceHeader() normalises 'documentdate' to a 'Y-m-d' string with normDate(), not a DateTime instance, so checking "instanceof DateTime" will be always false and left the invoice date unset. Since Invoice date can't be null, the invoice get (wrongly) the today's date. 

I fix it by parse it with dol_stringtotime() like it is done in FacturXProtocol.  

I also kept the null logic in case of error, but since the invoice date is a required field to retrieve the invoice in the PA (ex: to update event with AFNOR Flow API), it may be better to raise an error.

```php
// After
$supplierInvoice->date = !empty($parsedHeader['documentdate'])
    ? dol_stringtotime($parsedHeader['documentdate']) : null;
```

### 2. New shared method: `CommonProtocol::_applyPaymentInfoToSupplierInvoice()`

Fill Payment due on (date_echeance), Payment Terms (cond_reglement_id) and Payment method (mode_reglement_id) on a Dolibarr supplier invoice from data parsed out of a received CII/Factur-X document.

This method is intentionally conservative: a field is only set when it can determine an exact, unambiguous value. If nothing matches, the corresponding Dolibarr field is simply left empty/default, it is never guessed.

- Payment due on: `BT-9` (`paymentDueDate`), used as-is when present otherwise `null`.
- Payment Terms: not read from the XML label (`BT-20` is free text, not machine comparable). Instead it compute the number of days between the invoice date (`BT-2`) and the due date (`BT-9`), and look for an exact match in Dolibarr's dictionary "Payment Terms", restricted to the `type_cdr = 0` (fixed number of days) entries since the "end of month" variants (`type_cdr = 1`) require a calendar computation the plain BT-2/BT-9 day-count cannot reliably reproduce. If there is no exact match, it is left empty.
- Payment method: `BT-81` (`paymentMeansCode`) is a UNTDID 4461 code, mapped to Dolibarr's payment code via `self::$UNTDID4461_TO_DOLIBARR_PAIEMENT_CODE`. If the code is missing from the map, or not found/not active in the current Dolibarr instance's dictionary, it is left empty.

### 3. New class attribut: `CommonProtocol::$UNTDID4461_TO_DOLIBARR_PAIEMENT_CODE()`

Map of UNTDID 4461 payment means codes (`BT-81`, `TypeCode` under `SpecifiedTradeSettlementPaymentMeans`) to Dolibarr's paiement code.  

This is the mirror of `_getPaymentMeanNumber()`, used here in the opposite direction when importing a received E-invoice.  

Only codes with an unambiguous, standard Dolibarr equivalent are mapped; unmapped codes are left as 'unmapped'.

## Files changed

- `einvoicing/class/protocols/CommonProtocol.class.php` — new map + new method
- `einvoicing/class/protocols/CIIProtocol.class.php` — invoice-date bug fix + call to new method
- `einvoicing/class/protocols/FacturXProtocol.class.php` — call to new method

## How to test

I have setup Dolibarr eInvoice module with SuperPDP sandbox with Company/Organization and company E-Invoicing ID set as Burger Queen.  
I have added Tricatel as a supplier/vendor Third Party.

From SuperPDP invoice example, I have derivate 9 different invoices to test all use case :

| #   | Invoice ID (BT-1)    | Issue Date (BT-2) | BT-81 TypeCode | Dolibarr PaymentMeans | Due Date          |
| --- | -------------------- | ----------------- | -------------- | --------------------- | ----------------- |
| 1   | F20260703_110001_001 | 2026-07-03        | 10             | Cash                  | 2026-07-04 (+1d)  |
| 2   | F20260704_110002_002 | 2026-07-04        | 20             | Cheque                | 2026-08-03 (+30d) |
| 3   | F20260705_110003_003 | 2026-07-05        | 23             | Traite (Banque check) | 2026-09-03 (+60d) |
| 4   | F20260706_110004_004 | 2026-07-06        | 30             | Bank transfer         | 2026-07-16 (+10d) |
| 5   | F20260707_110005_005 | 2026-07-07        | 45             | TIP Payment           | 2026-07-21 (+14d) |
| 6   | F20260708_110006_006 | 2026-07-08        | 54             | Credit card           | 2026-07-13 (+5d)  |
| 7   | F20260709_110007_007 | 2026-07-09        | 59             | Debit payment order   | 2026-07-20 (+11d) |
| 8   | F20260710_110008_008 | 2026-07-10        | 68             | Online payment        | 2026-07-25 (+15d) |
| 9   | F20260711_110009_009 | 2026-07-11        | 1              | Factor                | 2026-08-30 (+50d) |


Here is a zip with the invoices :  [Test-Invoices.zip](https://github.com/user-attachments/files/29648272/Test-Invoices.zip)

In superpdp interface, I upload under `Tricatel - Factures de vente` all 9 invoices then in the page `E-invoice synchronization` of the module I press the button `Syncronize`.

9 supplier invoice should be created as drafts with the payment fields filled as the above table.

In order to make a full working test for payment mode, please make sure to activate most payment mode in `Dictionary setup - Payment Modes`  
If a payment mode is not activated, the field in the invoice will be empty.
You will also need to create product/service for `Poulet aux hormones` and  `Conseil en stratégie`

I have tested CII invoice, but **I have not tested Factur-X invoice**.
Test have been made with a dolibarr instance version 21.0.4