### PR TITLE
[Einvoicing] Force protocol to manage parseInvoice methods

### DIFF
--- a/einvoicing/class/helpers/SupplierInvoiceHelper.class.php
+++ b/einvoicing/class/helpers/SupplierInvoiceHelper.class.php
@@ -90,14 +90,7 @@ class SupplierInvoiceHelper
 		$protocol = $protocolManager->getProtocol($detectedProtocolName);
 
 		// Extract XML header data
-		switch ($detectedProtocolName) {
-			case 'CII':
-				$parsedHeader = $protocol->parseInvoiceHeader($xmlData);
-				break;
-				// Another format can be added here
-			default:
-				throw new Exception('Format ' . $detectedProtocolName . ' not available for comparison');
-		}
+		$parsedHeader = $protocol->parseInvoiceHeader($xmlData);
 
 		// Currency
 		$currencyCode = $dolSupplierInvoice->multicurrency_code ?? $conf->currency;

--- a/einvoicing/class/protocols/AbstractProtocol.class.php
+++ b/einvoicing/class/protocols/AbstractProtocol.class.php
@@ -118,6 +118,22 @@ abstract class AbstractProtocol
 	abstract public function generateSampleInvoice($einvoicing, $thirdpartySeller = null, $thirdpartyBuyer = null, $options = array());
 
 	/**
+	 * Parse the invoice header from raw file content.
+	 *
+	 * @param  string $rawContent Raw file content
+	 * @return array<string,float|string|array>
+	 */
+	abstract public function parseInvoiceHeader(string $rawContent);
+
+	/**
+	 * Parse all invoice line items from raw file content.
+	 *
+	 * @param  string $rawContent Raw file content
+	 * @return array<int,array<string,mixed>>
+	 */
+	abstract public function parseInvoiceLines(string $rawContent);
+
+	/**
 	 * Remove attachment nodes to get a smaller XML
 	 * @param string $xmlData The XML data to process
 	 * @return string Cleaned XML

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -1305,12 +1305,12 @@ class CIIProtocol extends AbstractProtocol
 	 *   '__MULTI__<xpath>'     → returns array of child node data
 	 *   '__ATTRPAIRS__<xpath>' → returns ['schemeID' => 'value', …]
 	 *
-	 * @param  string $xml Raw XML content
-	 * @return array<string,float|string>|false
+	 * @param  string $rawContent Raw XML content
+	 * @return array<string,float|string|array>
 	 */
-	public function parseInvoiceHeader($xml)
+	public function parseInvoiceHeader(string $rawContent)
 	{
-		list(, $xpath) = $this->initXPath($xml);
+		list(, $xpath) = $this->initXPath($rawContent);
 
 		$data = [];
 
@@ -1355,12 +1355,13 @@ class CIIProtocol extends AbstractProtocol
 	/**
 	 * Parse all invoice line items from CII XML.
 	 *
-	 * @param  string $xml Raw XML content
+	 * @param  string $rawContent Raw file content
 	 * @return array<int,array<string,null|bool|float|string|array<mixed>>>
 	 */
-	public function parseInvoiceLines($xml)
+	public function parseInvoiceLines(string $rawContent)
 	{
-		list(, $xpath) = $this->initXPath($xml);
+		// $rawContent is XML content
+		list(, $xpath) = $this->initXPath($rawContent);
 
 		// Grab header documentno once so we can fill parentDocumentNo on each line
 		$parentDocNo = $this->getXPathValue(

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -1157,13 +1157,8 @@ class FacturXProtocol extends CIIProtocol
 		$parsedHeader = [];
 		$parsedLines = [];
 		if (!getDolGlobalInt('EINVOICING_USE_EXTERNAL_FACTURX_READER')) { // The default is to use the same parser than the CII one.
-			dol_include_once('einvoicing/class/protocols/ProtocolManager.class.php');
-			$ProtocolManager = new ProtocolManager($db);
-			$CII = $ProtocolManager->getProtocol('CII');
-			'@phan-var-force CIIProtocol $CII';
-
-			$parsedHeader = $CII->parseInvoiceHeader($embeddedXml);
-			$parsedLines  = $CII->parseInvoiceLines($embeddedXml);
+			$parsedHeader = $this->parseInvoiceHeader($embeddedXml);
+			$parsedLines  = $this->parseInvoiceLines($embeddedXml);
 		} else {
 			// Use a duplicate parser (for test or dev tests)
 			$document->getDocumentInformation($documentno, $documenttypecode, $documentdate, $invoiceCurrency, $taxCurrency, $documentname, $documentlanguage, $effectiveSpecifiedPeriod);


### PR DESCRIPTION
Any protocol should be able to extract header/global data and lines of e-invoice. This PR ensures any protocol has to implement parseInvoiceHeader/parseInvoiceLines so these methods can be called without to check original protocol.