### PR TITLE
fix(einvoicing): use transnoentities for legal note texts to avoid double-encoding

### DIFF
--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -601,9 +601,9 @@ $invoiceData = [
 
 	// Notes
 	'documentNotePublic'   => $object->note_public ?: "",
-	'documentNotePMT'      => getDolGlobalString('EINVOICING_PMT') ?: $outputlangs->trans("NoInvoiceCollectionFees"),
-	'documentNotePMD'      => getDolGlobalString('EINVOICING_PMD') ?: $outputlangs->trans('NoLatePaymentFees'),
-	'documentNoteAAB'      => getDolGlobalString('EINVOICING_AAB') ?: $outputlangs->trans('NoEarlyPaymentDiscount'),
+	'documentNotePMT'      => getDolGlobalString('EINVOICING_PMT') ?: $outputlangs->transnoentities("NoInvoiceCollectionFees"),
+	'documentNotePMD'      => getDolGlobalString('EINVOICING_PMD') ?: $outputlangs->transnoentities('NoLatePaymentFees'),
+	'documentNoteAAB'      => getDolGlobalString('EINVOICING_AAB') ?: $outputlangs->transnoentities('NoEarlyPaymentDiscount'),
 	'documentNotes'        => [],
 
 	// Seller part


### PR DESCRIPTION
## Problem

The legal mention notes (PMT / PMD / AAB) are built with `trans()`:

```php
'documentNotePMT' => getDolGlobalString('EINVOICING_PMT') ?: $outputlangs->trans("NoInvoiceCollectionFees"),
'documentNotePMD' => getDolGlobalString('EINVOICING_PMD') ?: $outputlangs->trans('NoLatePaymentFees'),
'documentNoteAAB' => getDolGlobalString('EINVOICING_AAB') ?: $outputlangs->trans('NoEarlyPaymentDiscount'),
```

`Translate::trans()` HTML-encodes its result (`htdocs/core/class/translate.class.php`: `$str = htmlentities($str, ENT_COMPAT, $this->charset_output);`). So the French text "Aucune ristourne pour paiement anticipé", stored correctly with a raw "é" in `langs/fr_FR/einvoicing.lang`, becomes `anticip&eacute;`. The note is then written into the XML where the ampersand is escaped again (CIIProtocol via `htmlspecialchars`, FacturXProtocol via the zugferd DOM builder), producing a double-encoded value:

```xml
<ram:Content>Aucune ristourne pour paiement anticip&amp;eacute;</ram:Content>
```

## Fix

Use `transnoentities()`, which returns the raw translated text. This is the convention already used elsewhere in the module for non-HTML (XML / PDF) output, and it lets the XML layer perform the single, correct escaping.

## Result

```xml
<ram:Content>Aucune ristourne pour paiement anticipé</ram:Content>
```
