### PR TITLE
FIX #405 [einvoicing]: d4d_chorus_id computed formula floods PHP warnings and locks the field

### DIFF
--- a/einvoicing/core/modules/modEInvoicing.class.php
+++ b/einvoicing/core/modules/modEInvoicing.class.php
@@ -608,7 +608,9 @@ class modEInvoicing extends DolibarrModules
 		$result = $extrafields->addExtraField('d4d_service_code', $langs->trans('ChorusServiceCode'), 'varchar', 95026, '100', 'facture', 0, 0, '', '', 1, '', '1', '0', '', '', 'einvoicing@einvoicing', 'getDolGlobalInt("EINVOICING_USE_CHORUS")', 0, 1);
 		$result = $extrafields->addExtraField('d4d_contract_number', $langs->trans('ChorusContractNumber'), 'varchar', 95028, '50', 'facture', 0, 0, '', '', 1, '', '1', '0', '', '', 'einvoicing@einvoicing', 'getDolGlobalInt("EINVOICING_USE_CHORUS")', 0, 1);
 		$result = $extrafields->addExtraField('d4d_promise_code', $langs->trans('ChorusPromiseCode'), 'varchar', 95030, '50', 'facture', 0, 0, '', '', 1, '', '1', '0', '', '', 'einvoicing@einvoicing', 'getDolGlobalInt("EINVOICING_USE_CHORUS")', 0, 1);
-		$result = $extrafields->addExtraField('d4d_chorus_id', $langs->trans('ChorusId'), 'varchar', 95032, '36', 'facture', 0, 0, '', '', 1, '', '1', '0', '$object->array_options["options_chorus_id"]', '', 'einvoicing@einvoicing', 'getDolGlobalInt("EINVOICING_USE_CHORUS")', 0, 1);
+		// No computed formula here: the field must stay editable (see openDSI note below). A formula
+		// pointing at options_chorus_id also warns on every render, that extrafield belongs to openDSI.
+		$result = $extrafields->addExtraField('d4d_chorus_id', $langs->trans('ChorusId'), 'varchar', 95032, '36', 'facture', 0, 0, '', '', 1, '', '1', '0', '', '', 'einvoicing@einvoicing', 'getDolGlobalInt("EINVOICING_USE_CHORUS")', 0, 1);
 
 		// Same fields for orders
 		$result = $extrafields->addExtraField('d4d_separator', $langs->trans('ChorusSeparator'), 'separate', 95042, '', 'commande', 0, 1, '', $param, 1, '', '1', '0', '', '', 'einvoicing@einvoicing', 'getDolGlobalInt("EINVOICING_USE_CHORUS")');
@@ -621,7 +623,10 @@ class modEInvoicing extends DolibarrModules
 			$sql,
 			array(
 				"UPDATE " . MAIN_DB_PREFIX . "extrafields SET enabled='getDolGlobalInt(\"EINVOICING_USE_CHORUS\")' WHERE enabled = '\$conf->einvoicing->enabled'",
-				"UPDATE " . MAIN_DB_PREFIX . "extrafields SET enabled='getDolGlobalInt(\"EINVOICING_USE_CHORUS\")' WHERE enabled = '\$conf->global->EINVOICING_USE_CHORUS'"
+				"UPDATE " . MAIN_DB_PREFIX . "extrafields SET enabled='getDolGlobalInt(\"EINVOICING_USE_CHORUS\")' WHERE enabled = '\$conf->global->EINVOICING_USE_CHORUS'",
+				// Drop the stale computed formula on d4d_chorus_id: it targets options_chorus_id (openDSI),
+				// which raises a PHP warning on every invoice render and makes the field read-only.
+				"UPDATE " . MAIN_DB_PREFIX . "extrafields SET fieldcomputed = '' WHERE name = 'd4d_chorus_id' AND fieldcomputed LIKE '%options_chorus_id%'"
 			)
 		);
 
@@ -630,11 +635,11 @@ class modEInvoicing extends DolibarrModules
 			'd4d_chorus_id', //$attrname
 			$langs->trans('ChorusId'), //$label
 			'varchar', //$type
-			'95050', //$length
+			'36', //$length
 			'facture', //$elementtype
 			0, //$unique
 			0, //$required
-			1112, //$pos
+			95032, //$pos
 			array(), //$param
 			1, //$alwayseditable
 			'', //$perms


### PR DESCRIPTION
Fixes #405.

The `d4d_chorus_id` invoice extrafield is declared with the computed formula `$object->array_options["options_chorus_id"]`. That key never exists: the field created here is `d4d_chorus_id` (so `options_d4d_chorus_id`), while `chorus_id` belongs to the **openDSI** module. On any install without openDSI, `dol_eval()` raises `Undefined array key "options_chorus_id"` on every invoice card, list row and ajax tooltip, and the field stays read-only because it is flagged as computed.

The `$extrafields->update()` block right below was written to fix exactly that — its comment says *"il faut pouvoir éditer le champ ChorusId"* — but its `$length` and `$pos` arguments are swapped against the core signature. It passes `'95050'` as the varchar length, so `DDLUpdateField()` fails on `ALTER TABLE ... varchar(95050)` (`ERROR 1074: Column length too big, max = 16383`) and `update()` returns `-1` before ever reaching `update_label()`. The repair has never run.

Confirmed on a live install: the `llx_extrafields` row carries `pos=95032, size=36` (the `addExtraField()` values, not the `pos=1112, size=95050` the `update()` would have written) and the column is still `varchar(36)`.

### Changes

* drop the bogus computed formula from `addExtraField()` — `alwayseditable` is already `1` there, so removing the formula is what actually makes the field editable;
* pass the correct `length` (`36`) and `pos` (`95032`, consistent with `addExtraField()`) to `update()` so the call can run instead of aborting;
* add one migration statement, next to the existing "fix condition of extrafields for old installations" block, clearing the stale formula on installations where the row is already in database.

### Testing

Reproduced and verified on Dolibarr 23.0.3 / PHP 8.4 / MariaDB 11.4.7, module enabled with `EINVOICING_USE_CHORUS=1` and no openDSI:

* before: warning raised on every invoice render, field read-only;
* after: `showOutputField('d4d_chorus_id', ...)` renders with an empty formula and no warning; field editable.

The `ERROR 1074` rejection of `varchar(95050)` was checked directly against the database rather than assumed.

`phpcs` with `dev/setup/codesniffer/ruleset.xml` and `php -l` are both clean on the modified file.
