### PR TITLE
FIX : avoid fatal error when supplier invoice matches e-invoice exactly

### DIFF
--- a/einvoicing/class/helpers/SupplierInvoiceHelper.class.php
+++ b/einvoicing/class/helpers/SupplierInvoiceHelper.class.php
@@ -123,6 +123,7 @@ class SupplierInvoiceHelper
 
 		foreach ($calculationRules as $calculationRule => $vatComputeMode) {
 			$details = self::getInvoiceDetailsForComparison($dolSupplierInvoice, $vatComputeMode);
+			$amountErrors[$calculationRule] = [];
 
 			// VAT excl. total
 			if (!self::areAmountsEqual($details['total_ht'], $parsedHeader['lineTotalAmount'])) {


### PR DESCRIPTION
checkDolInvoiceAndEInvoiceConsistency() only pushed into $amountErrors[$calculationRule] on mismatch, so when the current VAT mode had zero discrepancies the array key was never set. The subsequent count($amountErrors['current']) then received null, throwing a fatal TypeError on supplier invoice validation.

Introduced by https://github.com/Dolibarr/dolibarr-community-modules/commit/6fab2831