### PR TITLE
FIX : Escape origin_redirect_uri to prevent reflected XSS

### DIFF
--- a/einvoicing/public/proxy_oauthcallback.php
+++ b/einvoicing/public/proxy_oauthcallback.php
@@ -393,7 +393,7 @@ if (empty($code) && !GETPOST('error')) {
 
 					print '<br>';
 					print '<br>';
-					print '<a href="'.$origin_redirect_uri.'">Go back to setup page...</a>';
+					print '<a href="'.dol_escape_htmltag($origin_redirect_uri).'">Go back to setup page...</a>';
 					print '<br>';
 
 					print '</center>';


### PR DESCRIPTION
The error branch of the OAuth proxy callback printed $origin_redirect_uri (derived from the redirect_uri submitted at the start of the flow) directly into an href attribute without escaping, unlike the identical construct a few lines above (error-from-provider branch) which correctly uses dol_escape_htmltag(). A crafted redirect_uri could inject arbitrary HTML/JS on this public (NOLOGIN) page.

Verified: dol_escape_htmltag() neutralizes a real <script> payload.

Note: the broader redirect_uri validation (no allow-list of authorized partner domains before using it in a token-bearing redirect) is intentionally left for a separate fix - needs product input on how partner domains should be registered/whitelisted for the "via partner" proxy flow.