### PR TITLE
feat(einvoicing): recipient directory reachability pre-check on the invoice card

### DIFF
--- a/einvoicing/admin/setup_options.php
+++ b/einvoicing/admin/setup_options.php
@@ -216,6 +216,13 @@ if (!getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP')) {
 	$item->cssClass = 'minwidth500';
 	$item->fieldParams['forcereload'] = 0;
 
+	// Setup conf to check the recipient reachability in the Approved Platforms directory (annuaire PA) before
+	// sending, and surface it on the invoice card. On by default. A read-only directory lookup: it never blocks.
+	$item = $formSetup->newItem('EINVOICING_PRECHECK_DIRECTORY')->setAsYesNo();
+	$item->helpText = $langs->transnoentities('EINVOICING_PRECHECK_DIRECTORY_HELP');
+	$item->defaultFieldValue = 1;
+	$item->cssClass = 'minwidth500';
+
 	// Setup conf to skip e-invoicing for B2C third parties (private individuals): out of the e-invoicing
 	// scope (e-reporting applies instead). Off by default. Company vs individual detection is delegated to
 	// Societe::isACompany() (and its own options), so there is nothing extra to configure here.

--- a/einvoicing/ajax/checkdirectory.php
+++ b/einvoicing/ajax/checkdirectory.php
@@ -1,0 +1,177 @@
+<?php
+/* Copyright (C) 2026		Gregory Aliot			<greg.aliot@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ *       \file       htdocs/einvoicing/ajax/checkdirectory.php
+ *       \brief      Ajax endpoint: check a recipient reachability in the Approved Platforms directory
+ */
+
+if (!defined('NOTOKENRENEWAL')) {
+	define('NOTOKENRENEWAL', 1); // Disables token renewal
+}
+if (!defined('NOREQUIREMENU')) {
+	define('NOREQUIREMENU', '1');
+}
+if (!defined('NOREQUIREHTML')) {
+	define('NOREQUIREHTML', '1');
+}
+if (!defined('NOREQUIREAJAX')) {
+	define('NOREQUIREAJAX', '1');
+}
+if (!defined('NOREQUIRESOC')) {
+	define('NOREQUIRESOC', '1');
+}
+if (!defined('NOCSRFCHECK')) {
+	define('NOCSRFCHECK', '1');
+}
+
+// Load Dolibarr environment
+$res = 0;
+// Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
+if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
+	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
+}
+// Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
+$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME'];
+$tmp2 = realpath(__FILE__);
+$i = strlen($tmp) - 1;
+$j = strlen($tmp2) - 1;
+while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
+	$i--;
+	$j--;
+}
+if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
+	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
+}
+if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
+	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
+}
+// Try main.inc.php using relative path
+if (!$res && file_exists("../../main.inc.php")) {
+	$res = @include "../../main.inc.php";
+}
+if (!$res && file_exists("../../../main.inc.php")) {
+	$res = @include "../../../main.inc.php";
+}
+if (!$res && file_exists("../../../../main.inc.php")) {
+	$res = @include "../../../../main.inc.php";
+}
+if (!$res && file_exists("../../../../../main.inc.php")) {
+	$res = @include "../../../../../main.inc.php";
+}
+if (!$res) {
+	http_response_code(500);
+	die("Include of main fails");
+}
+/**
+ * @var Conf $conf
+ * @var DoliDB $db
+ * @var Translate $langs
+ * @var User $user
+ */
+
+$objectRef = GETPOST('ref', 'alpha');	// 'alpha' like the invoice card (compta/facture/card.php): keeps refs with '/', '-', etc. from numbering masks. fetch() escapes it for SQL.
+
+// Security check
+if (!$user->hasRight('einvoicing', 'read')) {
+	accessforbidden();
+}
+
+dol_syslog("Call ajax einvoicing/ajax/checkdirectory.php");
+$langs->load('einvoicing@einvoicing');
+
+top_httphead();
+
+/**
+ * Build a localized, ready-to-display HTML snippet from a directory result.
+ *
+ * @param array 	$r 		Result from AbstractPDPProvider::checkRecipientDirectory()
+ * @param string 	$siren 	Recipient SIREN, for messages
+ * @return string 			HTML snippet
+ */
+function einvoicing_directory_html($r, $siren)
+{
+	global $langs;
+	$status = $r['status'] ?? 'error';
+	switch ($status) {
+		case 'routable':
+			$txt = $langs->trans("EInvoicingDirectoryRoutable");
+			if (!empty($r['identifier'])) {
+				$txt .= ' <span class="opacitymedium small">('.dol_escape_htmltag($r['identifier']).')</span>';
+			}
+			return img_picto('', 'tick', 'class="color-green paddingright"').$txt;
+		case 'absent':
+			return img_picto('', 'error', 'class="color-red paddingright"').$langs->trans("EInvoicingDirectoryAbsent", $siren);
+		case 'inactive':
+			return img_picto('', 'warning', 'class="paddingright"').$langs->trans("EInvoicingDirectoryInactive", $siren);
+		case 'unsupported':
+			return '<span class="opacitymedium">'.img_picto('', 'info', 'class="paddingright"').$langs->trans("EInvoicingDirectoryUnsupported").'</span>';
+		default:
+			// Escape the provider/proxy error text: it is interpolated into an HTML snippet that the card
+			// injects with .html(), so untrusted markup in an API error response must not be executable.
+			$msg = dol_escape_htmltag(!empty($r['message']) ? $r['message'] : ('HTTP '.($r['httpcode'] ?? 0)));
+			return img_picto('', 'error', 'class="color-red paddingright"').$langs->trans("EInvoicingDirectoryError", $msg);
+	}
+}
+
+if (!$objectRef) {
+	print json_encode(array('status' => 'error', 'html' => img_picto('', 'error').' '.$langs->trans("EInvoicingDirectoryError", 'no ref')));
+	$db->close();
+	exit;
+}
+
+require_once DOL_DOCUMENT_ROOT."/compta/facture/class/facture.class.php";
+$invoice = new Facture($db);
+$invoice->fetch(0, $objectRef);
+if ($invoice->id <= 0) {
+	print json_encode(array('status' => 'error', 'html' => img_picto('', 'error').' '.$langs->trans("EInvoicingDirectoryError", 'invoice '.$objectRef)));
+	$db->close();
+	exit;
+}
+
+// Authorize the fetched invoice with the standard invoice/third-party access rules: the e-invoicing
+// read right alone must not expose an invoice (and its recipient data) the user cannot otherwise read.
+restrictedArea($user, 'facture', $invoice->id, '', '', 'fk_soc', 'rowid');
+
+$invoice->fetch_thirdparty();
+$siren = is_object($invoice->thirdparty) ? preg_replace('/[^0-9]/', '', (string) $invoice->thirdparty->idprof1) : '';
+if ($siren === '') {
+	print json_encode(array(
+		'status' => 'error',
+		'reachable' => -1,
+		'html' => img_picto('', 'warning', 'class="warning"').' '.$langs->trans("EInvoicingDirectoryNoSiren"),
+	));
+	$db->close();
+	exit;
+}
+
+require_once "../class/providers/PDPProviderManager.class.php";
+$PDPManager = new PDPProviderManager($db);
+$provider = $PDPManager->getProvider(getDolGlobalString('EINVOICING_PDP'));
+if (!is_object($provider)) {
+	print json_encode(array('status' => 'error', 'html' => img_picto('', 'error').' '.$langs->trans("EInvoicingDirectoryError", 'no provider')));
+	$db->close();
+	exit;
+}
+
+$r = $provider->checkRecipientDirectory($siren);
+$r['siren'] = $siren;
+$r['html'] = einvoicing_directory_html($r, $siren);
+
+print json_encode($r);
+
+$db->close();

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -1323,6 +1323,39 @@ class EInvoicing
 			$resprints .= '</tr>';
 		}
 
+		// Recipient reachability in the Approved Platforms directory (annuaire PA), checked before sending.
+		// This is a read-only lookup surfaced on the card so the user sees whether the recipient can receive
+		// an e-invoice, instead of discovering a routing rejection (fr:213) only after transmission.
+		if (($object->element == 'facture' || $object->element == 'invoice') && $action != 'create' && getDolGlobalInt('EINVOICING_PRECHECK_DIRECTORY', 1)) {
+			if (!is_object($object->thirdparty ?? null) && !empty($object->socid)) {
+				$object->fetch_thirdparty();
+			}
+			$directorySiren = is_object($object->thirdparty ?? null) ? preg_replace('/[^0-9]/', '', (string) $object->thirdparty->idprof1) : '';
+			if ($directorySiren !== '') {
+				$urlajaxdir = dol_buildpath('einvoicing/ajax/checkdirectory.php', 1);
+				// Auto-run once in the pre-send window (validated, not yet really transmitted to the AP).
+				$autorun = ((int) $object->status === Facture::STATUS_VALIDATED && empty($currentStatusInfo['everTransmitted'])) ? 1 : 0;
+				$resprints .= '<tr class="treinvoicing_collapseseparator">';
+				$resprints .= '<td>' . $form->textwithpicto($langs->trans("EInvoicingDirectoryCheck"), $langs->trans("EInvoicingDirectoryCheckHelp")) . '</td>';
+				$resprints .= '<td><span id="einvoice-directory" class="opacitymedium">' . ($autorun ? dol_escape_htmltag($langs->trans("EInvoicingDirectoryChecking")) : '-') . '</span>';
+				$resprints .= ' <a href="#" id="einvoice-directory-check" class="paddingleft">' . img_picto('', 'refresh', 'class="paddingright"') . $langs->trans("EInvoicingDirectoryCheckButton") . '</a>';
+				$resprints .= '</td></tr>';
+				$resprints .= '<script type="text/javascript">
+				(function(){
+					function einvoiceCheckDirectory(){
+						$("#einvoice-directory").html("' . dol_escape_js($langs->trans("EInvoicingDirectoryChecking")) . '").addClass("opacitymedium");
+						$.get("' . $urlajaxdir . '", { token: "' . currentToken() . '", ref: "' . dol_escape_js($object->ref) . '" }, function(data){
+							if (typeof data === "string") { try { data = JSON.parse(data); } catch(e){ console.error("checkdirectory: not JSON", data); return; } }
+							$("#einvoice-directory").html(data.html || "").removeClass("opacitymedium");
+						}, "text").fail(function(x){ console.error("checkdirectory ajax", x.status, x.statusText); });
+					}
+					$("#einvoice-directory-check").click(function(e){ e.preventDefault(); einvoiceCheckDirectory(); });
+					' . ($autorun ? 'setTimeout(einvoiceCheckDirectory, 1200);' : '') . '
+				})();
+				</script>';
+			}
+		}
+
 		// Invoice-level routing ID override (BT-49)
 		if ($object->element == 'facture' || $object->element == 'invoice') {
 			$currentOverrideRouting = $currentStatusInfo['override_routing_id'] ?? '';

--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -172,6 +172,13 @@ abstract class AbstractPDPProvider
 			if (!empty($prod)) {
 				$url = $this->config['ap_api_url'];
 			}
+		} elseif ($mode === 'afnor_directory') {
+			// Base of the standardized AFNOR Directory Service (XP Z12-013). Only providers that expose
+			// it set the config keys; the others return an empty string and skip the standardized check.
+			$url = !empty($this->config['test_afnor_directory_url']) ? $this->config['test_afnor_directory_url'] : '';
+			if (!empty($prod) && !empty($this->config['prod_afnor_directory_url'])) {
+				$url = $this->config['prod_afnor_directory_url'];
+			}
 		}
 
 		return $url;
@@ -207,7 +214,64 @@ abstract class AbstractPDPProvider
 	 */
 	public function checkRecipientDirectory($idprof1)
 	{
-		return array('status' => 'unsupported', 'reachable' => -1, 'entries' => 0, 'active' => 0, 'identifier' => '', 'message' => '', 'httpcode' => 0);
+		$result = array('status' => 'unsupported', 'reachable' => -1, 'entries' => 0, 'active' => 0, 'identifier' => '', 'message' => '', 'httpcode' => 0);
+
+		// The standardized route check uses the AFNOR Directory Service (XP Z12-013), so any conformant
+		// Approved Platform is supported. A provider that does not expose that base keeps the
+		// 'unsupported' status (it may still override this method with its own directory lookup).
+		$base = $this->getApiUrl('afnor_directory');
+		if (empty($base) || !method_exists($this, 'callApi')) {
+			return $result;
+		}
+
+		$siren = preg_replace('/[^0-9]/', '', (string) $idprof1);
+		if (!preg_match('/^[0-9]{9}$/', (string) $siren)) {
+			$result['status'] = 'error';
+			$result['message'] = 'EInvoicingDirectoryNoSiren';
+			return $result;
+		}
+
+		// 1) Search the directory lines for a reception address declared for this SIREN.
+		$body = json_encode(array('filters' => array('siren' => array('op' => 'strict', 'value' => $siren))));
+		$response = $this->callApi('afnor-directory/v1/directory-line/search', 'POST', $body, array(), 'precheck_directory');
+		$result['httpcode'] = (int) (isset($response['status_code']) ? $response['status_code'] : 0);
+
+		if ($result['httpcode'] != 200) {
+			$result['status'] = 'error';
+			$result['message'] = isset($response['errorMessage']) ? $response['errorMessage'] : ('HTTP ' . $result['httpcode']);
+			return $result;
+		}
+
+		$lines = array();
+		if (isset($response['response']['results']) && is_array($response['response']['results'])) {
+			$lines = $response['response']['results'];
+		}
+		$result['entries'] = count($lines);
+
+		if ($result['entries'] > 0) {
+			// At least one directory line: the recipient has a reception address on an Approved Platform.
+			$result['active'] = $result['entries'];
+			$result['status'] = 'routable';
+			$result['reachable'] = 1;
+			foreach ($lines as $line) {
+				if ($result['identifier'] === '' && !empty($line['addressingIdentifier'])) {
+					$result['identifier'] = (string) $line['addressingIdentifier'];
+				}
+			}
+			return $result;
+		}
+
+		// 2) No directory line: tell apart a legal unit known to the directory but not able to receive
+		//    yet (inactive) from a SIREN that is unknown to the directory (absent).
+		$consult = $this->callApi('afnor-directory/v1/siren/code-insee:' . urlencode($siren), 'GET', false, array(), 'precheck_directory');
+		$consultcode = (int) (isset($consult['status_code']) ? $consult['status_code'] : 0);
+		if ($consultcode == 200 && !empty($consult['response']['siren'])) {
+			$result['status'] = 'inactive';
+		} else {
+			$result['status'] = 'absent';
+		}
+		$result['reachable'] = 0;
+		return $result;
 	}
 
 	/**

--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -187,6 +187,28 @@ abstract class AbstractPDPProvider
 		return !empty($this->config['has_validator']);
 	}
 
+	/**
+	 * Check whether a recipient has an active reception address in the Approved Platforms
+	 * directory (annuaire des Plateformes Agreees) before attempting to send an e-invoice.
+	 *
+	 * A recipient that is absent from the directory, or present but without any active routing
+	 * line, cannot receive electronic invoices: sending would be rejected by the platform with
+	 * a routing error (lifecycle fr:213). Checking beforehand lets the caller warn the user with
+	 * a clear message instead of the opaque platform rejection.
+	 *
+	 * Providers that do not expose a directory lookup keep the default 'unsupported' status so
+	 * the feature degrades gracefully and never blocks them.
+	 *
+	 * @param 	string 	$idprof1 	Recipient professional id 1 (SIREN for France)
+	 * @return 	array{status:string,reachable:int,entries:int,active:int,identifier:string,message:string,httpcode:int}
+	 *								status: unsupported|error|absent|inactive|routable ;
+	 *								reachable: 1 routable, 0 not routable, -1 unknown ;
+	 *								identifier: first active electronic address found (if any).
+	 */
+	public function checkRecipientDirectory($idprof1)
+	{
+		return array('status' => 'unsupported', 'reachable' => -1, 'entries' => 0, 'active' => 0, 'identifier' => '', 'message' => '', 'httpcode' => 0);
+	}
 
 	/**
 	 * Generate a UUID used to correlate logs between Dolibarr and PDP.

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -1103,7 +1103,8 @@ class SuperPDPProvider extends AbstractPDPProvider
 		// The OAuth token endpoint lives on the auth base (/oauth2/), not the Flow API base. This applies to
 		// every token grant: client_credentials, authorization_code and refresh_token.
 		$url = $this->getApiUrl(($resource == 'token' || $callType == 'get_access_token') ? 'auth' : 'api') . $resource;
-		if ($resource == 'validation_reports') {
+		if ($resource == 'validation_reports' || strpos($resource, 'french_directory') === 0) {
+			// validation_reports and the French directory lookup both live on the AP API base (v1.beta).
 			$url = $this->getApiUrl('ap_api') . $resource;
 		}
 
@@ -1179,6 +1180,62 @@ class SuperPDPProvider extends AbstractPDPProvider
 		}
 
 		return $returnarray;
+	}
+
+	/**
+	 * Check whether a recipient (SIREN) has an active reception address in the French directory
+	 * of Approved Platforms, using the SuperPDP directory endpoint (GET french_directory/entries).
+	 *
+	 * @param 	string 	$idprof1 	Recipient SIREN (idprof1)
+	 * @return 	array{status:string,reachable:int,entries:int,active:int,identifier:string,message:string,httpcode:int}
+	 */
+	public function checkRecipientDirectory($idprof1)
+	{
+		$result = array('status' => 'error', 'reachable' => -1, 'entries' => 0, 'active' => 0, 'identifier' => '', 'message' => '', 'httpcode' => 0);
+
+		$siren = preg_replace('/[^0-9]/', '', (string) $idprof1);
+		if ($siren === '') {
+			$result['message'] = 'EInvoicingDirectoryNoSiren';
+			return $result;
+		}
+
+		$resource = 'french_directory/entries?number=' . urlencode($siren);
+		$response = $this->callApi($resource, 'GET', false, array(), 'precheck_directory');
+		$result['httpcode'] = (int) (isset($response['status_code']) ? $response['status_code'] : 0);
+
+		if ($result['httpcode'] != 200) {
+			$result['message'] = isset($response['errorMessage']) ? $response['errorMessage'] : ('HTTP ' . $result['httpcode']);
+			return $result;
+		}
+
+		$data = array();
+		if (isset($response['response']['data']) && is_array($response['response']['data'])) {
+			$data = $response['response']['data'];
+		}
+		$result['entries'] = count($data);
+		foreach ($data as $entry) {
+			if (!empty($entry['is_active'])) {
+				$result['active']++;
+				if ($result['identifier'] === '' && !empty($entry['identifier'])) {
+					$result['identifier'] = $entry['identifier'];
+				}
+			}
+		}
+
+		if ($result['entries'] == 0) {
+			// Recipient not present in the directory at all.
+			$result['status'] = 'absent';
+			$result['reachable'] = 0;
+		} elseif ($result['active'] == 0) {
+			// Present but no active routing line (reason NON_TRANSMISE): still cannot receive.
+			$result['status'] = 'inactive';
+			$result['reachable'] = 0;
+		} else {
+			$result['status'] = 'routable';
+			$result['reachable'] = 1;
+		}
+
+		return $result;
 	}
 
 	/**

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -71,6 +71,8 @@ class SuperPDPProvider extends AbstractPDPProvider
 			'prod_api_url'  => 'https://api.superpdp.tech/afnor-flow/v1/',
 			'test_api_url'  => 'https://api.superpdp.tech/afnor-flow/v1/',
 			'ap_api_url' 	=> 'https://api.superpdp.tech/v1.beta/',
+			'prod_afnor_directory_url' => 'https://api.superpdp.tech/afnor-directory/',
+			'test_afnor_directory_url' => 'https://api.superpdp.tech/afnor-directory/',
 			'client_id'     => getDolGlobalString('EINVOICING_SUPERPDP_CLIENT_ID'.(getDolGlobalInt('EINVOICING_LIVE') ? '_PROD' : '')),
 			'client_secret' => getDolGlobalString('EINVOICING_SUPERPDP_CLIENT_SECRET'.(getDolGlobalInt('EINVOICING_LIVE') ? '_PROD' : '')),
 			'dol_prefix'    => getDolGlobalString('EINVOICING_PDP') == 'SUPERPDPViaPartner' ? 'EINVOICING_SUPERPDPVIAPARTNER' : 'EINVOICING_SUPERPDP',
@@ -1107,6 +1109,11 @@ class SuperPDPProvider extends AbstractPDPProvider
 			// validation_reports and the French directory lookup both live on the AP API base (v1.beta).
 			$url = $this->getApiUrl('ap_api') . $resource;
 		}
+		if (strpos($resource, 'afnor-directory/') === 0) {
+			// Standardized AFNOR Directory Service (XP Z12-013) lives on its own base. The 'afnor-directory/'
+			// prefix is only a routing marker and is stripped before appending the real resource path.
+			$url = $this->getApiUrl('afnor_directory') . substr($resource, strlen('afnor-directory/'));
+		}
 
 		$httpheader = array();
 		if (!isset($extraHeaders['Content-Type'])) {
@@ -1183,13 +1190,34 @@ class SuperPDPProvider extends AbstractPDPProvider
 	}
 
 	/**
-	 * Check whether a recipient (SIREN) has an active reception address in the French directory
-	 * of Approved Platforms, using the SuperPDP directory endpoint (GET french_directory/entries).
+	 * Check whether a recipient (SIREN) is routable, preferring the standardized AFNOR Directory
+	 * Service (XP Z12-013) handled by the parent, and falling back to the SuperPDP specific
+	 * french_directory endpoint only when the standardized lookup is not available.
 	 *
 	 * @param 	string 	$idprof1 	Recipient SIREN (idprof1)
 	 * @return 	array{status:string,reachable:int,entries:int,active:int,identifier:string,message:string,httpcode:int}
 	 */
 	public function checkRecipientDirectory($idprof1)
+	{
+		// Standardized AFNOR directory check first (works for any conformant Approved Platform).
+		$result = parent::checkRecipientDirectory($idprof1);
+		if (in_array($result['status'], array('routable', 'inactive', 'absent'), true)) {
+			return $result;
+		}
+
+		// Standardized lookup unavailable or errored: fall back to the SuperPDP specific endpoint.
+		return $this->checkRecipientDirectoryLegacy($idprof1);
+	}
+
+	/**
+	 * Legacy fallback: check the recipient reception address through the SuperPDP specific directory
+	 * endpoint (GET french_directory/entries on the v1.beta base). Kept for platforms or environments
+	 * where the standardized AFNOR Directory Service is not reachable.
+	 *
+	 * @param 	string 	$idprof1 	Recipient SIREN (idprof1)
+	 * @return 	array{status:string,reachable:int,entries:int,active:int,identifier:string,message:string,httpcode:int}
+	 */
+	private function checkRecipientDirectoryLegacy($idprof1)
 	{
 		$result = array('status' => 'error', 'reachable' => -1, 'entries' => 0, 'active' => 0, 'identifier' => '', 'message' => '', 'httpcode' => 0);
 

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -405,3 +405,16 @@ EINVOICING_ALLOW_REGEN_TRANSMITTED=Allow regenerating the e-invoice of a transmi
 EINVOICING_ALLOW_REGEN_TRANSMITTED_HELP=Off by default. Dev/inspection only: keeps the "Regenerate e-invoice" button and action available on a transmitted invoice so you can rebuild the CII/Factur-X and inspect the XML. Re-sending stays locked.
 EINVOICING_TRANSMITTED_NOT_FOR_PROD=Warning: must not be used in production, breaks the AFNOR/PA/PDP contracts
 EInvoiceTransmittedModifyDisabled=This invoice has been transmitted to the Access Point and can no longer be modified. Issue a credit note or a corrective invoice to amend it.
+# Recipient directory pre-check (annuaire des Plateformes Agreees)
+EINVOICING_PRECHECK_DIRECTORY=Check recipient reachability in the directory
+EINVOICING_PRECHECK_DIRECTORY_HELP=On by default. On the invoice card, checks that the recipient (its SIREN) has an active reception address in the Approved Platforms directory. A recipient absent from the directory, or present but without an active routing line, cannot receive electronic invoices (sending would be rejected with a routing error). This is a read-only lookup and never blocks. Note: the sandbox directory is incomplete, so results are only indicative in test mode.
+EInvoicingDirectoryCheck=Recipient reachability (directory)
+EInvoicingDirectoryCheckHelp=Whether the recipient (its SIREN) has an active reception address in the Approved Platforms directory (annuaire). A recipient that is absent, or present with no active routing line, cannot receive electronic invoices and sending would be rejected with a routing error.
+EInvoicingDirectoryCheckButton=Check directory
+EInvoicingDirectoryChecking=Checking the directory...
+EInvoicingDirectoryRoutable=Reachable: an active reception address was found in the directory
+EInvoicingDirectoryAbsent=Not reachable: recipient (SIREN %s) is absent from the Approved Platforms directory
+EInvoicingDirectoryInactive=Not reachable: recipient (SIREN %s) is in the directory but has no active routing line
+EInvoicingDirectoryUnsupported=Directory lookup is not available for the current platform
+EInvoicingDirectoryError=Directory check failed: %s
+EInvoicingDirectoryNoSiren=No SIREN set on the recipient third party: cannot check the directory


### PR DESCRIPTION
## What

Add a recipient reachability check against the Approved Platforms directory (annuaire des Plateformes Agreees), surfaced on the customer invoice card before sending.

## Why

An invoice sent to a recipient that is absent from the directory, or present but without an active routing line, is rejected by the platform with a routing error (lifecycle fr:213). Today the module has no way to know this before transmitting: the user only discovers the problem after the rejection, when the invoice is already in a transmitted state. Surfacing the recipient reachability on the card, before sending, turns an opaque post-send rejection into a clear pre-send indication.

## What it does

- New provider method `AbstractPDPProvider::checkRecipientDirectory($idprof1)`. The base implementation returns status `unsupported` so any provider that does not expose a directory lookup keeps working unchanged (no abstract method added, nothing to implement for Esalink or future providers).
- `SuperPDPProvider::checkRecipientDirectory()` queries the SuperPDP directory endpoint `GET french_directory/entries?number=SIREN` (routed to the existing `ap_api` base, the same base already used for `validation_reports`). It classifies the recipient as:
  - `routable`: at least one entry with an active reception address (the electronic address identifier is returned)
  - `inactive`: present in the directory but no active routing line (reason NON_TRANSMISE)
  - `absent`: not present in the directory
  - `error` / `unsupported`: lookup failed or not available
- On the customer invoice card, a new "Recipient reachability (directory)" row shows the result. It runs on demand (a "Check directory" link) and auto-runs once in the pre-send window (invoice validated, not yet transmitted). The lookup is done through an AJAX endpoint `ajax/checkdirectory.php`, so the card render itself never makes a network call.
- New option `EINVOICING_PRECHECK_DIRECTORY` (on by default). The feature is read-only and never blocks generation or sending; it only informs.

## Notes

- The sandbox directory is incomplete, so results are only indicative in test mode; the check is accurate against the production directory.
- This PR intentionally only surfaces the information. A follow-up can add an optional hard block at send time (in live mode only) on top of this method, kept separate to stay reviewable.
- No version bump included, to avoid conflicts with the other open einvoicing PRs; happy to add one if preferred.

## Testing

Validated on a live SuperPDP sandbox through the module's own token and HTTP helper:

```
checkRecipientDirectory('552081317')  => routable  (id 0225:552081317_ACHAT_TESTPILOTE, 2 active entries)
checkRecipientDirectory('000000001')  => absent
checkRecipientDirectory('')           => error (no SIREN)
checkRecipientDirectory('FR 552 081 317') => routable (digits extracted from noisy input)
Esalink provider                      => unsupported (default, non breaking)
```

- Full data path on a real invoice (recipient SIREN 552081317): the card AJAX returns "Reachable: an active reception address was found in the directory (0225:552081317_ACHAT_TESTPILOTE)".
- Invoice card renders the new row, the check button and the AJAX wiring with no error.
- `php -l` clean on all changed PHP files; the AJAX endpoint bootstraps correctly under the web server.

## Files

- `einvoicing/class/providers/AbstractPDPProvider.class.php`: default `checkRecipientDirectory()` (unsupported)
- `einvoicing/class/providers/SuperPDPProvider.class.php`: SuperPDP implementation + route `french_directory` to the ap_api base
- `einvoicing/ajax/checkdirectory.php`: new AJAX endpoint
- `einvoicing/class/einvoicing.class.php`: recipient reachability row on the invoice card
- `einvoicing/admin/setup_options.php`: `EINVOICING_PRECHECK_DIRECTORY` toggle
- `einvoicing/langs/en_US/einvoicing.lang`: strings
