### PR TITLE
Fix/dolibarr 17 compatibility

### DIFF
--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -373,10 +373,14 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 			if (empty($parameters['context']) || !preg_match('/takepospay/', $parameters['context'])) {
 				print '<!-- Current AP: ' . getDolGlobalString('EINVOICING_PDP') . ' -->';
 				if (!empty($url_button)) {
+					// dolGetButtonAction() only supports an array $url (dropdown mode) since Dolibarr 18;
+					// use our own polyfill below that version.
 					// Pass the visible label as the 1st arg ($label), not the 2nd ($text). On Dolibarr 18/19
 					// the dropdown <a> renders only $label; v22+ falls back to $text when $label is empty,
 					// but to keep behavior consistent across versions we always use $label.
-					if ((float) DOL_VERSION < 22) {
+					if ((float) DOL_VERSION < 18) {
+						print einvoicingDolGetButtonActionDropdown($langs->trans('einvoice'), $url_button);
+					} elseif ((float) DOL_VERSION < 22) {
 						print dolGetButtonAction($langs->trans('einvoice'), '', 'default', $url_button, '', true);
 					} else {
 						print dolGetButtonAction('', $langs->trans('einvoice'), 'default', $url_button, '', true);
@@ -435,7 +439,9 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 					}
 
 					if (!empty($url_button)) {
-						if ((float) DOL_VERSION < 22) {
+						if ((float) DOL_VERSION < 18) {
+							print einvoicingDolGetButtonActionDropdown($langs->trans('einvoice'), $url_button);
+						} elseif ((float) DOL_VERSION < 22) {
 							print dolGetButtonAction($langs->trans('einvoice'), '', 'default', $url_button, '', true);
 						} else {
 							print dolGetButtonAction('', $langs->trans('einvoice'), 'default', $url_button, '', true);

--- a/einvoicing/core/modules/modEInvoicing.class.php
+++ b/einvoicing/core/modules/modEInvoicing.class.php
@@ -153,7 +153,7 @@ class modEInvoicing extends DolibarrModules
 		// Prerequisites
 		$this->phpmin = array(7, 2); // Minimum version of PHP required by module
 		// $this->phpmax = array(8, 0); // Maximum version of PHP required by module
-		$this->need_dolibarr_version = array(18, -3); // Minimum version of Dolibarr required by module
+		$this->need_dolibarr_version = array(17, -3); // Minimum version of Dolibarr required by module
 		// $this->max_dolibarr_version = array(19, -3); // Maximum version of Dolibarr required by module
 		$this->need_javascript_ajax = 0;
 

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -393,7 +393,7 @@ if (!function_exists('einvoicingDolGetButtonActionDropdown')) {
 	 *
 	 *  @param	string	$label			Dropdown toggle visible label
 	 *  @param	array	$urlButtons		List of sub-buttons, same format as the native $url array
-	 *  									(each entry: 'lang', 'enabled', 'perm', 'label', 'url')
+	 *                                  (each entry: 'lang', 'enabled', 'perm', 'label', 'url')
 	 *  @param	array	$params			Extra params (only 'backtopage' is honored, like the core function)
 	 *  @return	string					Dropdown HTML
 	 *  @since	Dolibarr V18

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -384,6 +384,42 @@ if (!function_exists('getDolGlobalFloat')) {
 	}
 }
 
+if (!function_exists('einvoicingDolGetButtonActionDropdown')) {
+	/**
+	 *  Build a dropdown action button from a list of sub-buttons.
+	 *  Polyfill for Dolibarr < 18, where dolGetButtonAction() does not support an array as $url
+	 *  (dropdown mode). Mirrors, line for line, the array-mode HTML built natively by
+	 *  dolGetButtonAction() since Dolibarr 18, so the rendered dropdown is identical.
+	 *
+	 *  @param	string	$label			Dropdown toggle visible label
+	 *  @param	array	$urlButtons		List of sub-buttons, same format as the native $url array
+	 *  									(each entry: 'lang', 'enabled', 'perm', 'label', 'url')
+	 *  @param	array	$params			Extra params (only 'backtopage' is honored, like the core function)
+	 *  @return	string					Dropdown HTML
+	 *  @since	Dolibarr V18
+	 */
+	function einvoicingDolGetButtonActionDropdown($label, array $urlButtons, array $params = array())  // @phan-suppress-current-line PhanRedefineFunction
+	{
+		global $langs;
+
+		$out = '<div class="dropdown inline-block dropdown-holder">';
+		$out .= '<a style="margin-right: auto;" class="dropdown-toggle butAction" data-toggle="dropdown">' . $label . '</a>';
+		$out .= '<div class="dropdown-content">';
+		foreach ($urlButtons as $subbutton) {
+			if (!empty($subbutton['enabled']) && !empty($subbutton['perm'])) {
+				if (!empty($subbutton['lang'])) {
+					$langs->load($subbutton['lang']);
+				}
+				$out .= dolGetButtonAction('', $langs->trans($subbutton['label']), 'default', DOL_URL_ROOT . $subbutton['url'] . (empty($params['backtopage']) ? '' : '&amp;backtopage=' . urlencode($params['backtopage'])), '', 1);
+			}
+		}
+		$out .= '</div>';
+		$out .= '</div>';
+
+		return $out;
+	}
+}
+
 if (!function_exists('dolPrintHTML')) {
 	/**
 	 * Return a string ready to be output on HTML page

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -367,6 +367,23 @@ if (!function_exists("GETPOSTFLOAT")) {
 	}
 }
 
+if (!function_exists('getDolGlobalFloat')) {
+	/**
+	 *  Return a Dolibarr global constant value, converted into float.
+	 *  Provided as a polyfill for Dolibarr < 21, where this function does not exist yet.
+	 *
+	 *  @param  string  $key        Name of the constant
+	 *  @param  float   $default    Default value if constant is not defined
+	 *  @return float               Value converted into float
+	 *  @since  Dolibarr V21
+	 */
+	function getDolGlobalFloat($key, $default = 0)  // @phan-suppress-current-line PhanRedefineFunction
+	{
+		global $conf;
+		return (float) (isset($conf->global->$key) ? $conf->global->$key : $default);
+	}
+}
+
 if (!function_exists('dolPrintHTML')) {
 	/**
 	 * Return a string ready to be output on HTML page


### PR DESCRIPTION
If it's OK for you, this changes are made to declare the module available since v17 of Dolibarr.
It fixes the **getDolGlobalFloat** used even if it's present since v21
It adds the **dolGetButtonAction** working with a dropdown (present since v18)