### PR TITLE
FIX #354 [einvoicing]: add missing extlinks columns on module-only upgrades

### DIFF
--- a/einvoicing/sql/llx_einvoicing_extlinks.sql
+++ b/einvoicing/sql/llx_einvoicing_extlinks.sql
@@ -32,3 +32,17 @@ CREATE TABLE llx_einvoicing_extlinks (
 	ap_precheck_result text,				-- Result/details of the PDP pre-check
 	override_routing_id varchar(255)		-- Optional routing ID override for this specific invoice (overrides thirdparty default routing)
 ) ENGINE = innodb;
+
+-- Migrations for installations created before these columns existed.
+-- The CREATE TABLE above is a no-op on an existing table, and dolibarr_allversions.sql is played
+-- only when the Dolibarr core itself is upgraded, never on a module-only upgrade. Without the
+-- statements below, such an installation keeps a table missing these columns while the code already
+-- selects and inserts them, which breaks any invoice creation with
+-- "Unknown column 'ap_precheck_status' in 'field list'" (see issue #354).
+-- These are replayed at each module activation: _load_tables() runs every llx_*.sql file, and
+-- run_sql() accepts DB_ERROR_COLUMN_ALREADY_EXISTS as a non blocking error, so they are idempotent.
+-- Keep them in sync with dolibarr_allversions.sql.
+ALTER TABLE llx_einvoicing_extlinks ADD COLUMN provider_sender_routing_id varchar(50) NULL;
+ALTER TABLE llx_einvoicing_extlinks ADD COLUMN ap_precheck_status varchar(50) DEFAULT NULL;
+ALTER TABLE llx_einvoicing_extlinks ADD COLUMN ap_precheck_result text DEFAULT NULL;
+ALTER TABLE llx_einvoicing_extlinks ADD COLUMN override_routing_id varchar(255) NULL DEFAULT NULL;


### PR DESCRIPTION
Fixes #354.

An installation created before 2026-06-29 (`dceb50d`, which introduced the Access Point pre-check) has an `llx_einvoicing_extlinks` table without `ap_precheck_status` / `ap_precheck_result`, while the code already selects and inserts them unconditionally:

* `einvoicing/class/einvoicing.class.php:2029` — SELECT list of `fetchLastknownInvoiceStatus()`
* `einvoicing/class/einvoicing.class.php:2283` — INSERT column list of `insertOrUpdateExtLink()`

Any invoice creation then fails with `Unknown column 'ap_precheck_status' in 'field list'`: the `BILL_CREATE` trigger gets `-1` from `setEInvoiceStatus()` and returns `-1`, so `Facture::create()` rolls back. That is why the reporter's recurring-invoice job stopped and why disabling the module made it work again.

Worth noting for the issue: **this is not cron specific**. Creating an invoice from the web UI fails identically on such an install — the reporter simply only creates invoices through the scheduled job.

### Why no migration reaches these installs today

* the `CREATE TABLE` in this file is a no-op on an existing table;
* `sql/dolibarr_allversions.sql` does carry the `ALTER` (added in `3349a7b`), but core plays that file only from the Dolibarr upgrade wizard (`install/upgrade.php`), so it never runs on a module-only upgrade;
* `sql/update_v1.0.3.sql` is referenced by no code at all;
* `DolibarrModules::_load_tables()` only runs files whose name starts with `llx_`.

So an existing install currently has **no in-product way** to obtain these columns — not even by disabling and re-enabling the module. Only a manual `ALTER` or a full core upgrade fixes it.

### Change

Put the `ALTER` statements in `llx_einvoicing_extlinks.sql`, which `_load_tables()` does replay at every module activation. `override_routing_id` and `provider_sender_routing_id` are included: they have the same latent defect, just not reported yet.

Affected users need one disable/re-enable of the module — worth mentioning when closing the issue.

### Testing

* Reproduced on a scratch database holding the pre-`dceb50d` schema: the module's own SELECT fails with `Unknown column ... `. After the four `ALTER`, the same query passes.
* Idempotency, which matters because `init()` returns `-1` on SQL error and would break activation: replaying the statements raises MySQL `1060`, mapped to `DB_ERROR_COLUMN_ALREADY_EXISTS` by `core/db/mysqli.class.php:561`, and that code is in the default `$okerrors` of `run_sql()` (`core/lib/admin.lib.php:501`). PostgreSQL maps `42701` to the same code, so this is portable.
* On a real Dolibarr 23.0.3 / PHP 8.4 / MariaDB 11.4.7 instance: ran `modEInvoicing::init()` twice, returned `1` both times, table left intact.
* The `test/phpunit/SupplierInvoiceHelperTest.php` suite stays green (11/11).
