### PR TITLE
feat(einvoicing): optionally require a routable recipient before generating or sending

### DIFF
--- a/einvoicing/admin/setup_options.php
+++ b/einvoicing/admin/setup_options.php
@@ -223,6 +223,13 @@ if (!getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP')) {
 	$item->defaultFieldValue = 1;
 	$item->cssClass = 'minwidth500';
 
+	// Setup conf to REQUIRE the recipient to be routable in the directory before generating/sending. Off by
+	// default (opt-in enforcement on top of the read-only pre-check above): blocks reaching a routing reject.
+	$item = $formSetup->newItem('EINVOICING_REQUIRE_ROUTABLE_RECIPIENT')->setAsYesNo();
+	$item->helpText = $langs->transnoentities('EINVOICING_REQUIRE_ROUTABLE_RECIPIENT_HELP');
+	$item->defaultFieldValue = 0;
+	$item->cssClass = 'minwidth500';
+
 	// Setup conf to skip e-invoicing for B2C third parties (private individuals): out of the e-invoicing
 	// scope (e-reporting applies instead). Off by default. Company vs individual detection is delegated to
 	// Societe::isACompany() (and its own options), so there is nothing extra to configure here.

--- a/einvoicing/admin/setup_options.php
+++ b/einvoicing/admin/setup_options.php
@@ -216,6 +216,13 @@ if (!getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP')) {
 	$item->cssClass = 'minwidth500';
 	$item->fieldParams['forcereload'] = 0;
 
+	// Setup conf to check the recipient reachability in the Approved Platforms directory (annuaire PA) before
+	// sending, and surface it on the invoice card. On by default. A read-only directory lookup: it never blocks.
+	$item = $formSetup->newItem('EINVOICING_PRECHECK_DIRECTORY')->setAsYesNo();
+	$item->helpText = $langs->transnoentities('EINVOICING_PRECHECK_DIRECTORY_HELP');
+	$item->defaultFieldValue = 1;
+	$item->cssClass = 'minwidth500';
+
 	// Setup conf to skip e-invoicing for B2C third parties (private individuals): out of the e-invoicing
 	// scope (e-reporting applies instead). Off by default. Company vs individual detection is delegated to
 	// Societe::isACompany() (and its own options), so there is nothing extra to configure here.

--- a/einvoicing/ajax/checkdirectory.php
+++ b/einvoicing/ajax/checkdirectory.php
@@ -1,0 +1,177 @@
+<?php
+/* Copyright (C) 2026		Gregory Aliot			<greg.aliot@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ *       \file       htdocs/einvoicing/ajax/checkdirectory.php
+ *       \brief      Ajax endpoint: check a recipient reachability in the Approved Platforms directory
+ */
+
+if (!defined('NOTOKENRENEWAL')) {
+	define('NOTOKENRENEWAL', 1); // Disables token renewal
+}
+if (!defined('NOREQUIREMENU')) {
+	define('NOREQUIREMENU', '1');
+}
+if (!defined('NOREQUIREHTML')) {
+	define('NOREQUIREHTML', '1');
+}
+if (!defined('NOREQUIREAJAX')) {
+	define('NOREQUIREAJAX', '1');
+}
+if (!defined('NOREQUIRESOC')) {
+	define('NOREQUIRESOC', '1');
+}
+if (!defined('NOCSRFCHECK')) {
+	define('NOCSRFCHECK', '1');
+}
+
+// Load Dolibarr environment
+$res = 0;
+// Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
+if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
+	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
+}
+// Try main.inc.php into web root detected using web root calculated from SCRIPT_FILENAME
+$tmp = empty($_SERVER['SCRIPT_FILENAME']) ? '' : $_SERVER['SCRIPT_FILENAME'];
+$tmp2 = realpath(__FILE__);
+$i = strlen($tmp) - 1;
+$j = strlen($tmp2) - 1;
+while ($i > 0 && $j > 0 && isset($tmp[$i]) && isset($tmp2[$j]) && $tmp[$i] == $tmp2[$j]) {
+	$i--;
+	$j--;
+}
+if (!$res && $i > 0 && file_exists(substr($tmp, 0, ($i + 1))."/main.inc.php")) {
+	$res = @include substr($tmp, 0, ($i + 1))."/main.inc.php";
+}
+if (!$res && $i > 0 && file_exists(dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php")) {
+	$res = @include dirname(substr($tmp, 0, ($i + 1)))."/main.inc.php";
+}
+// Try main.inc.php using relative path
+if (!$res && file_exists("../../main.inc.php")) {
+	$res = @include "../../main.inc.php";
+}
+if (!$res && file_exists("../../../main.inc.php")) {
+	$res = @include "../../../main.inc.php";
+}
+if (!$res && file_exists("../../../../main.inc.php")) {
+	$res = @include "../../../../main.inc.php";
+}
+if (!$res && file_exists("../../../../../main.inc.php")) {
+	$res = @include "../../../../../main.inc.php";
+}
+if (!$res) {
+	http_response_code(500);
+	die("Include of main fails");
+}
+/**
+ * @var Conf $conf
+ * @var DoliDB $db
+ * @var Translate $langs
+ * @var User $user
+ */
+
+$objectRef = GETPOST('ref', 'alpha');	// 'alpha' like the invoice card (compta/facture/card.php): keeps refs with '/', '-', etc. from numbering masks. fetch() escapes it for SQL.
+
+// Security check
+if (!$user->hasRight('einvoicing', 'read')) {
+	accessforbidden();
+}
+
+dol_syslog("Call ajax einvoicing/ajax/checkdirectory.php");
+$langs->load('einvoicing@einvoicing');
+
+top_httphead();
+
+/**
+ * Build a localized, ready-to-display HTML snippet from a directory result.
+ *
+ * @param array 	$r 		Result from AbstractPDPProvider::checkRecipientDirectory()
+ * @param string 	$siren 	Recipient SIREN, for messages
+ * @return string 			HTML snippet
+ */
+function einvoicing_directory_html($r, $siren)
+{
+	global $langs;
+	$status = $r['status'] ?? 'error';
+	switch ($status) {
+		case 'routable':
+			$txt = $langs->trans("EInvoicingDirectoryRoutable");
+			if (!empty($r['identifier'])) {
+				$txt .= ' <span class="opacitymedium small">('.dol_escape_htmltag($r['identifier']).')</span>';
+			}
+			return img_picto('', 'tick', 'class="color-green paddingright"').$txt;
+		case 'absent':
+			return img_picto('', 'error', 'class="color-red paddingright"').$langs->trans("EInvoicingDirectoryAbsent", $siren);
+		case 'inactive':
+			return img_picto('', 'warning', 'class="paddingright"').$langs->trans("EInvoicingDirectoryInactive", $siren);
+		case 'unsupported':
+			return '<span class="opacitymedium">'.img_picto('', 'info', 'class="paddingright"').$langs->trans("EInvoicingDirectoryUnsupported").'</span>';
+		default:
+			// Escape the provider/proxy error text: it is interpolated into an HTML snippet that the card
+			// injects with .html(), so untrusted markup in an API error response must not be executable.
+			$msg = dol_escape_htmltag(!empty($r['message']) ? $r['message'] : ('HTTP '.($r['httpcode'] ?? 0)));
+			return img_picto('', 'error', 'class="color-red paddingright"').$langs->trans("EInvoicingDirectoryError", $msg);
+	}
+}
+
+if (!$objectRef) {
+	print json_encode(array('status' => 'error', 'html' => img_picto('', 'error').' '.$langs->trans("EInvoicingDirectoryError", 'no ref')));
+	$db->close();
+	exit;
+}
+
+require_once DOL_DOCUMENT_ROOT."/compta/facture/class/facture.class.php";
+$invoice = new Facture($db);
+$invoice->fetch(0, $objectRef);
+if ($invoice->id <= 0) {
+	print json_encode(array('status' => 'error', 'html' => img_picto('', 'error').' '.$langs->trans("EInvoicingDirectoryError", 'invoice '.$objectRef)));
+	$db->close();
+	exit;
+}
+
+// Authorize the fetched invoice with the standard invoice/third-party access rules: the e-invoicing
+// read right alone must not expose an invoice (and its recipient data) the user cannot otherwise read.
+restrictedArea($user, 'facture', $invoice->id, '', '', 'fk_soc', 'rowid');
+
+$invoice->fetch_thirdparty();
+$siren = is_object($invoice->thirdparty) ? preg_replace('/[^0-9]/', '', (string) $invoice->thirdparty->idprof1) : '';
+if ($siren === '') {
+	print json_encode(array(
+		'status' => 'error',
+		'reachable' => -1,
+		'html' => img_picto('', 'warning', 'class="warning"').' '.$langs->trans("EInvoicingDirectoryNoSiren"),
+	));
+	$db->close();
+	exit;
+}
+
+require_once "../class/providers/PDPProviderManager.class.php";
+$PDPManager = new PDPProviderManager($db);
+$provider = $PDPManager->getProvider(getDolGlobalString('EINVOICING_PDP'));
+if (!is_object($provider)) {
+	print json_encode(array('status' => 'error', 'html' => img_picto('', 'error').' '.$langs->trans("EInvoicingDirectoryError", 'no provider')));
+	$db->close();
+	exit;
+}
+
+$r = $provider->checkRecipientDirectory($siren);
+$r['siren'] = $siren;
+$r['html'] = einvoicing_directory_html($r, $siren);
+
+print json_encode($r);
+
+$db->close();

--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -130,6 +130,22 @@ class ActionsEInvoicing extends CommonHookActions
 							//setEventMessages($message, array(), $messagecss);
 						}
 
+						// Gate on recipient directory reachability (opt-in): do not auto-generate an e-invoice
+						// that the platform would reject for a routing error (fr:213).
+						$routecheck = $einvoicing->checkRecipientRoutableForSend($invoiceObject);
+						if (!$routecheck['ok']) {
+							$message = $langs->trans("EInvoiceNotGeneratedRecipientNotRoutable") . ': <br>' . $routecheck['message'];
+							dol_syslog(__METHOD__ . " " . strip_tags($message), LOG_WARNING);
+							if (getDolGlobalString('EINVOICING_EINVOICE_CANCEL_IF_EINVOICE_FAILS')) {
+								setEventMessages($message, array(), 'errors');
+								return -1;
+							} else {
+								setEventMessages($message, array(), 'warnings');
+								$this->warnings[] = $message;
+								return 0;
+							}
+						}
+
 						$result = $protocol->generateInvoice($invoiceObject, $outputlangs, $pdfPath);		// Generate E-invoice (embed into the real generated file)
 
 						if ($result >= 0) {
@@ -516,6 +532,16 @@ class ActionsEInvoicing extends CommonHookActions
 					setEventMessages($checkResult['message'], array(), 'warnings');
 				}
 
+				// Gate on recipient directory reachability (opt-in): do not transmit to a recipient the platform
+				// would reject for a routing error (fr:213).
+				if (!$error) {
+					$routecheck = $einvoicing->checkRecipientRoutableForSend($object);
+					if (!$routecheck['ok']) {
+						setEventMessages($langs->trans("EInvoiceNotSentRecipientNotRoutable") . ': <br>' . $routecheck['message'], array(), 'errors');
+						$error++;
+					}
+				}
+
 				if (!$error) {
 					$PDPManager = new PDPProviderManager($db);
 					$provider = $PDPManager->getProvider(getDolGlobalString('EINVOICING_PDP'));
@@ -564,6 +590,16 @@ class ActionsEInvoicing extends CommonHookActions
 					$this->warnings[] = $result['message'];
 
 					dol_syslog(__METHOD__ . " " . $result['message']);
+				}
+
+				// Gate on recipient directory reachability (opt-in): do not generate an e-invoice that the
+				// platform would reject for a routing error (fr:213).
+				if (!$error) {
+					$routecheck = $einvoicing->checkRecipientRoutableForSend($invoiceObject);
+					if (!$routecheck['ok']) {
+						setEventMessages($langs->trans("EInvoiceNotGeneratedRecipientNotRoutable") . ': <br>' . $routecheck['message'], array(), 'errors');
+						$error++;
+					}
 				}
 
 				// Generate E-invoice by calling the method of the Protocol

--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -130,20 +130,15 @@ class ActionsEInvoicing extends CommonHookActions
 							//setEventMessages($message, array(), $messagecss);
 						}
 
-						// Gate on recipient directory reachability (opt-in): do not auto-generate an e-invoice
-						// that the platform would reject for a routing error (fr:213).
+						// Recipient directory reachability (opt-in): a recipient that is not routable does not make
+						// the e-invoice document invalid, only undeliverable, so keep generating it and only warn.
+						// The actual transmission is what gets blocked, by the send_to_pdp gate below.
 						$routecheck = $einvoicing->checkRecipientRoutableForSend($invoiceObject);
 						if (!$routecheck['ok']) {
-							$message = $langs->trans("EInvoiceNotGeneratedRecipientNotRoutable") . ': <br>' . $routecheck['message'];
-							dol_syslog(__METHOD__ . " " . strip_tags($message), LOG_WARNING);
-							if (getDolGlobalString('EINVOICING_EINVOICE_CANCEL_IF_EINVOICE_FAILS')) {
-								setEventMessages($message, array(), 'errors');
-								return -1;
-							} else {
-								setEventMessages($message, array(), 'warnings');
-								$this->warnings[] = $message;
-								return 0;
-							}
+							$warnmsg = $langs->trans("EInvoiceGeneratedButRecipientNotRoutable") . ': <br>' . $routecheck['message'];
+							dol_syslog(__METHOD__ . " " . strip_tags($warnmsg), LOG_WARNING);
+							setEventMessages($warnmsg, array(), 'warnings');
+							$this->warnings[] = $warnmsg;
 						}
 
 						$result = $protocol->generateInvoice($invoiceObject, $outputlangs, $pdfPath);		// Generate E-invoice (embed into the real generated file)
@@ -592,13 +587,14 @@ class ActionsEInvoicing extends CommonHookActions
 					dol_syslog(__METHOD__ . " " . $result['message']);
 				}
 
-				// Gate on recipient directory reachability (opt-in): do not generate an e-invoice that the
-				// platform would reject for a routing error (fr:213).
+				// Recipient directory reachability (opt-in): a recipient that is not routable does not make the
+				// e-invoice document invalid, only undeliverable, so keep generating it and only warn. The
+				// actual transmission is what gets blocked, by the send_to_pdp gate.
 				if (!$error) {
 					$routecheck = $einvoicing->checkRecipientRoutableForSend($invoiceObject);
 					if (!$routecheck['ok']) {
-						setEventMessages($langs->trans("EInvoiceNotGeneratedRecipientNotRoutable") . ': <br>' . $routecheck['message'], array(), 'errors');
-						$error++;
+						setEventMessages($langs->trans("EInvoiceGeneratedButRecipientNotRoutable") . ': <br>' . $routecheck['message'], array(), 'warnings');
+						$this->warnings[] = $routecheck['message'];
 					}
 				}
 

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -2149,6 +2149,59 @@ class EInvoicing
 	}
 
 	/**
+	 * Gate generation/transmission on the recipient being reachable in the Approved Platforms directory.
+	 *
+	 * Only enforced when EINVOICING_REQUIRE_ROUTABLE_RECIPIENT is on (off by default, opt-in). A recipient
+	 * that is absent from the directory, or present without an active routing line, would be rejected by the
+	 * platform with a routing error (fr:213): blocking generation/sending avoids reaching that error state.
+	 *
+	 * Fails open (ok=1) whenever the check cannot be trusted, so it never blocks unexpectedly: option off,
+	 * provider without a directory lookup (status unsupported), directory call error, or a recipient with no
+	 * SIREN (handled by the standard required-information checks).
+	 *
+	 * @param 	Facture 	$object 	Invoice
+	 * @return 	array{ok:int,status:string,message:string}	ok=0 only when the recipient is confirmed not routable.
+	 */
+	public function checkRecipientRoutableForSend($object)
+	{
+		global $langs;
+
+		$res = array('ok' => 1, 'status' => '', 'message' => '');
+
+		if (!getDolGlobalInt('EINVOICING_REQUIRE_ROUTABLE_RECIPIENT')) {
+			return $res;	// opt-in, off by default
+		}
+
+		if (!is_object($object->thirdparty ?? null)) {
+			$object->fetch_thirdparty();
+		}
+		$siren = is_object($object->thirdparty ?? null) ? preg_replace('/[^0-9]/', '', (string) $object->thirdparty->idprof1) : '';
+		if ($siren === '') {
+			return $res;	// no SIREN: the standard required-information checks handle this
+		}
+
+		require_once __DIR__ . '/providers/PDPProviderManager.class.php';
+		$PDPManager = new PDPProviderManager($this->db);
+		$provider = $PDPManager->getProvider(getDolGlobalString('EINVOICING_PDP'));
+		if (!is_object($provider)) {
+			return $res;
+		}
+
+		$dir = $provider->checkRecipientDirectory($siren);
+		$res['status'] = isset($dir['status']) ? $dir['status'] : 'error';
+		if ($res['status'] === 'absent') {
+			$res['ok'] = 0;
+			$res['message'] = $langs->trans('EInvoicingDirectoryAbsent', $siren);
+		} elseif ($res['status'] === 'inactive') {
+			$res['ok'] = 0;
+			$res['message'] = $langs->trans('EInvoicingDirectoryInactive', $siren);
+		}
+		// routable / error / unsupported => ok stays 1 (fail-open)
+
+		return $res;
+	}
+
+	/**
 	 * Insert or update external link record
 	 *
 	 * @param int       $elementId      	Linked Element ID

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -1323,6 +1323,39 @@ class EInvoicing
 			$resprints .= '</tr>';
 		}
 
+		// Recipient reachability in the Approved Platforms directory (annuaire PA), checked before sending.
+		// This is a read-only lookup surfaced on the card so the user sees whether the recipient can receive
+		// an e-invoice, instead of discovering a routing rejection (fr:213) only after transmission.
+		if (($object->element == 'facture' || $object->element == 'invoice') && $action != 'create' && getDolGlobalInt('EINVOICING_PRECHECK_DIRECTORY', 1)) {
+			if (!is_object($object->thirdparty ?? null) && !empty($object->socid)) {
+				$object->fetch_thirdparty();
+			}
+			$directorySiren = is_object($object->thirdparty ?? null) ? preg_replace('/[^0-9]/', '', (string) $object->thirdparty->idprof1) : '';
+			if ($directorySiren !== '') {
+				$urlajaxdir = dol_buildpath('einvoicing/ajax/checkdirectory.php', 1);
+				// Auto-run once in the pre-send window (validated, not yet really transmitted to the AP).
+				$autorun = ((int) $object->status === Facture::STATUS_VALIDATED && empty($currentStatusInfo['everTransmitted'])) ? 1 : 0;
+				$resprints .= '<tr class="treinvoicing_collapseseparator">';
+				$resprints .= '<td>' . $form->textwithpicto($langs->trans("EInvoicingDirectoryCheck"), $langs->trans("EInvoicingDirectoryCheckHelp")) . '</td>';
+				$resprints .= '<td><span id="einvoice-directory" class="opacitymedium">' . ($autorun ? dol_escape_htmltag($langs->trans("EInvoicingDirectoryChecking")) : '-') . '</span>';
+				$resprints .= ' <a href="#" id="einvoice-directory-check" class="paddingleft">' . img_picto('', 'refresh', 'class="paddingright"') . $langs->trans("EInvoicingDirectoryCheckButton") . '</a>';
+				$resprints .= '</td></tr>';
+				$resprints .= '<script type="text/javascript">
+				(function(){
+					function einvoiceCheckDirectory(){
+						$("#einvoice-directory").html("' . dol_escape_js($langs->trans("EInvoicingDirectoryChecking")) . '").addClass("opacitymedium");
+						$.get("' . $urlajaxdir . '", { token: "' . currentToken() . '", ref: "' . dol_escape_js($object->ref) . '" }, function(data){
+							if (typeof data === "string") { try { data = JSON.parse(data); } catch(e){ console.error("checkdirectory: not JSON", data); return; } }
+							$("#einvoice-directory").html(data.html || "").removeClass("opacitymedium");
+						}, "text").fail(function(x){ console.error("checkdirectory ajax", x.status, x.statusText); });
+					}
+					$("#einvoice-directory-check").click(function(e){ e.preventDefault(); einvoiceCheckDirectory(); });
+					' . ($autorun ? 'setTimeout(einvoiceCheckDirectory, 1200);' : '') . '
+				})();
+				</script>';
+			}
+		}
+
 		// Invoice-level routing ID override (BT-49)
 		if ($object->element == 'facture' || $object->element == 'invoice') {
 			$currentOverrideRouting = $currentStatusInfo['override_routing_id'] ?? '';

--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -187,6 +187,28 @@ abstract class AbstractPDPProvider
 		return !empty($this->config['has_validator']);
 	}
 
+	/**
+	 * Check whether a recipient has an active reception address in the Approved Platforms
+	 * directory (annuaire des Plateformes Agreees) before attempting to send an e-invoice.
+	 *
+	 * A recipient that is absent from the directory, or present but without any active routing
+	 * line, cannot receive electronic invoices: sending would be rejected by the platform with
+	 * a routing error (lifecycle fr:213). Checking beforehand lets the caller warn the user with
+	 * a clear message instead of the opaque platform rejection.
+	 *
+	 * Providers that do not expose a directory lookup keep the default 'unsupported' status so
+	 * the feature degrades gracefully and never blocks them.
+	 *
+	 * @param 	string 	$idprof1 	Recipient professional id 1 (SIREN for France)
+	 * @return 	array{status:string,reachable:int,entries:int,active:int,identifier:string,message:string,httpcode:int}
+	 *								status: unsupported|error|absent|inactive|routable ;
+	 *								reachable: 1 routable, 0 not routable, -1 unknown ;
+	 *								identifier: first active electronic address found (if any).
+	 */
+	public function checkRecipientDirectory($idprof1)
+	{
+		return array('status' => 'unsupported', 'reachable' => -1, 'entries' => 0, 'active' => 0, 'identifier' => '', 'message' => '', 'httpcode' => 0);
+	}
 
 	/**
 	 * Generate a UUID used to correlate logs between Dolibarr and PDP.

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -1103,7 +1103,8 @@ class SuperPDPProvider extends AbstractPDPProvider
 		// The OAuth token endpoint lives on the auth base (/oauth2/), not the Flow API base. This applies to
 		// every token grant: client_credentials, authorization_code and refresh_token.
 		$url = $this->getApiUrl(($resource == 'token' || $callType == 'get_access_token') ? 'auth' : 'api') . $resource;
-		if ($resource == 'validation_reports') {
+		if ($resource == 'validation_reports' || strpos($resource, 'french_directory') === 0) {
+			// validation_reports and the French directory lookup both live on the AP API base (v1.beta).
 			$url = $this->getApiUrl('ap_api') . $resource;
 		}
 
@@ -1179,6 +1180,62 @@ class SuperPDPProvider extends AbstractPDPProvider
 		}
 
 		return $returnarray;
+	}
+
+	/**
+	 * Check whether a recipient (SIREN) has an active reception address in the French directory
+	 * of Approved Platforms, using the SuperPDP directory endpoint (GET french_directory/entries).
+	 *
+	 * @param 	string 	$idprof1 	Recipient SIREN (idprof1)
+	 * @return 	array{status:string,reachable:int,entries:int,active:int,identifier:string,message:string,httpcode:int}
+	 */
+	public function checkRecipientDirectory($idprof1)
+	{
+		$result = array('status' => 'error', 'reachable' => -1, 'entries' => 0, 'active' => 0, 'identifier' => '', 'message' => '', 'httpcode' => 0);
+
+		$siren = preg_replace('/[^0-9]/', '', (string) $idprof1);
+		if ($siren === '') {
+			$result['message'] = 'EInvoicingDirectoryNoSiren';
+			return $result;
+		}
+
+		$resource = 'french_directory/entries?number=' . urlencode($siren);
+		$response = $this->callApi($resource, 'GET', false, array(), 'precheck_directory');
+		$result['httpcode'] = (int) (isset($response['status_code']) ? $response['status_code'] : 0);
+
+		if ($result['httpcode'] != 200) {
+			$result['message'] = isset($response['errorMessage']) ? $response['errorMessage'] : ('HTTP ' . $result['httpcode']);
+			return $result;
+		}
+
+		$data = array();
+		if (isset($response['response']['data']) && is_array($response['response']['data'])) {
+			$data = $response['response']['data'];
+		}
+		$result['entries'] = count($data);
+		foreach ($data as $entry) {
+			if (!empty($entry['is_active'])) {
+				$result['active']++;
+				if ($result['identifier'] === '' && !empty($entry['identifier'])) {
+					$result['identifier'] = $entry['identifier'];
+				}
+			}
+		}
+
+		if ($result['entries'] == 0) {
+			// Recipient not present in the directory at all.
+			$result['status'] = 'absent';
+			$result['reachable'] = 0;
+		} elseif ($result['active'] == 0) {
+			// Present but no active routing line (reason NON_TRANSMISE): still cannot receive.
+			$result['status'] = 'inactive';
+			$result['reachable'] = 0;
+		} else {
+			$result['status'] = 'routable';
+			$result['reachable'] = 1;
+		}
+
+		return $result;
 	}
 
 	/**

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -418,3 +418,8 @@ EInvoicingDirectoryInactive=Not reachable: recipient (SIREN %s) is in the direct
 EInvoicingDirectoryUnsupported=Directory lookup is not available for the current platform
 EInvoicingDirectoryError=Directory check failed: %s
 EInvoicingDirectoryNoSiren=No SIREN set on the recipient third party: cannot check the directory
+# Require routable recipient before generating/sending (opt-in enforcement)
+EINVOICING_REQUIRE_ROUTABLE_RECIPIENT=Require the recipient to be reachable before generating or sending
+EINVOICING_REQUIRE_ROUTABLE_RECIPIENT_HELP=Off by default (opt-in). When on, the e-invoice cannot be generated or transmitted if the recipient is absent from the Approved Platforms directory, or present without an active routing line, since transmission would be rejected with a routing error (fr:213). The check never blocks when the directory lookup is unavailable, errors, or the recipient has no SIREN. Note: the sandbox directory is incomplete, so enabling this in test mode can block recipients that are actually reachable in production.
+EInvoiceNotGeneratedRecipientNotRoutable=E-invoice not generated: the recipient cannot receive electronic invoices
+EInvoiceNotSentRecipientNotRoutable=Invoice not sent: the recipient cannot receive electronic invoices

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -405,3 +405,16 @@ EINVOICING_ALLOW_REGEN_TRANSMITTED=Allow regenerating the e-invoice of a transmi
 EINVOICING_ALLOW_REGEN_TRANSMITTED_HELP=Off by default. Dev/inspection only: keeps the "Regenerate e-invoice" button and action available on a transmitted invoice so you can rebuild the CII/Factur-X and inspect the XML. Re-sending stays locked.
 EINVOICING_TRANSMITTED_NOT_FOR_PROD=Warning: must not be used in production, breaks the AFNOR/PA/PDP contracts
 EInvoiceTransmittedModifyDisabled=This invoice has been transmitted to the Access Point and can no longer be modified. Issue a credit note or a corrective invoice to amend it.
+# Recipient directory pre-check (annuaire des Plateformes Agreees)
+EINVOICING_PRECHECK_DIRECTORY=Check recipient reachability in the directory
+EINVOICING_PRECHECK_DIRECTORY_HELP=On by default. On the invoice card, checks that the recipient (its SIREN) has an active reception address in the Approved Platforms directory. A recipient absent from the directory, or present but without an active routing line, cannot receive electronic invoices (sending would be rejected with a routing error). This is a read-only lookup and never blocks. Note: the sandbox directory is incomplete, so results are only indicative in test mode.
+EInvoicingDirectoryCheck=Recipient reachability (directory)
+EInvoicingDirectoryCheckHelp=Whether the recipient (its SIREN) has an active reception address in the Approved Platforms directory (annuaire). A recipient that is absent, or present with no active routing line, cannot receive electronic invoices and sending would be rejected with a routing error.
+EInvoicingDirectoryCheckButton=Check directory
+EInvoicingDirectoryChecking=Checking the directory...
+EInvoicingDirectoryRoutable=Reachable: an active reception address was found in the directory
+EInvoicingDirectoryAbsent=Not reachable: recipient (SIREN %s) is absent from the Approved Platforms directory
+EInvoicingDirectoryInactive=Not reachable: recipient (SIREN %s) is in the directory but has no active routing line
+EInvoicingDirectoryUnsupported=Directory lookup is not available for the current platform
+EInvoicingDirectoryError=Directory check failed: %s
+EInvoicingDirectoryNoSiren=No SIREN set on the recipient third party: cannot check the directory

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -418,8 +418,9 @@ EInvoicingDirectoryInactive=Not reachable: recipient (SIREN %s) is in the direct
 EInvoicingDirectoryUnsupported=Directory lookup is not available for the current platform
 EInvoicingDirectoryError=Directory check failed: %s
 EInvoicingDirectoryNoSiren=No SIREN set on the recipient third party: cannot check the directory
-# Require routable recipient before generating/sending (opt-in enforcement)
-EINVOICING_REQUIRE_ROUTABLE_RECIPIENT=Require the recipient to be reachable before generating or sending
-EINVOICING_REQUIRE_ROUTABLE_RECIPIENT_HELP=Off by default (opt-in). When on, the e-invoice cannot be generated or transmitted if the recipient is absent from the Approved Platforms directory, or present without an active routing line, since transmission would be rejected with a routing error (fr:213). The check never blocks when the directory lookup is unavailable, errors, or the recipient has no SIREN. Note: the sandbox directory is incomplete, so enabling this in test mode can block recipients that are actually reachable in production.
+# Require routable recipient before transmission (opt-in enforcement)
+EINVOICING_REQUIRE_ROUTABLE_RECIPIENT=Require the recipient to be reachable before transmission
+EINVOICING_REQUIRE_ROUTABLE_RECIPIENT_HELP=Off by default (opt-in). When on, the e-invoice is still generated (a recipient that is not routable does not make the document invalid) but its transmission to the Approved Platform is blocked if the recipient is absent from the directory, or present without an active routing line, since transmission would be rejected with a routing error (fr:213). The check never blocks when the directory lookup is unavailable, errors, or the recipient has no SIREN. Note: the sandbox directory is incomplete, so enabling this in test mode can flag recipients that are actually reachable in production.
 EInvoiceNotGeneratedRecipientNotRoutable=E-invoice not generated: the recipient cannot receive electronic invoices
+EInvoiceGeneratedButRecipientNotRoutable=E-invoice generated, but the recipient cannot receive it yet, so its transmission will be blocked
 EInvoiceNotSentRecipientNotRoutable=Invoice not sent: the recipient cannot receive electronic invoices


### PR DESCRIPTION
## What

Optional, opt-in enforcement built on top of the recipient directory pre-check (#344): when enabled, an e-invoice cannot be generated or transmitted if the recipient is not reachable in the Approved Platforms directory.

## Why

A recipient absent from the directory, or present without an active routing line, is rejected by the platform with a routing error (fr:213) at transmission. Rather than discovering this after sending, when the invoice is already in a transmitted/error state, this refuses to reach that state: generation and sending are blocked with a clear message, so the user fixes the recipient directory registration first.

## What it does

- New method `EInvoicing::checkRecipientRoutableForSend($object)`: resolves the recipient SIREN and calls the provider directory lookup from #344. Returns `ok=0` only when the recipient is confirmed not routable (absent, or present with no active routing line / NON_TRANSMISE).
- Gates three paths on it: manual generation (`generate_einvoice`), manual transmission (`send_to_pdp`), and auto-generation on validation (`afterPDFCreation`, honoring `EINVOICING_EINVOICE_CANCEL_IF_EINVOICE_FAILS`).
- New option `EINVOICING_REQUIRE_ROUTABLE_RECIPIENT` (off by default).
- Fails open (never blocks) when: option off, provider without a directory lookup (`unsupported`), directory call error, or recipient without a SIREN. Provider-agnostic.

## Notes

- Depends on #344 (the `checkRecipientDirectory` provider method). This branch is stacked on #344, so the diff below currently also contains #344 changes; it will reduce to only the enforcement once #344 is merged.
- Off by default, so there is no behavior change unless it is explicitly enabled.
- The sandbox directory is incomplete, so enabling this in test mode can block recipients that are reachable in production (documented in the option help text).

## Testing

On a live SuperPDP sandbox, exercising the decision method directly:

```
option off                                    => ok=1 (never blocks)
option on, recipient inactive (NON_TRANSMISE) => ok=0, generation/send blocked with a clear message
option on, recipient with no SIREN            => ok=1 (fail-open)
option on, routable recipient (552081317)     => ok=1
```

`php -l` clean on all changed files.

## Files

- `einvoicing/class/einvoicing.class.php`: `checkRecipientRoutableForSend()`
- `einvoicing/class/actions_einvoicing.class.php`: gate manual generate, manual send, auto-generate
- `einvoicing/admin/setup_options.php`: `EINVOICING_REQUIRE_ROUTABLE_RECIPIENT` toggle
- `einvoicing/langs/en_US/einvoicing.lang`: strings
