### PR TITLE
FIX : enforce real permission checks on document_* pages and index

### DIFF
--- a/einvoicing/document_agenda.php
+++ b/einvoicing/document_agenda.php
@@ -146,16 +146,8 @@ if ($id > 0 || !empty($ref)) {
 	$upload_dir = $conf->einvoicing->multidir_output[!empty($object->entity) ? $object->entity : $conf->entity]."/".$object->id;
 }
 
-// There is several ways to check permission.
-// Set $enablepermissioncheck to 1 to enable a minimum low level of checks
-$enablepermissioncheck = getDolGlobalInt('EINVOICING_ENABLE_PERMISSION_CHECK');
-if ($enablepermissioncheck) {
-	$permissiontoread = $user->hasRight('einvoicing', 'read');
-	$permissiontoadd = $user->hasRight('einvoicing', 'write');
-} else {
-	$permissiontoread = 1;
-	$permissiontoadd = 1;
-}
+$permissiontoread = $user->hasRight('einvoicing', 'read');
+$permissiontoadd = $user->hasRight('einvoicing', 'write');
 
 // Security check (enable the most restrictive one)
 //if ($user->socid > 0) accessforbidden();

--- a/einvoicing/document_card.php
+++ b/einvoicing/document_card.php
@@ -145,22 +145,11 @@ if (empty($action) && empty($id) && empty($ref)) {
 // Load object
 include DOL_DOCUMENT_ROOT.'/core/actions_fetchobject.inc.php'; // Must be 'include', not 'include_once'.
 
-// There is several ways to check permission.
-// Set $enablepermissioncheck to 1 to enable a minimum low level of checks
-$enablepermissioncheck = getDolGlobalInt('EINVOICING_ENABLE_PERMISSION_CHECK', 0);
-if ($enablepermissioncheck) {
-	$permissiontoread = $user->hasRight('einvoicing', 'read');
-	$permissiontoadd = $user->hasRight('einvoicing', 'write'); // Used by the include of actions_addupdatedelete.inc.php and actions_lineupdown.inc.php
-	$permissiontodelete = (int) ($user->hasRight('einvoicing', 'delete') || ($permissiontoadd && isset($object->status) && $object->status == $object::STATUS_DRAFT));
-	$permissionnote = $user->hasRight('einvoicing', 'write'); // Used by the include of actions_setnotes.inc.php
-	$permissiondellink = $user->hasRight('einvoicing', 'write'); // Used by the include of actions_dellink.inc.php
-} else {
-	$permissiontoread = 1;
-	$permissiontoadd = 1; // Used by the include of actions_addupdatedelete.inc.php and actions_lineupdown.inc.php
-	$permissiontodelete = 1;
-	$permissionnote = 1;
-	$permissiondellink = 1;
-}
+$permissiontoread = $user->hasRight('einvoicing', 'read');
+$permissiontoadd = $user->hasRight('einvoicing', 'write'); // Used by the include of actions_addupdatedelete.inc.php and actions_lineupdown.inc.php
+$permissiontodelete = (int) ($user->hasRight('einvoicing', 'delete') || ($permissiontoadd && isset($object->status) && $object->status == $object::STATUS_DRAFT));
+$permissionnote = $user->hasRight('einvoicing', 'write'); // Used by the include of actions_setnotes.inc.php
+$permissiondellink = $user->hasRight('einvoicing', 'write'); // Used by the include of actions_dellink.inc.php
 
 $upload_dir = $conf->einvoicing->multidir_output[isset($object->entity) ? $object->entity : 1].'/document';
 

--- a/einvoicing/document_contact.php
+++ b/einvoicing/document_contact.php
@@ -93,16 +93,8 @@ $extrafields->fetch_name_optionals_label($object->table_element);
 // Load object
 include DOL_DOCUMENT_ROOT.'/core/actions_fetchobject.inc.php'; // Must be 'include', not 'include_once'. Include fetch and fetch_thirdparty but not fetch_optionals
 
-// There is several ways to check permission.
-// Set $enablepermissioncheck to 1 to enable a minimum low level of checks
-$enablepermissioncheck = getDolGlobalInt('EINVOICING_ENABLE_PERMISSION_CHECK');
-if ($enablepermissioncheck) {
-	$permissiontoread = $user->hasRight('einvoicing', 'read');
-	$permissiontoadd = $user->hasRight('einvoicing', 'write');
-} else {
-	$permissiontoread = 1;
-	$permissiontoadd = 1;
-}
+$permissiontoread = $user->hasRight('einvoicing', 'read');
+$permissiontoadd = $user->hasRight('einvoicing', 'write');
 
 // Security check (enable the most restrictive one)
 //if ($user->socid > 0) accessforbidden();

--- a/einvoicing/document_document.php
+++ b/einvoicing/document_document.php
@@ -141,16 +141,8 @@ if ($id > 0 || !empty($ref)) {
 }
 
 // Permissions
-// (There are several ways to check permission.)
-// Set $enablepermissioncheck to 1 to enable a minimum low level of checks
-$enablepermissioncheck = getDolGlobalInt('EINVOICING_ENABLE_PERMISSION_CHECK');
-if ($enablepermissioncheck) {
-	$permissiontoread = $user->hasRight('einvoicing', 'read');
-	$permissiontoadd  = $user->hasRight('einvoicing', 'write'); // Used by the include of actions_addupdatedelete.inc.php and actions_linkedfiles.inc.php
-} else {
-	$permissiontoread = 1;
-	$permissiontoadd  = 1;
-}
+$permissiontoread = $user->hasRight('einvoicing', 'read');
+$permissiontoadd  = $user->hasRight('einvoicing', 'write'); // Used by the include of actions_addupdatedelete.inc.php and actions_linkedfiles.inc.php
 
 // Security check (enable the most restrictive one)
 //if ($user->socid > 0) accessforbidden();

--- a/einvoicing/document_list.php
+++ b/einvoicing/document_list.php
@@ -224,18 +224,9 @@ include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_array_fields.tpl.php';
 $object->fields = dol_sort_array($object->fields, 'position');
 $arrayfields = dol_sort_array($arrayfields, 'position');
 
-// There is several ways to check permission.
-// Set $enablepermissioncheck to 1 to enable a minimum low level of checks
-$enablepermissioncheck = getDolGlobalInt('EINVOICING_ENABLE_PERMISSION_CHECK');
-if ($enablepermissioncheck) {
-	$permissiontoread = $user->hasRight('einvoicing', 'read');
-	$permissiontoadd = $user->hasRight('einvoicing', 'write');
-	$permissiontodelete = $user->hasRight('einvoicing', 'delete');
-} else {
-	$permissiontoread = 1;
-	$permissiontoadd = 1;
-	$permissiontodelete = 1;
-}
+$permissiontoread = $user->hasRight('einvoicing', 'read');
+$permissiontoadd = $user->hasRight('einvoicing', 'write');
+$permissiontodelete = $user->hasRight('einvoicing', 'delete');
 
 // Security check (enable the most restrictive one)
 if ($user->socid > 0) {

--- a/einvoicing/document_note.php
+++ b/einvoicing/document_note.php
@@ -118,18 +118,9 @@ if ($id > 0 || !empty($ref)) {
 }
 
 
-// There is several ways to check permission.
-// Set $enablepermissioncheck to 1 to enable a minimum low level of checks
-$enablepermissioncheck = getDolGlobalInt('EINVOICING_ENABLE_PERMISSION_CHECK');
-if ($enablepermissioncheck) {
-	$permissiontoread = $user->hasRight('einvoicing', 'read');
-	$permissiontoadd = $user->hasRight('einvoicing', 'write');
-	$permissionnote = $user->hasRight('einvoicing', 'write'); // Used by the include of actions_setnotes.inc.php
-} else {
-	$permissiontoread = 1;
-	$permissiontoadd = 1;
-	$permissionnote = 1;
-}
+$permissiontoread = $user->hasRight('einvoicing', 'read');
+$permissiontoadd = $user->hasRight('einvoicing', 'write');
+$permissionnote = $user->hasRight('einvoicing', 'write'); // Used by the include of actions_setnotes.inc.php
 
 // Security check (enable the most restrictive one)
 //if ($user->socid > 0) accessforbidden();

--- a/einvoicing/einvoicingindex.php
+++ b/einvoicing/einvoicingindex.php
@@ -92,18 +92,12 @@ if (!empty($user->socid) && $user->socid > 0) {
 //$hookmanager->initHooks(array($object->element.'index'));
 
 // Security check (enable the most restrictive one)
-//if ($user->socid > 0) accessforbidden();
-//if ($user->socid > 0) $socid = $user->socid;
-//if (!isModEnabled('einvoicing')) {
-//	accessforbidden('Module not enabled');
-//}
-//if (! $user->hasRight('einvoicing', 'myobject', 'read')) {
-//	accessforbidden();
-//}
-//restrictedArea($user, 'einvoicing', 0, 'einvoicing_myobject', 'myobject', '', 'rowid');
-//if (empty($user->admin)) {
-//	accessforbidden('Must be admin');
-//}
+if (!isModEnabled('einvoicing')) {
+	accessforbidden('Module not enabled');
+}
+if (!$user->hasRight('einvoicing', 'read')) {
+	accessforbidden();
+}
 
 
 /*


### PR DESCRIPTION
The permission variables on document_card.php, document_list.php, document_agenda.php, document_contact.php, document_document.php and einvoicingindex.php were gated behind EINVOICING_ENABLE_PERMISSION_CHECK, a constant never set anywhere in the module, so any logged-in user had full read/write/delete access regardless of their actual rights. Permissions are now always computed from $user->hasRight('einvoicing', ...), and einvoicingindex.php now enforces isModEnabled()/hasRight() instead of leaving all its access checks commented out.