### PR TITLE
Qual(einvoicing): Update syncFlows return type and related methods

### DIFF
--- a/dev/tools/phan/baseline.txt
+++ b/dev/tools/phan/baseline.txt
@@ -11,42 +11,38 @@ return [
     // # Issue statistics:
     // PhanUndeclaredProperty : 55+ occurrences
     // PhanUndeclaredVariable : 50+ occurrences
-    // PhanTypeMismatchArgument : 45+ occurrences
     // PhanDeprecatedProperty : 40+ occurrences
     // PhanTypeArraySuspiciousNull : 40+ occurrences
     // PhanTypeInvalidDimOffset : 35+ occurrences
-    // PhanTypeArraySuspiciousNullable : 30+ occurrences
-    // PhanTypeMismatchArgumentNullable : 25+ occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 20+ occurrences
-    // PhanPossiblyUndeclaredVariable : 15+ occurrences
+    // PhanTypeArraySuspiciousNullable : 25+ occurrences
     // PhanRedefineFunction : 15+ occurrences
+    // PhanTypeMismatchArgument : 15+ occurrences
+    // PhanTypeMismatchArgumentNullable : 15+ occurrences
     // PhanAccessMethodPrivate : 10+ occurrences
+    // PhanTypeMismatchArgumentProbablyReal : 10+ occurrences
     // PhanTypeMismatchArgumentReal : 10+ occurrences
     // PhanUndeclaredMethod : 10+ occurrences
-    // PhanTypeMismatchArgumentNullableInternal : 9 occurrences
-    // PhanTypeMismatchProperty : 8 occurrences
-    // PhanTypeMismatchArgumentSuperType : 7 occurrences
+    // PhanTypeMismatchProperty : 7 occurrences
     // PhanUndeclaredVariableDim : 7 occurrences
     // PhanPossiblyNullTypeMismatchProperty : 6 occurrences
+    // PhanTypeMismatchArgumentNullableInternal : 6 occurrences
     // PhanTypeMismatchReturn : 6 occurrences
     // PhanTypeObjectUnsetDeclaredProperty : 6 occurrences
     // PhanUndeclaredClassMethod : 6 occurrences
-    // PhanPossiblyUndeclaredGlobalVariable : 5 occurrences
-    // PhanTypeSuspiciousEcho : 5 occurrences
+    // PhanPossiblyUndeclaredVariable : 5 occurrences
     // PhanEmptyForeach : 4 occurrences
-    // PhanPluginEmptyStatementIf : 4 occurrences
     // PhanPluginRedundantReturnComment : 4 occurrences
     // PhanPluginUnreachableCode : 4 occurrences
+    // PhanPossiblyUndeclaredGlobalVariable : 4 occurrences
     // PhanPluginLoopVariableReuse : 3 occurrences
     // PhanTypeExpectedObjectPropAccessButGotNull : 3 occurrences
     // PhanTypeMismatchArgumentInternal : 3 occurrences
     // PhanTypeMismatchForeach : 3 occurrences
     // PhanDeprecatedClassConstant : 2 occurrences
     // PhanDeprecatedFunction : 2 occurrences
-    // PhanPluginBothLiteralsBinaryOp : 2 occurrences
     // PhanPluginDuplicateExpressionAssignmentOperation : 2 occurrences
+    // PhanPluginEmptyStatementIf : 2 occurrences
     // PhanPluginSimplifyExpressionBool : 2 occurrences
-    // PhanRedefinedExtendedClass : 2 occurrences
     // PhanTypeExpectedObjectOrClassName : 2 occurrences
     // PhanTypeInvalidLeftOperandOfNumericOp : 2 occurrences
     // PhanTypeMismatchPropertyProbablyReal : 2 occurrences
@@ -62,6 +58,7 @@ return [
     // PhanPluginDuplicateIfCondition : 1 occurrence
     // PhanPluginEmptyStatementForeachLoop : 1 occurrence
     // PhanRedefineClass : 1 occurrence
+    // PhanRedefinedExtendedClass : 1 occurrence
     // PhanRedundantArrayValuesCall : 1 occurrence
     // PhanTypeInvalidLeftOperandOfAdd : 1 occurrence
     // PhanTypeInvalidRightOperandOfAdd : 1 occurrence
@@ -85,7 +82,7 @@ return [
         'einvoicing/class/document.class.php' => ['PhanPluginRedundantReturnComment', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnNullable', 'PhanTypeObjectUnsetDeclaredProperty', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredProperty'],
         'einvoicing/class/einvoicing.class.php' => ['PhanTypeMismatchArgumentNullable'],
         'einvoicing/class/helpers/SupplierInvoiceHelper.class.php' => ['PhanPluginRedundantReturnComment', 'PhanTypeMismatchArgumentNullableInternal', 'PhanUndeclaredMethod'],
-        'einvoicing/class/protocols/CIIProtocol.class.php' => ['PhanDeprecatedClassConstant', 'PhanDeprecatedProperty', 'PhanEmptyForeach', 'PhanParamTooMany', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPluginUnreachableCode', 'PhanRedundantArrayValuesCall', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentReal', 'PhanTypeMismatchProperty', 'PhanUndeclaredProperty', 'PhanUndeclaredVariable'],
+        'einvoicing/class/protocols/CIIProtocol.class.php' => ['PhanDeprecatedClassConstant', 'PhanDeprecatedProperty', 'PhanEmptyForeach', 'PhanParamTooMany', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPluginUnreachableCode', 'PhanRedundantArrayValuesCall', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentReal', 'PhanUndeclaredProperty', 'PhanUndeclaredVariable'],
         'einvoicing/class/protocols/CommonProtocol.class.php' => ['PhanTypeMismatchArgumentNullable', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty'],
         'einvoicing/class/protocols/FacturXProtocol.class.php' => ['PhanDeprecatedClassConstant', 'PhanDeprecatedFunction', 'PhanDeprecatedProperty', 'PhanEmptyForeach', 'PhanNonClassMethodCall', 'PhanPluginSimplifyExpressionBool', 'PhanPluginUnreachableCode', 'PhanPossiblyNullTypeMismatchProperty', 'PhanPossiblyUndeclaredVariable', 'PhanTypeArraySuspiciousNull', 'PhanTypeArraySuspiciousNullable', 'PhanTypeExpectedObjectPropAccessButGotNull', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchArgumentReal', 'PhanTypeMismatchDimAssignment', 'PhanTypeMismatchDimFetch', 'PhanTypeMismatchDimFetchNullable', 'PhanTypeMismatchForeach', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredVariable', 'PhanUndeclaredVariableDim', 'PhanUnreferencedUseNormal'],
         'einvoicing/class/protocols/ProtocolManager.class.php' => ['PhanPossiblyUndeclaredVariable'],
@@ -97,8 +94,7 @@ return [
         'einvoicing/compat/commonhookactions.class.php' => ['PhanRedefineClass'],
         'einvoicing/compat/profid.lib.php' => ['PhanRedefineFunction', 'PhanTypeInvalidDimOffset'],
         'einvoicing/core/modules/modEInvoicing.class.php' => ['PhanTypeMismatchProperty'],
-        'einvoicing/document_card.php' => ['PhanPluginBothLiteralsBinaryOp', 'PhanTypeMismatchArgumentNullable', 'PhanUndeclaredProperty'],
-        'einvoicing/document_list.php' => ['PhanPossiblyUndeclaredGlobalVariable', 'PhanTypeInvalidDimOffset', 'PhanTypeSuspiciousEcho', 'PhanUndeclaredProperty'],
+        'einvoicing/document_card.php' => ['PhanUndeclaredProperty'],
         'einvoicing/lib/buildinvoicelines.inc.php' => ['PhanAccessMethodPrivate', 'PhanDeprecatedFunction', 'PhanDeprecatedProperty', 'PhanTypeArraySuspiciousNullable', 'PhanTypeInvalidLeftOperandOfAdd', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeInvalidRightOperandOfAdd', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanUndeclaredProperty'],
         'einvoicing/lib/einvoicing.lib.php' => ['PhanRedefineFunction', 'PhanTypeMismatchArgumentNullable', 'PhanUndeclaredVariableDim'],
         'einvoicing/public/proxy_oauthcallback.php' => ['PhanTypeArraySuspiciousNullable'],

--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -377,7 +377,7 @@ abstract class AbstractPDPProvider
 	 * @param   int   $syncFromDate     Timestamp from which to start synchronization. If 0, begins from epoch (1970-01-01).
 	 * @param   int   $limit            Maximum number of flows to synchronize. 0 means no limit.
 	 *
-	 * @return 	bool|array{res:int, messages:array<string>, details:array<string>, actions:array<string>} 	True on success, false on failure along with messages, details for debugging, and suggested optional actions.
+	 * @return 	bool|array{res:int, messages:string[], totalFlows?:?int, alreadyExist?:int, syncedFlows?:int, batchlimit?:int, actions?:array<string,array{actionurl:string,actioncode:string,action:string,businessmessage:string}>, details?:string[]} 	True on success, false on failure along with messages, details for debugging, and suggested optional actions.
 	 */
 	abstract public function syncFlows($syncFromDate = 0, $limit = 0);
 
@@ -602,7 +602,7 @@ abstract class AbstractPDPProvider
 
 		if ($resql) {
 			$obj = $db->fetch_object($resql);
-			$LastSyncDate = $obj->last_sync_date  ? strtotime($obj->last_sync_date) : null;
+			$LastSyncDate = $obj->last_sync_date ? strtotime($obj->last_sync_date) : null;
 		} else {
 			dol_syslog(__METHOD__ . " SQL warning: Failed to get last sync date: we try to sync all flows from today", LOG_WARNING);
 		}

--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -766,7 +766,7 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 	 *
 	 * @param   int   $syncFromDate     Timestamp from which to start synchronization. If 0, begins from epoch (1970-01-01).
 	 * @param   int   $limit            Maximum number of flows to synchronize. 0 means no limit.
-	 * @return 	bool|array{res:int, messages:array<string>, details?:array<string>, actions?:array<string>} 	True on success, false on failure along with messages, details for debugging, and suggested optional actions.
+	 * @return 	bool|array{res:int, messages:string[], totalFlows?:?int, alreadyExist?:int, syncedFlows?:int, batchlimit?:int, actions?:array<string,array{actionurl:string,actioncode:string,action:string,businessmessage:string}>, details?:string[]} 	True on success, false on failure along with messages, details for debugging, and suggested optional actions.
 	 */
 	public function syncFlows($syncFromDate = 0, $limit = 0)
 	{

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -1271,7 +1271,7 @@ class SuperPDPProvider extends AbstractPDPProvider
 	 *
 	 * @param   int   $syncFromDate     Timestamp from which to start synchronization. If 0, begins from epoch (1970-01-01).
 	 * @param   int   $limit            Maximum number of flows to synchronize. 0 means no limit.
-	 * @return 	bool|array{res:int<-1,1>, messages:array<string>, details?:array<string>, actions?:array<string>} 	True on success, false on failure along with messages, details for debugging, and suggested optional actions.
+	 * @return 	bool|array{res:int, messages:string[], totalFlows?:?int, alreadyExist?:int, syncedFlows?:int, batchlimit?:int, actions?:array<string,array{actionurl:string,actioncode:string,action:string,businessmessage:string}>, details?:string[]} 	True on success, false on failure along with messages, details for debugging, and suggested optional actions.
 	 */
 	public function syncFlows($syncFromDate = 0, $limit = 0)
 	{

--- a/einvoicing/document_card.php
+++ b/einvoicing/document_card.php
@@ -147,11 +147,11 @@ include DOL_DOCUMENT_ROOT.'/core/actions_fetchobject.inc.php'; // Must be 'inclu
 
 // There is several ways to check permission.
 // Set $enablepermissioncheck to 1 to enable a minimum low level of checks
-$enablepermissioncheck = getDolGlobalInt('EINVOICING_ENABLE_PERMISSION_CHECK');
+$enablepermissioncheck = getDolGlobalInt('EINVOICING_ENABLE_PERMISSION_CHECK', 0);
 if ($enablepermissioncheck) {
 	$permissiontoread = $user->hasRight('einvoicing', 'read');
 	$permissiontoadd = $user->hasRight('einvoicing', 'write'); // Used by the include of actions_addupdatedelete.inc.php and actions_lineupdown.inc.php
-	$permissiontodelete = $user->hasRight('einvoicing', 'delete') || ($permissiontoadd && isset($object->status) && $object->status == $object::STATUS_DRAFT);
+	$permissiontodelete = (int) ($user->hasRight('einvoicing', 'delete') || ($permissiontoadd && isset($object->status) && $object->status == $object::STATUS_DRAFT));
 	$permissionnote = $user->hasRight('einvoicing', 'write'); // Used by the include of actions_setnotes.inc.php
 	$permissiondellink = $user->hasRight('einvoicing', 'write'); // Used by the include of actions_dellink.inc.php
 } else {
@@ -271,7 +271,7 @@ llxHeader('', $title, $help_url, '', 0, 0, '', '', '', 'mod-einvoicing page-card
 
 // Part to create
 if ($action == 'create') {
-	if (empty($permissiontoadd)) {
+	if (!$permissiontoadd) {
 		accessforbidden('NotEnoughPermissions', 0, 1);
 	}
 
@@ -527,7 +527,8 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 	// Buttons for actions
 
-	if ($action != 'presend' && $action != 'editline' && 1 == 0) {
+	if ($action != 'presend' && $action != 'editline' && 1 == 0) {  // @phan-suppress-current-line PhanPluginBothLiteralsBinaryOp
+		$permissiontoadd = (int) $permissiontoadd;  // workaround for Phan
 		print '<div class="tabsAction">'."\n";
 		$parameters = array();
 		$reshook = $hookmanager->executeHooks('addMoreActionsButtons', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
@@ -601,7 +602,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		$action = 'presend';
 	}
 
-	if ($action != 'presend' && 1 == 0) {
+	if ($action != 'presend' && 1 == 0) {  // @phan-suppress-current-line PhanPluginBothLiteralsBinaryOp
 		print '<div class="fichecenter"><div class="fichehalfleft">';
 		print '<a name="builddoc"></a>'; // ancre
 
@@ -614,8 +615,8 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			$filedir = $conf->einvoicing->dir_output.'/'.$object->element.'/'.$objref;
 			$urlsource = $_SERVER["PHP_SELF"]."?id=".$object->id;
 			$genallowed = $permissiontoread; // If you can read, you can build the PDF to read content
-			$delallowed = $permissiontoadd; // If you can create/edit, you can remove a file on card
-			print $formfile->showdocuments('einvoicing:Document', $object->element.'/'.$objref, $filedir, $urlsource, $genallowed, $delallowed, $object->model_pdf, 1, 0, 0, 28, 0, '', '', '', $langs->defaultlang);
+			$delallowed = (int) $permissiontoadd; // If you can create/edit, you can remove a file on card
+			print $formfile->showdocuments('einvoicing:Document', $object->element.'/'.$objref, $filedir, $urlsource, $genallowed, $delallowed, (string) $object->model_pdf, 1, 0, 0, 28, 0, '', '', '', $langs->defaultlang);
 		}
 
 		// Show links to link elements

--- a/einvoicing/document_list.php
+++ b/einvoicing/document_list.php
@@ -98,7 +98,7 @@ $groupby = GETPOST('groupby', 'aZ09');	// Example: $groupby = 'p.fk_opp_status' 
 
 $id = GETPOSTINT('id');
 $ref = GETPOST('ref', 'alpha');
-$sync_result = '';
+$sync_result = array();
 $maxflows = GETPOSTINT('maxflows');
 $syncFromDate = GETPOSTINT('syncfromdate');
 
@@ -133,6 +133,7 @@ $object = new Document($db);
 $extrafields = new ExtraFields($db);
 $diroutputmassaction = $conf->einvoicing->dir_output.'/temp/massgeneration/'.$user->id;
 $hookmanager->initHooks(array($contextpage)); 	// Note that conf->hooks_modules contains array of activated contexes
+$provider = null;
 
 // Fetch optionals attributes and labels
 $extrafields->fetch_name_optionals_label($object->table_element);
@@ -1163,8 +1164,8 @@ while ($i < $imaxinloop) {
 	if ($object->cdar_reason_code) {
 		$object->recap .= 'CDAR Reason Code: '.$object->cdar_reason_code.'<br>';
 	}
-	if ($object->cdar_reason_description) {
-		$object->recap .= 'CDAR Reason Description: '.$object->cdar_reason_description.'<br>';
+	if ($object->cdar_reason_desc) {
+		$object->recap .= 'CDAR Reason Description: '.$object->cdar_reason_desc.'<br>';
 	}
 	if ($object->cdar_reason_detail) {
 		$object->recap .= 'CDAR Reason Detail: '.$object->cdar_reason_detail.'<br>';


### PR DESCRIPTION
## Qual(einvoicing): Update syncFlows return type and related methods

- Update the return type of syncFlows method in AbstractPDPProvider, EsalinkPDPProvider, and SuperPDPProvider classes to include additional optional fields.
- Fix document_{data,card} Phan notices
- Update the baseline.txt file to reflect the changes in the codebase.