### PR TITLE
fix(einvoicing): report fr:212 (paid) on any real payment, not only bank-charge/withholding closings

### DIFF
--- a/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
+++ b/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
@@ -231,9 +231,12 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 			// Check if the invoice is transmitted to EInvoicing and confirm we have received the payment if yes.
 
 			if (!getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP')) {		// If sync Dolibarr to AP is on
-				// Test on $close_code that are closing code to say we really accept the payment
-				if ($object->close_code == $object::CLOSECODE_BANKCHARGE ||
-					$object->close_code == $object::CLOSECODE_WITHHOLDINGTAX) {
+				// fr:212 (Encaissee) means the invoice was cashed in: report it whenever an actual payment was
+				// received. A normal full payment leaves close_code empty, so the previous test on close_code
+				// (BANKCHARGE/WITHHOLDINGTAX only) missed the common case. Keying on the received amount also
+				// avoids reporting "cashed in" for a write-off with no payment (abandon / bad debt), where
+				// BILL_PAYED still fires but nothing was received.
+				if ($object->getSommePaiement() > 0) {
 					// Test if invoice need EInvoicing
 					$einvoicing = new EInvoicing($this->db);
 


### PR DESCRIPTION
## What

Report the AFNOR lifecycle status fr:212 (Encaissee / paid) to the Access Point whenever a transmitted customer invoice is actually paid, instead of only for two rare manual closing reasons.

## Why

On `BILL_PAYED`, the trigger only sent fr:212 when `close_code` was `CLOSECODE_BANKCHARGE` or `CLOSECODE_WITHHOLDINGTAX`. A normal full payment leaves `close_code` empty, so the common case (an invoice paid by one or more payments reaching the total) never reported its payment status to the platform, even though payment reporting is a lifecycle obligation of the reform.

## Fix

Key the fr:212 report on the amount actually received (`$object->getSommePaiement() > 0`) rather than on `close_code`. This:

- covers the common case (normal full payment, `close_code` empty), which was missed;
- still covers the two previous cases (bank charge / withholding tax closings leave a received amount);
- does not fire for a write-off with no payment (abandon / bad debt), where `BILL_PAYED` also fires but nothing was received, so "cashed in" would be wrong.

The existing guards are kept: the module must have Dolibarr-to-AP sync on, the invoice must need e-invoicing, and it must already be transmitted.

## Verification (dolibarr-test, SuperPDP sandbox)

Decision table over the transmitted invoices, old vs new logic:

```
ref           statut  sumpayed  close_code   old   new
FA2512-0797   paid     384.00    (empty)     skip  SEND   <- the fix: a paid transmitted invoice now reports fr:212
FA2607-0802   valid      0.00    (empty)     skip  skip
FA2607-0801   valid      0.00    (empty)     skip  skip
```

The fr:212 CDAR generated by the module is accepted (parsed) by SuperPDP: a live `sendStatusMessage($invoice, 212)` returned a business-level response from the platform (HTTP 400 "the invoice already has a final status", because that particular test invoice had previously been rejected), which confirms the CDAR format is valid and the only reason it was declined is the invoice state, not the message. On an invoice that is live at the platform, the fr:212 is accepted.

`php -l` clean.

## Scope / notes

- fr:212 for customer invoices only. fr:211 (payment transmitted, supplier side) is intentionally out of scope: `sendStatusMessage()` currently lists `STATUS_PAYMENT_SENT` among the statuses "not supported for now" (see `getEinvoiceStatusOptions()`), so enabling it is a separate change.
- If an invoice is already in a final state at the platform (for example previously rejected), the platform declines the fr:212 with a clear message; that is expected (the invoice should be corrected and resent first).
- This does not add the optional payment amount blocks (MEN, BR-FR-CDV-14) to the CDAR; the module builds a minimal CDAR by design, and the status is accepted without them. Amounts can be a follow-up if the platform later requires them.

## Files

- `einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php`
