### PR TITLE
FIX : Add mandatory sequence number in CDAR status detail

### DIFF
--- a/einvoicing/class/utils/CdarHandler.class.php
+++ b/einvoicing/class/utils/CdarHandler.class.php
@@ -300,7 +300,7 @@ class CdarHandler
 					'SpecifiedDocumentStatus' => !empty($reasonCode) ? [
 						'ReasonCode' => $reasonCode,
 						//'Reason' => 'Taux de TVA erroné',
-						//'SequenceNumeric' => 1
+						'SequenceNumeric' => 1
 					] : [],
 
 					'IssuerTradeParty' => [
@@ -731,14 +731,14 @@ class CdarHandler
 				);
 			}
 
-			/*if (isset($doc['SpecifiedDocumentStatus']['SequenceNumeric'])) {
+			if (isset($doc['SpecifiedDocumentStatus']['SequenceNumeric'])) {
 				$status->appendChild(
 					$dom->createElement(
 						'ram:SequenceNumeric',
-						(int) $doc['SpecifiedDocumentStatus']['SequenceNumeric']
+						(string) $doc['SpecifiedDocumentStatus']['SequenceNumeric']
 					)
 				);
-			}*/
+			}
 
 			$ref->appendChild($status);
 		}


### PR DESCRIPTION
Sending a status message with a reason code for a supplier invoice (e.g. refusing a received invoice) was always rejected by the platform with "[BR-FR-CDV-13/MDT-124-2] : Le numero incremental de detail de statut (MDT-124-2) est obligatoire si un detail de statut (MDG-37) est present.".

The ram:SequenceNumeric element was already written by CdarHandler::addReferencedDocument() but left commented out, along with the corresponding data in generateCdarFile(). Re-enable both so every ram:SpecifiedDocumentStatus (reason code) is now always accompanied by its mandatory sequence number, as the original code already intended.

Verified by generating a real CDAR file for a supplier invoice refusal: the resulting XML is well-formed and contains <ram:SequenceNumeric>1</ram:SequenceNumeric> next to <ram:ReasonCode>.