### PR TITLE
fix(einvoicing): do not add deposit lines to the prepaid total (BT-113)

### DIFF
--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -290,7 +290,6 @@ foreach ($object->lines as $line) {
 				$depositFactDate = new DateTime(dol_print_date($origFact->date, 'dayrfc'));
 			}
 		}
-		$prepaidAmount += abs($line->total_ttc);
 		$line->qty      = -$line->qty;				// For a deposit, ->qty should be -1.
 		$line->subprice = abs($line->subprice);
 


### PR DESCRIPTION
## Problem

Deposits already invoiced are represented with the line method (BT-153 / BT-154), as the code itself documents:

```php
// This is the first method described into XP_Z12-014 using the line into field BT-153 / BT-154
// The second method need to use the field BT-113. We don't use it as we use the first method.
```

For a `(DEPOSIT)` line the quantity is flipped negative (`$line->qty = -$line->qty;`), so the line already reduces `grand_total_ttc` through the normal line accumulation. In the same block, the deposit is additionally added to `$prepaidAmount`:

```php
$prepaidAmount += abs($line->total_ttc);
```

`$prepaidAmount` feeds `TotalPrepaidAmount` (BT-113) and `DuePayableAmount = grand_total_ttc - prepaidAmount`.

## Effect

This is a latent double subtraction of the deposit: once through the negative line (already in `grand_total_ttc`) and once through BT-113. It is currently masked because `$prepaidAmount` is unconditionally reassigned a few lines below (`$prepaidAmount = ...`), so this accumulation never reaches the output. But it is dead and misleading, it contradicts the documented BT-153 / BT-154 choice, and it would understate `DuePayableAmount` by the deposit amount if that later assignment were ever changed.

## Fix

Remove the line. Deposits remain handled by the line method (BT-153 / BT-154) only, as documented. No change to current output.
