### PR TITLE
[einvoicing] Load the classes the triggers need outside the module screens

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## 1.0.3
 
+FIX: The triggers no longer fail with "Class EInvoicing / PDPProviderManager not found" when the action
+comes from a context that never went through the module screens (cron, CLI, REST API, bank import).
+
 NEW: When the e-invoicing platform (PDP/PA) confirms the refusal of a received supplier invoice,
 the corresponding Dolibarr supplier invoice is automatically validated then abandoned (with a
 dedicated close code, keeping the refusal and its reason as trace) and is excluded from the

--- a/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
+++ b/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
@@ -25,6 +25,10 @@
 
 require_once DOL_DOCUMENT_ROOT.'/core/triggers/dolibarrtriggers.class.php';
 dol_include_once('einvoicing/class/helpers/SupplierInvoiceHelper.class.php');
+// The classes below happen to be already loaded when the action comes from the module screens, but not
+// when a trigger fires from a context that never went through them: cron, CLI, REST API, bank import...
+dol_include_once('einvoicing/class/einvoicing.class.php');
+dol_include_once('einvoicing/class/providers/PDPProviderManager.class.php');
 
 
 /**


### PR DESCRIPTION
## Problem

`interface_98_modEInvoicing_EInvoicingTriggers.class.php` uses `EInvoicing` and `PDPProviderManager` without including either. They only happen to be loaded when the action comes from the module screens, which have already pulled them in. When an invoice is created or paid from a context that never went through those screens — cron, CLI, REST API, bank import — the trigger fatals:

```
PHP Fatal error: Uncaught Error: Class "PDPProviderManager" not found in
einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php:263
Stack trace:
#0 htdocs/core/class/interfaces.class.php(232): InterfaceEInvoicingTriggers->runTrigger()
```

## Fix

Two `dol_include_once` at the top of the trigger file, next to the one already there for `SupplierInvoiceHelper`.

Found by firing `BILL_SUPPLIER_PAYED` from the command line on a test instance, where the paid status never left because the trigger died first.
