### PR TITLE
Use Converted instead of Original for supplier invoice retrieval

### DIFF
--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -1745,7 +1745,7 @@ class SuperPDPProvider extends AbstractPDPProvider
 
 				// Retrieve Original file
 				$receivedFile = null;
-				$flowResponse = $this->fetchFlowData($flowId, 'Original', 'get_flow_for_supplier_invoice');
+				$flowResponse = $this->fetchFlowData($flowId, 'Converted', 'get_flow_for_supplier_invoice');
 
 				if ($flowResponse['status_code'] != 200) {
 					return array('res' => -1, 'message' => "ERROR_FLOW_GETORIG Failed to retrieve 'Original' document for SupplierInvoice flow (flowId: " . $flowId . ")" . (empty($flowResponse['errorMessage']) ? '' : ' - ' . $flowResponse['errorMessage']));
@@ -1762,7 +1762,7 @@ class SuperPDPProvider extends AbstractPDPProvider
 				$exchangeProtocol = $tmpProtocolManager->getProtocol($detectedProtocol);
 				// if protocol not supported (like ubl), we skeep it
 				if (empty($exchangeProtocol)) {
-					return array('res' => 0, 'message' => "ERROR_FLOW_NOT_SUPPORTED_PROTOCOL detected protocol ".$detectedProtocol." not supported for flowId: " . $flowId);
+					return array('res' => -1, 'message' => "ERROR_FLOW_NOT_SUPPORTED_PROTOCOL detected protocol ".$detectedProtocol." not supported for flowId: " . $flowId);
 				}
 
 				$exceptionmessage = '';


### PR DESCRIPTION
- Use Converted instead of Original to retrieve supplier invoices with SuperPDP.
- Raise an error instead of a warning in case of a flow with an unsupported format.