### PR TITLE
FIX : add anti-CSRF state check on via-partner OAuth token return

### DIFF
--- a/einvoicing/admin/setup.php
+++ b/einvoicing/admin/setup.php
@@ -325,9 +325,18 @@ if (GETPOST('error')) {
 
 
 if (GETPOST('accesstoken') && $provider instanceof AbstractPDPProvider) {
-	// We are in the return of an OAUT proxy authorize+token callback
+	// We are in the return of an OAuth proxy authorize+token callback.
+	// The state must match the one we generated when building the "via partner" authorize link
+	// (see SuperPDPProvider::initFormSetup()), otherwise anyone could POST/GET an arbitrary token
+	// here and have it saved as our production PDP credential.
+	if (GETPOST('state', 'restricthtml') !== (isset($_SESSION['einvoicing_superpdp_viapartner_oauth_state']) ? $_SESSION['einvoicing_superpdp_viapartner_oauth_state'] : '')) {
+		setEventMessages($langs->trans('EINVOICING_SUPERPDP_OAUTH_STATE_MISMATCH'), null, 'errors');
+		header("Location: ".$_SERVER["PHP_SELF"]);
+		exit;
+	}
+	unset($_SESSION['einvoicing_superpdp_viapartner_oauth_state']);
 
-	$result = $provider->saveOAuthTokenDB(GETPOST('accesstoken'), GETPOST('refresh_token'), GETPOST('expires_in'));
+	$result = $provider->saveOAuthTokenDB(GETPOST('accesstoken', 'restricthtml'), GETPOST('refresh_token', 'restricthtml'), GETPOSTINT('expires_in'));
 
 	if ($result) {
 		setEventMessages("Token generated successfully", null, 'mesgs');

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -122,6 +122,15 @@ class SuperPDPProvider extends AbstractPDPProvider
 
 		$langs->load("oauth");
 
+		// Anti-CSRF state for the "via partner" (grey-label) authorization flow, checked back in
+		// admin/setup.php against $_SESSION['einvoicing_superpdp_viapartner_oauth_state'] before any
+		// accesstoken/refresh_token returned by the proxy is saved. The 'none-' prefix is kept so the
+		// proxy still parses it as "no scope requested" (see proxy_oauthcallback.php scope handling).
+		// Computed once and reused below so both links built in this method stay consistent (only the
+		// last value written to the session would validate otherwise).
+		$viaPartnerState = 'none-' . bin2hex(random_bytes(16));
+		$_SESSION['einvoicing_superpdp_viapartner_oauth_state'] = $viaPartnerState;
+
 		// Set content of the help page
 		if (getDolGlobalString('EINVOICING_PDP') == 'SUPERPDPViaPartner') {
 			if (getDolGlobalString("EINVOICING_SUPERPDP_VIAPARTNER") != 'proxy') {
@@ -140,7 +149,7 @@ class SuperPDPProvider extends AbstractPDPProvider
 				$urltogeneratetoken = getDolGlobalString('EINVOICING_SUPERPDP_VIAPARTNER_OAUTH_URL');
 				// $urltogeneratetoken .= '?proxy=superpdp&state=none&response_type=code&redirect_uri=' . urlencode(dol_buildpath('/einvoicing/admin/setup.php', 2));
 				$query = [
-					'state' => 'none',
+					'state' => $viaPartnerState,
 					'response_type' => 'code',
 					'redirect_uri' => dol_buildpath('/einvoicing/admin/setup.php', 2)
 				];
@@ -326,7 +335,7 @@ class SuperPDPProvider extends AbstractPDPProvider
 					$urltogeneratetoken = getDolGlobalString('EINVOICING_SUPERPDP_VIAPARTNER_OAUTH_URL');
 					// $urltogeneratetoken .= '?state=none&response_type=code&redirect_uri=' . urlencode(dol_buildpath('/einvoicing/admin/setup.php', 2));
 					$query = [
-						'state' => 'none',
+						'state' => $viaPartnerState,
 						'response_type' => 'code',
 						'redirect_uri' => dol_buildpath('/einvoicing/admin/setup.php', 2)
 					];


### PR DESCRIPTION
The "via partner" (grey-label) authorization link always used the literal state 'none', so admin/setup.php had nothing to verify when receiving accesstoken/refresh_token/expires_in back from the proxy. Any request forging these GET params would be saved as the production PDP credential.

SuperPDPProvider::initFormSetup() now generates a per-page-load random nonce ('none-' prefixed so the proxy still treats it as "no scope requested"), stored in $_SESSION['einvoicing_superpdp_viapartner_oauth_state'] and used consistently in both authorize links it builds. admin/setup.php now checks this state before calling saveOAuthTokenDB(), mirroring the existing check already used for the direct authorization_code flow.