### PR TITLE
fix(einvoicing): restore inverted document type code check in FacturXProtocol

### DIFF
--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -2000,7 +2000,7 @@ class FacturXProtocol extends AbstractProtocol
 		];
 
 
-		if (isset($map[$documenttypecode])) {
+		if (!isset($map[$documenttypecode])) {
 			dol_syslog(get_class($this) . '::_getDolibarrInvoiceType Unknown document type code: ' . $documenttypecode, LOG_WARNING);
 			return '-1';
 		}


### PR DESCRIPTION
## Fix

Restore the negated `isset()` guard in `FacturXProtocol::_getDolibarrInvoiceType()`.

Commit 01a0dee (*"Qual(einvoicing): Fix Phan notices in FacturXProtocol class"*) dropped the `!`, inverting the guard so that **known** document type codes returned `'-1'` while **unknown** codes read an undefined array index. This broke supplier-invoice creation during e-invoice synchronization (`ERROR_SYNCFLOW`) for every valid code such as `380` (standard invoice).

```diff
-		if (isset($map[$documenttypecode])) {
+		if (!isset($map[$documenttypecode])) {
 			dol_syslog(get_class($this) . '::_getDolibarrInvoiceType Unknown document type code: ' . $documenttypecode, LOG_WARNING);
 			return '-1';
 		}

 		return $map[$documenttypecode];
```

This restores the same behavior as the sibling `CIIProtocol::_getDolibarrInvoiceType()`, which was unaffected.

## Verification

- Known codes (`380`, `381`, `386`, `503`, ...) now map to their Dolibarr invoice type.
- Unknown / `null` codes correctly return `'-1'` and log a warning.
- `php -l` passes on the changed file.

Fixes #379

---
*Change authored by Claude (AI) and reviewed by a human.*
