### PR TITLE
FIX : Resolve SupplierInvoiceHelper path dynamically in trigger

### DIFF
--- a/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
+++ b/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
@@ -24,7 +24,7 @@
  */
 
 require_once DOL_DOCUMENT_ROOT.'/core/triggers/dolibarrtriggers.class.php';
-require_once DOL_DOCUMENT_ROOT.'/custom/einvoicing/class/helpers/SupplierInvoiceHelper.class.php';
+dol_include_once('einvoicing/class/helpers/SupplierInvoiceHelper.class.php');
 
 
 /**


### PR DESCRIPTION
The trigger required its helper dependency via a require_once hardcoded to DOL_DOCUMENT_ROOT.'/custom/einvoicing/...'. If this module is ever deployed directly under htdocs/einvoicing (instead of htdocs/custom/einvoicing), that require_once fails fatally, silently disabling every trigger of the module (anti-deletion locks, status sync, ...).

Use dol_include_once('einvoicing/class/helpers/SupplierInvoiceHelper.class.php') instead, resolved dynamically via dol_buildpath() like the rest of the module, so it works regardless of the install location.

Verified: the trigger class still loads and SupplierInvoiceHelper is still available after the change.