### PR TITLE
FIX #375 : Transmit the unit price with the accuracy the norm allows

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -61,6 +61,29 @@ class CIIProtocol extends AbstractProtocol
 	protected const BUILD_XML_PROFILE = 'EN16931';
 
 	/**
+	 * Maximum number of decimals allowed for the unit prices: Item net price (BT-146),
+	 * Item price discount (BT-147) and Item gross price (BT-148).
+	 *
+	 * EN 16931 sets no limit on these (BT-146 only carries BR-26 and BR-27), but the French
+	 * CTC layer does: rule BR-FR-DEC-03 of the FNFE-MPE CTC-FR Schematron rejects, with a
+	 * "fatal" flag, any value matching more than 6 decimals ('^[-]?\d{1,19}(\.\d{1,6})?$').
+	 * Note this is NOT the 2 decimals limit of the amounts (BR-DEC-* / BR-FR-DEC-01): a unit
+	 * price is not an amount, and no rule checks that the line net amount (BT-131) derives
+	 * arithmetically from the unit price.
+	 *
+	 * @const int
+	 */
+	protected const MAX_DECIMALS_UNIT_PRICE = 6;
+
+	/**
+	 * Maximum number of decimals allowed for the quantities: Invoiced quantity (BT-129) and
+	 * Item price base quantity (BT-149), per rule BR-FR-DEC-02 of the CTC-FR Schematron ("fatal").
+	 *
+	 * @const int
+	 */
+	protected const MAX_DECIMALS_QUANTITY = 4;
+
+	/**
 	 * @var array<string,string>
 	 */
 	protected $invoiceTemplate;
@@ -68,6 +91,23 @@ class CIIProtocol extends AbstractProtocol
 	 * @var array<string,null|false|int|string|array>
 	 */
 	protected $lineTemplate;
+	/**
+	 * Return the number of decimals to use for a unit price (BT-146, BT-147, BT-148).
+	 *
+	 * Follows the Dolibarr unit price accuracy, so a price is transmitted as accurately as it is
+	 * stored, but never above what the norm accepts (see self::MAX_DECIMALS_UNIT_PRICE): an
+	 * instance configured with a higher accuracy would otherwise produce invoices rejected by the
+	 * Access Point. Never goes below 2, which is the accuracy of an amount.
+	 *
+	 * @return	int							Number of decimals
+	 */
+	protected static function getUnitPriceDecimals()
+	{
+		$decimals = getDolGlobalInt('MAIN_MAX_DECIMALS_UNIT', 5);
+
+		return max(2, min($decimals, self::MAX_DECIMALS_UNIT_PRICE));
+	}
+
 	/**
 	 * Initialize available protocols.
 	 *
@@ -2000,21 +2040,21 @@ class CIIProtocol extends AbstractProtocol
 		if (isset($line['grosspriceamount'])) {
 			$gross = $doc->createElement('ram:GrossPriceProductTradePrice');
 			$price->appendChild($gross);
-			$gross->appendChild($doc->createElement('ram:ChargeAmount', number_format($line['grosspriceamount'], 2, '.', '')));
+			$gross->appendChild($doc->createElement('ram:ChargeAmount', number_format($line['grosspriceamount'], self::getUnitPriceDecimals(), '.', '')));
 		}
 
 		// Mandatory by Factur-X, EN 16931
 		// This is the unit price excluding tax. If it does not contains the discount, the discount must be declared into AllowanceCharge.
 		$net = $doc->createElement('ram:NetPriceProductTradePrice');
 		$price->appendChild($net);
-		$net->appendChild($doc->createElement('ram:ChargeAmount', number_format($line['netpriceamount'], 2, '.', '')));
+		$net->appendChild($doc->createElement('ram:ChargeAmount', number_format($line['netpriceamount'], self::getUnitPriceDecimals(), '.', '')));
 
 
 		// Quantity
 		$deliv = $doc->createElement('ram:SpecifiedLineTradeDelivery');
 		$el->appendChild($deliv);
 
-		$qty = $doc->createElement('ram:BilledQuantity', number_format($line['billedquantity'], 2, '.', ''));
+		$qty = $doc->createElement('ram:BilledQuantity', number_format($line['billedquantity'], self::MAX_DECIMALS_QUANTITY, '.', ''));
 		$qty->setAttribute('unitCode', $line['billedquantityunitcode']);
 		$deliv->appendChild($qty);
 

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -36,6 +36,7 @@ use horstoeko\zugferd\codelists\ZugferdVatCategoryCodes;
 use horstoeko\zugferd\codelists\ZugferdVatTypeCodes;
 use horstoeko\zugferd\ZugferdDocumentBuilder;
 use horstoeko\zugferd\ZugferdProfiles;
+use horstoeko\zugferd\ZugferdSettings;
 use horstoeko\zugferd\ZugferdDocumentPdfBuilder;
 use horstoeko\zugferd\ZugferdDocumentValidator;
 use horstoeko\zugferd\ZugferdDocumentPdfReader;
@@ -75,6 +76,35 @@ class FacturXProtocol extends CIIProtocol
 
 	/** @const string The profile used to generate XML */
 	protected const BUILD_XML_PROFILE = 'EXTENDED';
+
+	/** @const string Path of the line unit price nodes, relative to the line item node */
+	private const NODE_LINE_ITEM = '/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem';
+
+	/**
+	 * Tell the lib how many decimals the norm allows on the nodes where its default of 2 is wrong.
+	 *
+	 * The lib serializes every AmountType and QuantityType with 2 decimals unless a node is
+	 * declared here. That default is right for the amounts, but not for the unit prices
+	 * (BT-146/BT-148, up to 6 decimals) nor for the invoiced quantity (BT-129, up to 4): rounding
+	 * those to 2 loses the accuracy the receiver needs to recalculate the line amount.
+	 *
+	 * @return	void
+	 */
+	protected static function applyNormDecimalPlaces()
+	{
+		ZugferdSettings::addSpecialDecimalPlacesMap(
+			self::NODE_LINE_ITEM . '/ram:SpecifiedLineTradeAgreement/ram:NetPriceProductTradePrice/ram:ChargeAmount',
+			self::getUnitPriceDecimals()
+		);
+		ZugferdSettings::addSpecialDecimalPlacesMap(
+			self::NODE_LINE_ITEM . '/ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:ChargeAmount',
+			self::getUnitPriceDecimals()
+		);
+		ZugferdSettings::addSpecialDecimalPlacesMap(
+			self::NODE_LINE_ITEM . '/ram:SpecifiedLineTradeDelivery/ram:BilledQuantity',
+			self::MAX_DECIMALS_QUANTITY
+		);
+	}
 
 	/**
 	 * Generate the XML content for a given invoice according to the Factur-X standard.
@@ -266,6 +296,11 @@ class FacturXProtocol extends CIIProtocol
 			// =====================================================================
 			// Use horstoeko lib to build the XML
 			// =====================================================================
+
+			// The lib serializes every amount and quantity with 2 decimals, which is the accuracy of an
+			// amount, not of a unit price: it would truncate the unit price and make the receiver
+			// recalculate a wrong line amount. Ask for the accuracy the norm allows on these nodes.
+			self::applyNormDecimalPlaces();
 
 			// Initialize ZugferdDocumentBuilder (FacturX XML)
 			dol_syslog(get_class($this) . '::executeHooks create new XML document based on PROFILE_EN16931 (CIUS-FR)');


### PR DESCRIPTION
Closes #375

## Problem

Both generation paths wrote the unit price with **2 decimals**, which is the accuracy of an *amount*, not of a *unit price*.

With the figures from the issue: a price of `0.08334` was emitted as `0.08`, so the receiver recalculated the line amount as `160.21 x 0.08 = 12.82` instead of `13.35`. The invoice total and the VAT were wrong as well. Nothing rejected the invoice: it was silently corrupted.

## What the norm actually says

**EN 16931 sets no decimal limit on the Item net price (BT-146).** In the Factur-X Schematron (all four profiles), BT-146 only carries `BR-26` (must be present) and `BR-27` (must not be negative). The `BR-DEC-*` rules that impose 2 decimals all target **amounts** (BT-92/93, BT-99/100, BT-106..117, BT-131, BT-136/137, BT-141/142). The XSD type `udt:AmountType` is an unrestricted `xs:decimal`.

Notably, **no rule checks that the line net amount (BT-131) derives arithmetically from the unit price**, so a 6 decimals price alongside a 2 decimals line amount is compliant. That is the nominal case.

**The limit that does exist is French.** In the FNFE-MPE CTC-FR Schematron (v1.4.0, 2026-07-13), rule `BR-FR-DEC-03` applies to `.../ram:NetPriceProductTradePrice/ram:ChargeAmount` with `flag="fatal"`:

```
matches($amount, ^[-]?\d{1,19}(\.\d{1,6})?$)
```

So: **max 6 decimals** on BT-146/BT-147/BT-148. The sibling rule `BR-FR-DEC-02` caps the invoiced quantity (BT-129) and the price base quantity (BT-149) at **4 decimals**, also fatal.

## Solution

Follow the Dolibarr unit price accuracy (`MAIN_MAX_DECIMALS_UNIT`), **clamped to what the norm accepts**. Emitting the raw value would trade a truncation bug for a fatal rejection on any instance configured above 6 decimals, so the clamp is load-bearing rather than defensive.

`BilledQuantity` (BT-129) had the same defect and is raised from 2 to the 4 decimals the norm allows.

The Factur-X path needed a **different fix for the same defect**: it already passed the raw float, but the lib serializes every `AmountType` / `QuantityType` with 2 decimals unless the node is declared in `ZugferdSettings`' special decimal places map, which the module never configured. This is precisely the use case that API exists for.

BT-147 needs no change: the CII writer never emits `AppliedTradeAllowanceCharge`.

## Tests

On a test instance (Dolibarr 23, PHP 8.4), using the figures from the issue:

- **CII path** (through the real `buildLineItem()`): `<ram:ChargeAmount>0.083340</ram:ChargeAmount>`, `<ram:BilledQuantity unitCode="H87">160.2100</ram:BilledQuantity>`, and `<ram:LineTotalAmount>13.35</ram:LineTotalAmount>` still at 2 decimals.
- **Factur-X path** (through the real lib serializer): same three values, which also confirms the declared node paths match what the serializer emits.
- **Conformance**: each emitted value checked against the regexes copied verbatim from the CTC-FR Schematron. BT-146 and BT-148 pass `BR-FR-DEC-03`, BT-129 passes `BR-FR-DEC-02`, BT-131 passes `BR-FR-DEC-01`.
- **Clamp**: at `MAIN_MAX_DECIMALS_UNIT` = 0 / 2 / 5 / 6 / 8, the emitted accuracy is 2 / 2 / 5 / 6 / 6. The unclamped value an instance at 8 would produce (`0.08334000`) is confirmed to be a fatal reject, which is what the clamp prevents.

`php -l` and phpcs (`dolics`) are clean.