### PR TITLE
FIX : redact OAuth secrets from API call log and syslog

### DIFF
--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -621,6 +621,67 @@ abstract class AbstractPDPProvider
 	}
 
 	/**
+	 * Keys whose value must never be persisted in clear in the API call log (llx_einvoicing_call),
+	 * whatever request/response they appear in (OAuth token exchanges in particular).
+	 *
+	 * @var array<int,string>
+	 */
+	private const LOGCALL_SENSITIVE_KEYS = array('client_secret', 'access_token', 'refresh_token', 'id_token', 'password');
+
+	/**
+	 * Redact known sensitive fields (@see LOGCALL_SENSITIVE_KEYS) from a value before it is
+	 * persisted in the API call log, whatever its shape: PHP array, application/x-www-form-urlencoded
+	 * string (OAuth token requests), JSON string, or plain text (left untouched in that last case).
+	 *
+	 * @param  array<mixed>|string|null $value Value to redact
+	 * @return array<mixed>|string|null Redacted value, same shape as the input
+	 */
+	private static function redactSensitiveData($value)
+	{
+		if (is_array($value)) {
+			$redacted = array();
+			foreach ($value as $key => $item) {
+				if (is_string($key) && in_array(strtolower($key), self::LOGCALL_SENSITIVE_KEYS, true)) {
+					$redacted[$key] = '[REDACTED]';
+				} else {
+					$redacted[$key] = is_array($item) ? self::redactSensitiveData($item) : $item;
+				}
+			}
+			return $redacted;
+		}
+
+		if (is_string($value)) {
+			// application/x-www-form-urlencoded body, e.g. "grant_type=...&client_secret=..."
+			if (preg_match('/^[a-zA-Z0-9_.\[\]]+=/', $value)) {
+				parse_str($value, $parsed);
+				if (is_array($parsed) && !empty($parsed)) {
+					$changed = false;
+					foreach (self::LOGCALL_SENSITIVE_KEYS as $sensitiveKey) {
+						if (isset($parsed[$sensitiveKey])) {
+							$parsed[$sensitiveKey] = '[REDACTED]';
+							$changed = true;
+						}
+					}
+					if ($changed) {
+						return http_build_query($parsed);
+					}
+				}
+			}
+
+			// JSON body
+			$decoded = json_decode($value, true);
+			if (is_array($decoded)) {
+				$redacted = self::redactSensitiveData($decoded);
+				if ($redacted !== $decoded) {
+					return json_encode($redacted);
+				}
+			}
+		}
+
+		return $value;
+	}
+
+	/**
 	 * Log an API call into llx_einvoicing_call using a SEPARATE database connection.
 	 *
 	 * The call trace must survive even when the caller's main transaction is rolled
@@ -629,6 +690,10 @@ abstract class AbstractPDPProvider
 	 * Writing the log through an independent connection ($dbhistory) decouples it from
 	 * the business transaction, so it is committed whether the action succeeds or fails,
 	 * without ever forcing a commit on the rest. Same approach as the webhook logging.
+	 *
+	 * Request/response payloads are redacted (@see redactSensitiveData()) before being
+	 * persisted: this log is readable by any user with the 'einvoicing' read right, so
+	 * OAuth secrets and tokens must never end up in llx_einvoicing_call in clear.
 	 *
 	 * @param   ?string                     $callType   Functional type of the call (empty/null = do not log)
 	 * @param   string                      $resource   API resource/endpoint (without leading slash)
@@ -653,6 +718,9 @@ abstract class AbstractPDPProvider
 		}
 
 		$dbhistory->begin();
+
+		$params = self::redactSensitiveData($params);
+		$response = self::redactSensitiveData($response);
 
 		$call = new Call($dbhistory);
 		$call->call_id = $call->getNextCallId();

--- a/einvoicing/public/proxy_oauthcallback.php
+++ b/einvoicing/public/proxy_oauthcallback.php
@@ -325,7 +325,7 @@ if (empty($code) && !GETPOST('error')) {
 		// This was a callback request from service, get the token
 		try {
 			//var_dump($apiService);      // OAuth\OAuth2\Service\Generic
-			dol_syslog("We received a code=".$code." or error=".GETPOST('error'));
+			dol_syslog("We received a code=".dol_trunc($code, 5)." or error=".GETPOST('error'));
 
 			if (getDolGlobalString('EINVOICING_SUPERPDP_VIAPARTNER') == 'proxy') {
 				// Ask the token
@@ -376,7 +376,9 @@ if (empty($code) && !GETPOST('error')) {
 
 					//var_dump($origin_redirect_uri);	exit;
 
-					dol_syslog("Redirect now on origin_redirect_uri=".$origin_redirect_uri);
+					// Log only the destination without its query string: the query string carries
+					// the freshly issued access_token/refresh_token and must never reach the logs in clear.
+					dol_syslog("Redirect now on origin_redirect_uri=".strtok($origin_redirect_uri, '?'));
 
 					header('Location: '.$origin_redirect_uri);
 					exit();


### PR DESCRIPTION
logCall() persisted client_secret, access_token and refresh_token in clear into llx_einvoicing_call for every OAuth token exchange, readable by any user with the 'einvoicing' read right. Add redactSensitiveData() to mask known sensitive keys regardless of payload shape (array, urlencoded string, JSON string) before the call is logged.

proxy_oauthcallback.php also logged the full authorization code and the full redirect URL (including the freshly issued access_token/refresh_token in its query string) via dol_syslog. Truncate the code like the rest of the file already does, and log the redirect destination without its query string.