### PR TITLE
FIX : Avoid DivisionByZeroError on zero billed quantity with a discount

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -955,8 +955,14 @@ class CIIProtocol extends AbstractProtocol
 			if (!empty($parsedLine['lineAllowances'])) {
 				$discount = $this->_resolveLineDiscountPercent($parsedLine['lineAllowances'], $parsedLine['lineTotalAmount']);
 				if ($discount !== false) {
-					$line->remise_percent  = $discount['percent'];
-					$line->subprice = round($discount['priceWithoutDiscount'] / $parsedLine['billedquantity'], 8);
+					$line->remise_percent = $discount['percent'];
+					if (!empty($parsedLine['billedquantity'])) {
+						$line->subprice = round($discount['priceWithoutDiscount'] / $parsedLine['billedquantity'], 8);
+					} else {
+						// Avoid a fatal DivisionByZeroError on a zero/empty billed quantity (e.g. a free
+						// sample line): keep the discount percent, let subprice fall back to netpriceamount below.
+						dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource line ' . ($parsedLine['lineid'] ?? '?') . ' has a discount but billedquantity is zero/empty, skipping subprice adjustment', LOG_WARNING);
+					}
 				}
 			}
 			$line->qty = $parsedLine['billedquantity'];


### PR DESCRIPTION
CIIProtocol::doCreateSupplierInvoiceFromSource() divided by $parsedLine['billedquantity'] to compute the discounted subprice of a line, with no guard against a zero/empty quantity (e.g. a free sample line with a discount). In PHP8 this throws a fatal DivisionByZeroError (an Error, not an Exception - not caught by the existing catch(Exception) blocks upstream), aborting the entire import of that flow on a single malformed/edge-case line.

Guard the division: keep the resolved discount percent (it does not depend on quantity), skip only the subprice adjustment when quantity is zero/empty (it already falls back to netpriceamount right after), and log the case for visibility.

Verified: reproduced the original crash (100.0/0.0 throws DivisionByZeroError) and confirmed the guarded code path no longer throws while the normal (non-zero quantity) case is unaffected.