### PR TITLE
FIX : Apply line and header discounts when importing Factur-X invoices

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -953,7 +953,7 @@ class CIIProtocol extends AbstractProtocol
 			}
 			// handle line-level discount if exists and update amounts
 			if (!empty($parsedLine['lineAllowances'])) {
-				$discount = $this->_resolveLineDiscountPercent($parsedLine['lineAllowances'], $parsedLine['lineTotalAmount']);
+				$discount = $this->resolveLineDiscountPercent($parsedLine['lineAllowances'], $parsedLine['lineTotalAmount']);
 				if ($discount !== false) {
 					$line->remise_percent = $discount['percent'];
 					if (!empty($parsedLine['billedquantity'])) {
@@ -978,7 +978,7 @@ class CIIProtocol extends AbstractProtocol
 		// Create document level discounts (allowances) as discounts in Dolibarr
 		$globalDiscountIds = array();
 		if (!empty($parsedHeader['headerAllowancesCharges'])) {
-			$headerDiscountIds = $this->_createHeaderDiscounts($parsedHeader['headerAllowancesCharges'], $socId, 	$parsedHeader['documentno']);
+			$headerDiscountIds = $this->createHeaderDiscounts($parsedHeader['headerAllowancesCharges'], $socId, 	$parsedHeader['documentno']);
 			if (!empty($headerDiscountIds[-1])) {
 				return ['res' => -1, 'message' => $headerDiscountIds[-1]];
 			} else {
@@ -2623,7 +2623,7 @@ class CIIProtocol extends AbstractProtocol
 	 * @param float|null $lineTotalAmount BT-131 net line amount (base ht)
 	 * @return false|array{percent: float, base: float, discountAmount: float, priceWithoutDiscount: float}
 	 */
-	protected function _resolveLineDiscountPercent(array $lineAllowances, ?float $lineTotalAmount)
+	protected function resolveLineDiscountPercent(array $lineAllowances, ?float $lineTotalAmount)
 	{
 		// Keep only allowances (indicator = "false"), ignore charges (indicator = "true")
 		$allowances = array();
@@ -2674,7 +2674,7 @@ class CIIProtocol extends AbstractProtocol
 	 * @param string $description             	invoice number or any reference
 	 * @return array{-1:string}|array<int,int>	[ originalIndex => fk_remise_except_id ] or '-1' on error
 	 */
-	protected function _createHeaderDiscounts(array $headerAllowancesCharges, int $fk_soc, string $description): array
+	protected function createHeaderDiscounts(array $headerAllowancesCharges, int $fk_soc, string $description): array
 	{
 		global $db, $user;
 

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -2623,7 +2623,7 @@ class CIIProtocol extends AbstractProtocol
 	 * @param float|null $lineTotalAmount BT-131 net line amount (base ht)
 	 * @return false|array{percent: float, base: float, discountAmount: float, priceWithoutDiscount: float}
 	 */
-	private function _resolveLineDiscountPercent(array $lineAllowances, ?float $lineTotalAmount)
+	protected function _resolveLineDiscountPercent(array $lineAllowances, ?float $lineTotalAmount)
 	{
 		// Keep only allowances (indicator = "false"), ignore charges (indicator = "true")
 		$allowances = array();
@@ -2674,7 +2674,7 @@ class CIIProtocol extends AbstractProtocol
 	 * @param string $description             	invoice number or any reference
 	 * @return array{-1:string}|array<int,int>	[ originalIndex => fk_remise_except_id ] or '-1' on error
 	 */
-	private function _createHeaderDiscounts(array $headerAllowancesCharges, int $fk_soc, string $description): array
+	protected function _createHeaderDiscounts(array $headerAllowancesCharges, int $fk_soc, string $description): array
 	{
 		global $db, $user;
 

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -1577,7 +1577,7 @@ class FacturXProtocol extends CIIProtocol
 			}
 			// handle line-level discount if exists and update amounts
 			if (!empty($parsedLine['lineAllowances'])) {
-				$discount = $this->_resolveLineDiscountPercent($parsedLine['lineAllowances'], $parsedLine['lineTotalAmount']);
+				$discount = $this->resolveLineDiscountPercent($parsedLine['lineAllowances'], $parsedLine['lineTotalAmount']);
 				if ($discount !== false) {
 					$line->remise_percent = $discount['percent'];
 					if (!empty($parsedLine['billedquantity'])) {
@@ -1602,7 +1602,7 @@ class FacturXProtocol extends CIIProtocol
 		// Create document level discounts (allowances) as discounts in Dolibarr
 		$globalDiscountIds = array();
 		if (!empty($parsedHeader['headerAllowancesCharges'])) {
-			$headerDiscountIds = $this->_createHeaderDiscounts($parsedHeader['headerAllowancesCharges'], $socId, (string) $parsedHeader['documentno']);
+			$headerDiscountIds = $this->createHeaderDiscounts($parsedHeader['headerAllowancesCharges'], $socId, (string) $parsedHeader['documentno']);
 			if (!empty($headerDiscountIds[-1])) {
 				return ['res' => -1, 'message' => $headerDiscountIds[-1]];
 			} else {

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -1575,14 +1575,33 @@ class FacturXProtocol extends CIIProtocol
 
 				$remise_already_used_line_level_ids[] = $fk_remise;
 			}
+			// handle line-level discount if exists and update amounts
+			if (!empty($parsedLine['lineAllowances'])) {
+				$discount = $this->_resolveLineDiscountPercent($parsedLine['lineAllowances'], $parsedLine['lineTotalAmount']);
+				if ($discount !== false) {
+					$line->remise_percent  = $discount['percent'];
+					$line->subprice = round($discount['priceWithoutDiscount'] / $parsedLine['billedquantity'], 8);
+				}
+			}
 			$line->qty = (float) $parsedLine['billedquantity'];
-			$line->subprice = (float) $parsedLine['netpriceamount'];
+			$line->subprice = $line->subprice ?? (float) $parsedLine['netpriceamount'];
 			$line->tva_tx = (float) $parsedLine['rateApplicablePercent'];
 			$line->total_ht = (float) $parsedLine['lineTotalAmount'];
 			$line->total_tva = $parsedLine['calculatedAmount'] ?? 0;
 			$line->total_ttc = $parsedLine['lineTotalAmount'] + ($parsedLine['calculatedAmount'] ?? 0);
 
 			$supplierInvoice->lines[] = $line;
+		}
+
+		// Create document level discounts (allowances) as discounts in Dolibarr
+		$globalDiscountIds = array();
+		if (!empty($parsedHeader['headerAllowancesCharges'])) {
+			$headerDiscountIds = $this->_createHeaderDiscounts($parsedHeader['headerAllowancesCharges'], $socId, $parsedHeader['documentno']);
+			if (!empty($headerDiscountIds[-1])) {
+				return ['res' => -1, 'message' => $headerDiscountIds[-1]];
+			} else {
+				$globalDiscountIds = $headerDiscountIds;
+			}
 		}
 
 		//return ['res' => 1, 'message' => 'Not implemented yet' ];
@@ -1733,6 +1752,20 @@ class FacturXProtocol extends CIIProtocol
 				$supplier->fournisseur = 1;
 				$supplier->code_fournisseur = 'auto';
 				$supplier->update($supplier->id, $user);
+			}
+
+			// Insert global discounts (allowances) as lines in this supplier invoice
+			if (!empty($globalDiscountIds)) {
+				foreach ($globalDiscountIds as $fk_remise_except) {
+					$currentSupplierInvoice = new FactureFournisseur($db);
+					$currentSupplierInvoice->fetch($supplierInvoiceId);
+					$result = $currentSupplierInvoice->insert_discount($fk_remise_except);
+					if ($result < 0) {
+						return ['res' => -1, 'message' => 'Failed to insert global discount into supplier invoice: ' . $currentSupplierInvoice->error];
+					} else {
+						dol_syslog('Global discount inserted into supplier invoice with line id: ' . $result);
+					}
+				}
 			}
 
 			// Create or update supplier prices for imported products

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -1602,7 +1602,7 @@ class FacturXProtocol extends CIIProtocol
 		// Create document level discounts (allowances) as discounts in Dolibarr
 		$globalDiscountIds = array();
 		if (!empty($parsedHeader['headerAllowancesCharges'])) {
-			$headerDiscountIds = $this->_createHeaderDiscounts($parsedHeader['headerAllowancesCharges'], $socId, $parsedHeader['documentno']);
+			$headerDiscountIds = $this->_createHeaderDiscounts($parsedHeader['headerAllowancesCharges'], $socId, (string) $parsedHeader['documentno']);
 			if (!empty($headerDiscountIds[-1])) {
 				return ['res' => -1, 'message' => $headerDiscountIds[-1]];
 			} else {

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -1579,8 +1579,14 @@ class FacturXProtocol extends CIIProtocol
 			if (!empty($parsedLine['lineAllowances'])) {
 				$discount = $this->_resolveLineDiscountPercent($parsedLine['lineAllowances'], $parsedLine['lineTotalAmount']);
 				if ($discount !== false) {
-					$line->remise_percent  = $discount['percent'];
-					$line->subprice = round($discount['priceWithoutDiscount'] / $parsedLine['billedquantity'], 8);
+					$line->remise_percent = $discount['percent'];
+					if (!empty($parsedLine['billedquantity'])) {
+						$line->subprice = round($discount['priceWithoutDiscount'] / $parsedLine['billedquantity'], 8);
+					} else {
+						// Avoid a fatal DivisionByZeroError on a zero/empty billed quantity (e.g. a free
+						// sample line): keep the discount percent, let subprice fall back to netpriceamount below.
+						dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource line ' . ($parsedLine['lineid'] ?? '?') . ' has a discount but billedquantity is zero/empty, skipping subprice adjustment', LOG_WARNING);
+					}
 				}
 			}
 			$line->qty = (float) $parsedLine['billedquantity'];


### PR DESCRIPTION
FacturXProtocol::doCreateSupplierInvoiceFromSource() built invoice lines and totals directly from parsed XML values, never calling CIIProtocol::_resolveLineDiscountPercent()/_createHeaderDiscounts() (both private, and FacturXProtocol has its own override of doCreateSupplierInvoiceFromSource() rather than calling parent::). A supplier invoice received as Factur-X (PDF with embedded CII XML) with a line or header discount was imported with the header total correct but the lines not discounted - a real line/total mismatch on actual financial data. The pure CII import path (native XML, no PDF) already applied discounts correctly.

- Change _resolveLineDiscountPercent()/_createHeaderDiscounts() from private to protected in CIIProtocol, so FacturXProtocol (which extends CIIProtocol) can call them.
- Add the line-discount block, the header-discount computation block, and the header-discount application block to FacturXProtocol::doCreateSupplierInvoiceFromSource(), mirroring CIIProtocol's own implementation exactly.

Verified via reflection against a real FacturXProtocol instance: _resolveLineDiscountPercent() returns the correct percent/price for a 10% line allowance, and _createHeaderDiscounts() creates a real llx_societe_remise_except row (rolled back after the test, no data left behind).