### PR TITLE
fix(einvoicing): do not double-count the paid amount in the prepaid total

### DIFF
--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -570,7 +570,10 @@ if ($resql) {
 // Already paid deposits
 $getAlreadyPaid = $object->getSommePaiement();
 
-$prepaidAmount  = $object->sumpayed + $getAlreadyPaid + $usedcreditnoteamount;
+// getSommePaiement() (called just above) already assigns its return value to $object->sumpayed.
+// Adding both $object->sumpayed and $getAlreadyPaid counted the paid amount twice, doubling
+// TotalPrepaidAmount (BT-113) and producing a wrong / negative DuePayableAmount (BR-CO-16).
+$prepaidAmount  = $getAlreadyPaid + $usedcreditnoteamount;
 
 // Delivery date
 $deliveryDate = !empty($deliveryDateList)


### PR DESCRIPTION
## Problem

In `einvoicing/lib/buildinvoicelines.inc.php`, the prepaid total is computed as:

```php
$getAlreadyPaid = $object->getSommePaiement();
$prepaidAmount  = $object->sumpayed + $getAlreadyPaid + $usedcreditnoteamount;
```

`Facture::getSommePaiement()` both returns the paid sum and assigns it to `$this->sumpayed`. So `$object->sumpayed` and `$getAlreadyPaid` hold the same value, and the already paid amount is added twice.

## Effect

`TotalPrepaidAmount` (BT-113) is doubled and `DuePayableAmount` (BT-115) is wrong. For a fully paid invoice it becomes negative. Example: total 384.00, paid 384.00 gives prepaid 768.00 and due -384.00, which violates EN16931 rule BR-CO-16 and is rejected by the Access Point. In France invoices are frequently transmitted already paid, so this hits a common case.

## Fix

Use the paid sum once:

```php
$prepaidAmount = $getAlreadyPaid + $usedcreditnoteamount;
```

## Verification

After the fix, a fully paid invoice (total 384.00, paid 384.00) produces `TotalPrepaidAmount 384.00` and `DuePayableAmount 0.00`, and SuperPDP's validation service (`POST /validation_reports`, FNFE CTC schematrons V1.3.0) returns `is_valid: true`. Before the fix the same invoice had `TotalPrepaidAmount 768.00` and `DuePayableAmount -384.00`.
