### PR TITLE
FIX #449 : Read the CDAR from the converted document when no original exists

### DIFF
--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -1271,20 +1271,20 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 				*/
 
 				// 2. Read CDAR and update status of linked customer invoice
-				$flowResource = 'flows/' . $flowId;
-				$flowUrlparams = array(
-					'docType' => 'Original', // docType can be 'Metadata', 'Original', 'Converted' or 'ReadableView'
-				);
-				$flowResource .= '?' . http_build_query($flowUrlparams);
-				$flowResponse = $this->callApi(
-					$flowResource,
-					"GET",
-					false,
-					['Accept' => 'application/octet-stream']
-				);
+				// The CDAR is normally read as the "Original" document. Some flows have no original on the
+				// platform, only the converted copy, and the synchronization then stops on that flow and on
+				// every flow behind it with no way to go past it. Both documents carry the same CDAR, so fall
+				// back on the converted one rather than blocking. docType can be 'Metadata', 'Original',
+				// 'Converted' or 'ReadableView'.
+				$flowResponse = $this->fetchFlowData($flowId, 'Original');
 
 				if ($flowResponse['status_code'] != 200) {
-					return array('res' => -1, 'message' => "Failed to retrieve flow details for flowId: " . $flowId);
+					dol_syslog(__METHOD__ . " No 'Original' document for flowId: " . $flowId . " (HTTP " . $flowResponse['status_code'] . "), reading the CDAR from the 'Converted' document instead", LOG_WARNING);
+					$flowResponse = $this->fetchFlowData($flowId, 'Converted');
+				}
+
+				if ($flowResponse['status_code'] != 200) {
+					return array('res' => -1, 'message' => "Failed to retrieve flow details (neither 'Original' nor 'Converted' document) for flowId: " . $flowId);
 				}
 				$cdarXml = $flowResponse['response'];
 


### PR DESCRIPTION
Fixes #449.

## Problem

`EsalinkPDPProvider::syncFlow()` reads the CDAR of a lifecycle flow as the **`Original`** document. Some flows have no original on the platform — only the converted copy — and the call then fails, `syncFlow()` returns `-1`, and the synchronization stops on that flow and on every flow queued behind it. There is no way to get past it from the interface: the reported workaround was to edit the `docType` in the source, run the sync, and put it back.

## What this does

Falls back on the `Converted` document when there is no original, and logs the fallback. Both carry the same CDAR, so nothing is lost. The synchronization only fails when neither document can be read, and its message now says which ones were tried.

The call also goes through `fetchFlowData()` instead of rebuilding the query by hand, like the `SupplierInvoice` case a few lines above already does.

## Testing

`php -l` and `phan --quick` clean. Not exercised against a real EsaLink account (no access here), so a confirmation from someone who can reproduce the original report would be welcome — the change is a fallback, it cannot make a currently working sync fail.
