### PR TITLE
fix #441 Update SupplierInvoiceHelper.class.php

### DIFF
--- a/einvoicing/class/helpers/SupplierInvoiceHelper.class.php
+++ b/einvoicing/class/helpers/SupplierInvoiceHelper.class.php
@@ -334,6 +334,7 @@ class SupplierInvoiceHelper
 		$sql = "SELECT rowid, flow_id, provider, xml_data FROM " . $db->prefix() . "einvoicing_document";
 		$sql .= " WHERE fk_element_type = '" . $db->escape('invoice_supplier') . "'";
 		$sql .= " AND fk_element_id = " . (int) $supplierInvoiceId;
+		$sql .= " AND flow_type = '" . $db->escape('SupplierInvoice') . "'";
 		$sql .= " LIMIT 2";
 
 		$resql = $db->query($sql);
@@ -414,6 +415,7 @@ class SupplierInvoiceHelper
 		$sql = "SELECT rowid FROM " . $db->prefix() . "einvoicing_document";
 		$sql .= " WHERE fk_element_type = '" . $db->escape('invoice_supplier') . "'";
 		$sql .= " AND fk_element_id = " . (int) $supplierInvoiceId;
+		$sql .= " AND flow_type = '" . $db->escape('SupplierInvoice') . "'";
 		$sql .= " LIMIT 2";
 
 		$resql = $db->query($sql);


### PR DESCRIPTION
Fix #441 allow only reading original file and not the Life Cycle entries in the DB therefore not creating the duplicate entry in DB