### PR TITLE
FIX : Replace getDolGlobalBool() unavailable before Dolibarr 21

### DIFF
--- a/einvoicing/admin/setup_options.php
+++ b/einvoicing/admin/setup_options.php
@@ -337,7 +337,7 @@ if (!getDolGlobalString('EINVOICING_DISABLE_SYNC_AP_TO_DOLI')) {
 	$item->fieldAttr['placeholder'] = $langs->transnoentities('Hours');
 	$item->cssClass = 'maxwidth100';
 
-	if (getDolGlobalBool('EINVOICING_SUPPLIER_INVOICE_CHECK_CONSISTENCY_ON_VALIDATION_AVAILABLE')) {
+	if (getDolGlobalString('EINVOICING_SUPPLIER_INVOICE_CHECK_CONSISTENCY_ON_VALIDATION_AVAILABLE')) {
 		// Setup conf to enable or not the consistency check on supplier invoice validation
 		$item = $formSetup->newItem('EINVOICING_SUPPLIER_INVOICE_CHECK_CONSISTENCY_ON_VALIDATION');
 		$item->helpText = $langs->transnoentities('EINVOICING_SUPPLIER_INVOICE_CHECK_CONSISTENCY_ON_VALIDATION_HELP');


### PR DESCRIPTION
getDolGlobalBool() was only introduced in Dolibarr core 21.0.0, causing a fatal "Call to undefined function" (HTTP 500) on any 18/19/20 install. The module declares Dolibarr 18 as its minimum supported version. Use getDolGlobalString(), the convention already used for every other boolean-style global check in this file.