### PR TITLE
test(einvoicing): do not assume third party id 1 exists in the supplier invoice fixture

### DIFF
--- a/einvoicing/test/phpunit/SupplierInvoiceHelperTest.php
+++ b/einvoicing/test/phpunit/SupplierInvoiceHelperTest.php
@@ -79,10 +79,37 @@ class SupplierInvoiceHelperTest extends CommonClassTest
 		$localobject = new FactureFournisseur($db);
 		$localobject->initAsSpecimen();
 		$localobject->ref_supplier = 'SUPPLIER_REF_SPECIMEN_' . uniqid();
+		// initAsSpecimen() hardcodes socid = 1, which only exists on an instance still carrying the
+		// demo data. Anywhere else the insert fails on the fk_facture_fourn_fk_soc foreign key, so
+		// resolve an existing third party instead of assuming that id.
+		$localobject->socid = $this->getAnyThirdpartyId();
 		$result = $localobject->create($user);
 		$this->assertGreaterThan(0, $result, $localobject->errorsToString());
 
 		return $localobject;
+	}
+
+	/**
+	 * Return the id of any existing third party, so the specimen fixtures do not depend on the
+	 * demo data being present.
+	 *
+	 * @return int	Id of an existing third party
+	 */
+	private function getAnyThirdpartyId()
+	{
+		global $db;
+
+		$sql = "SELECT rowid FROM " . MAIN_DB_PREFIX . "societe";
+		$sql .= " WHERE entity IN (" . getEntity('societe') . ")";
+		$sql .= $db->plimit(1);
+
+		$resql = $db->query($sql);
+		$this->assertNotEquals(false, $resql, 'Cannot query third parties: ' . $db->lasterror());
+
+		$obj = $db->fetch_object($resql);
+		$this->assertNotEquals(null, $obj, 'No third party in database, cannot build the fixture');
+
+		return (int) $obj->rowid;
 	}
 
 	/**


### PR DESCRIPTION
No issue for this one — found while running the suite against a real instance.

`FactureFournisseur::initAsSpecimen()` hardcodes `socid = 1`. That id only exists on an instance still carrying the Dolibarr demo data. On any other instance (mine starts at `rowid = 2`), `create()` fails on the `fk_facture_fourn_fk_soc` foreign key and **6 of the 11 tests** error out.

The failure is also opaque: `create()` returns `-2`, so the assertion reads

```
Failed asserting that -2 is greater than 0.
```

and the actual cause — the foreign key — only shows up in the message body, easily missed.

### Change

Resolve any existing third party for the fixture instead of assuming id 1. Entity-scoped via `getEntity('societe')`, and it asserts if the database has no third party at all, so a genuinely empty instance still fails with a clear message rather than a foreign key error.

### Testing

Against Dolibarr 23.0.3 / PHP 8.4 / MariaDB 11.4.7, PHPUnit 9.6:

* before: `Tests: 11, Assertions: 12, Failures: 6`
* after: `OK (11 tests, 47 assertions)`

Note for anyone running this suite: the Dolibarr core test base class `CommonClassTest` is not compatible with PHPUnit 11 (`onNotSuccessfulTest(): never`), so PHPUnit 9 is needed.
