### PR TITLE
fix(esalink): migrate token auth to OAuth2 client_credentials (API v1.2.6)

### DIFF
--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -543,7 +543,7 @@ abstract class AbstractPDPProvider
 	 * the business transaction, so it is committed whether the action succeeds or fails,
 	 * without ever forcing a commit on the rest. Same approach as the webhook logging.
 	 *
-	 * @param   string                      $callType   Functional type of the call (empty = do not log)
+	 * @param   ?string                     $callType   Functional type of the call (empty/null = do not log)
 	 * @param   string                      $resource   API resource/endpoint (without leading slash)
 	 * @param   string                      $method     HTTP method (POSTALREADYFORMATED is normalized to POST)
 	 * @param   string|array<mixed>         $params     Request body
@@ -551,7 +551,7 @@ abstract class AbstractPDPProvider
 	 * @param   int                         $statusCode HTTP status code of the response
 	 * @return  ?array{id:int,call_id:string}           Created log identifiers, or null if not logged
 	 */
-	protected function logCall($callType, $resource, $method, $params, $response, $statusCode)
+	protected function logCall(?string $callType, $resource, $method, $params, $response, $statusCode)
 	{
 		global $conf, $user, $dolibarr_main_db_pass, $dbhistory;
 

--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -280,15 +280,17 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 	{
 		global $langs;
 
-		$param = json_encode(array(
-			'username' => $this->config['username'],
-			'password' => $this->config['password']
+		// OAuth2 client_credentials — RFC 6749, application/x-www-form-urlencoded
+		// Remplace l'ancien POST /v1/token (JSON username/password) désactivé depuis v1.2.6 (juillet 2026).
+		$param = http_build_query(array(
+			'grant_type'    => 'client_credentials',
+			'client_id'     => $this->config['username'],
+			'client_secret' => $this->config['password'],
 		));
 
-		$extraHeaders = array();
+		$extraHeaders = array('Content-Type' => 'application/x-www-form-urlencoded');
 
-		// We call /token api of Esalink with username and pass. May be they are just client_id / client_secret that were renamed ?
-		$response = $this->callApi("token", "POSTALREADYFORMATED", $param, $extraHeaders, 'get_access_token');
+		$response = $this->callApi("oauth2/token", "POSTALREADYFORMATED", $param, $extraHeaders, 'get_access_token');
 
 		$status_code = $response['status_code'];
 		$body = $response['response'];
@@ -699,7 +701,7 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 		}
 
 		// check or get access token
-		if ($resource != 'token') {
+		if ($callType != 'get_access_token') {
 			if (!empty($this->tokenData['token'])) {
 				if ($this->isTokenExpired()) {
 					$this->refreshAccessToken(); // This will fill again $this->tokenData['token'] and save it in database
@@ -710,7 +712,7 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 		}
 
 		// Add Authorization header if we have a token
-		if (!empty($this->tokenData['token']) && $resource != 'token') {
+		if (!empty($this->tokenData['token']) && $callType != 'get_access_token') {
 			$httpheader[] = 'Authorization: Bearer ' . $this->tokenData['token'];
 		}
 


### PR DESCRIPTION
## Summary

Two related fixes in the Esalink/Hubtimize integration:

### 1. OAuth2 token endpoint (breaking change in API v1.2.6)

Hubtimize disabled `POST /v1/token` (JSON body). The replacement is `POST /v1/oauth2/token` using RFC 6749 `client_credentials` flow with `application/x-www-form-urlencoded` encoding.

`EsalinkPDPProvider.class.php`
- `getAccessToken()`: switch to `http_build_query(["grant_type" => "client_credentials", "client_id", "client_secret"])` + `Content-Type: application/x-www-form-urlencoded`, call `oauth2/token`
- `callApi()`: replace `$resource != 'token'` anti-recursion guard with `$callType != 'get_access_token'`

Ref: https://help.hubtimize.fr/fr/article/obtenir-un-jeton-api-token-txo1bh/

### 2. Phan PhanTypeMismatchArgumentNullable fix

`callApi()` declares `$callType` as `string|null` but `AbstractPDPProvider::logCall()` only accepted `string`, triggering a Phan error. The method already handles `empty($callType)`, so widening to `?string` is safe. Fixes the same issue in `SuperPDPProvider` too.

`AbstractPDPProvider.class.php`
- `logCall()` signature: `string $callType` → `?string $callType`

## Test plan

- [ ] `POST /v1/oauth2/token` returns a JWT with valid credentials
- [ ] `checkHealth()` succeeds after token retrieval
- [ ] Phan analysis passes with no `PhanTypeMismatchArgumentNullable` on `logCall()`
- [ ] Sending an invoice works end-to-end
