### PR TITLE
Fix #372: [einvoicing] TotalPrepaidAmount double-counts the payment

### DIFF
--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -571,10 +571,13 @@ if ($resql) {
 	dol_syslog("Error " . $db->error() . " when looking for credit note linked to invoice to calculate prepaid amount for invoice " . $object->id, LOG_WARNING);
 }
 
-// Already paid deposits
+// Amount already received for this invoice: direct payments + used credit notes.
+// getSommePaiement() returns the sum of payments; on Dolibarr <= 22 it also stores that same
+// value into $object->sumpayed, so adding both double-counted the payment (#372: a fully paid
+// invoice reported TotalPrepaidAmount = 2x the amount and a negative DuePayableAmount).
 $getAlreadyPaid = $object->getSommePaiement();
 
-$prepaidAmount  = $object->sumpayed + $getAlreadyPaid + $usedcreditnoteamount;
+$prepaidAmount  = $getAlreadyPaid + $usedcreditnoteamount;
 
 // Delivery date
 $deliveryDate = !empty($deliveryDateList)


### PR DESCRIPTION
Fixes #372.

`buildinvoicelines.inc.php` computed:

```php
$getAlreadyPaid = $object->getSommePaiement();
$prepaidAmount  = $object->sumpayed + $getAlreadyPaid + $usedcreditnoteamount;
```

`getSommePaiement()` returns the sum of payments **and**, on Dolibarr ≤ 22, stores that same value into `$object->sumpayed`. So the payment was added twice: the reporter's fully paid invoice (GrandTotal 3.52, paid 3.52) produced `TotalPrepaidAmount = 7.04` and `DuePayableAmount = -3.52` — a BR-CO-16 violation that fails EN16931 validation.

Fix: key the prepaid amount on `getSommePaiement()` alone (+ used credit notes), dropping the redundant `$object->sumpayed` term.

**Version note:** on Dolibarr 23 `getSommePaiement()` sets `totalpaid` instead and leaves `sumpayed` null, so the bug only shows on 18–22; the fix is correct and a no-op on 23+.

**Tested:** verified on Dolibarr 23.0.3 that `getSommePaiement()` leaves `sumpayed` null (bug cannot manifest natively, fix is safe), and a version-invariant harness reproduces `7.04 / -3.52` on ≤22 → `3.52 / 0.00` after the fix, unchanged on 23/dev.