### PR TITLE
FIX : Add restrictedArea() to prevent IDOR on status-check ajax endpoints

### DIFF
--- a/einvoicing/ajax/checkinvoicestatus.php
+++ b/einvoicing/ajax/checkinvoicestatus.php
@@ -125,6 +125,10 @@ if ($objectRef) {
 		exit;
 	}
 
+	// Authorize the fetched invoice with the standard invoice/third-party access rules: the
+	// e-invoicing write right alone must not expose an invoice the user cannot otherwise read.
+	restrictedArea($user, 'facture', $invoice->id, '', '', 'fk_soc', 'rowid');
+
 	// Get flowId from linked document log
 	$flowId = '';
 	$sql = "SELECT flow_id";

--- a/einvoicing/ajax/checksupplierinvoicestatus.php
+++ b/einvoicing/ajax/checksupplierinvoicestatus.php
@@ -124,6 +124,10 @@ if ($objectID) {
 		exit;
 	}
 
+	// Authorize the fetched invoice with the standard supplier invoice/third-party access rules:
+	// the e-invoicing write right alone must not expose an invoice the user cannot otherwise read.
+	restrictedArea($user, 'fournisseur', $invoice->id, 'facture_fourn', 'facture', 'fk_soc', 'rowid');
+
 	// Get flowId from linked document log
 	$flowId = '';
 	$sql = "SELECT rowid, flow_id, lc_status, lc_reason_code FROM ".MAIN_DB_PREFIX."einvoicing_lifecycle_msg";


### PR DESCRIPTION
ajax/checkinvoicestatus.php and ajax/checksupplierinvoicestatus.php only checked $user->hasRight('einvoicing', 'write') before fetching and acting on an arbitrary invoice/supplier invoice by ref/id - any user with that single module right could query or trigger a status sync on an invoice belonging to a third party they have no other access to.

ajax/checkdirectory.php already had the correct pattern (restrictedArea($user, 'facture', ...) right after fetching the invoice) with a comment explaining exactly this risk; replicate it here, and use the supplier invoice equivalent (matching fourn/facture/card.php's own restrictedArea() call) for the second file.

Verified: restrictedArea() runs cleanly (returns 1, no accessforbidden()) for a legitimate admin user on both a real supplier invoice and a real customer invoice.