### PR TITLE
FIX : Log BILL_PAYED platform notification failure via dol_syslog

### DIFF
--- a/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
+++ b/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
@@ -265,6 +265,13 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 							if ($result['res'] > 0) {
 								setEventMessage($langs->trans("ModuleEInvoicingName").' : '.$langs->trans('EInvStatus212Paid'), 'mesgs');
 							} else {
+								// Not escalated to $this->errors/return -1 on purpose: a negative return here
+								// would make Facture::setPaid() roll back the payment it just recorded (see
+								// compta/facture/class/facture.class.php) - a platform notification failure
+								// must never undo a real payment. dol_syslog is the only channel that reliably
+								// surfaces this outside an interactive session (cron, API, bank import, ...),
+								// since setEventMessage() only shows up on the next HTML page render.
+								dol_syslog(__METHOD__ . ' Failed to send paid status (212) to platform for invoice id=' . $object->id . ' : ' . $result['message'], LOG_ERR);
 								setEventMessage($langs->trans("ModuleEInvoicingName").' : '.$result['message'], 'errors');
 							}
 						}


### PR DESCRIPTION
When sendStatusMessage(212) failed to report a paid invoice to the e-invoicing platform, the only trace was setEventMessage(), which is only visible on the next interactive HTML page render - invisible for a payment recorded via cron, API, or bank reconciliation import.

Deliberately NOT mirroring the $this->errors[] + return -1 pattern used by the other blocks of this trigger: BILL_PAYED fires from Facture::setPaid() AFTER the payment UPDATE has already run, and a negative trigger return there makes setPaid() roll back that UPDATE (see compta/facture/class/facture.class.php:3358-3376). A platform notification failure must never undo a real recorded payment, so the existing non-blocking behavior is kept; only proper logging is added.