### PR TITLE
FIX #354 : Do not abort the creation of an invoice when its e-invoice status cannot be recorded

### DIFF
--- a/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
+++ b/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
@@ -136,11 +136,21 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 					$statustouse = $einvoicing->needEInvoiceManagement($object);
 				}
 
-				// When invoice is created
+				// When invoice is created.
+				// A failure here must not abort the creation of the invoice: what is recorded is the
+				// e-invoice status of a draft, which BILL_VALIDATE computes again when the invoice is
+				// validated (an unknown or not-generated status is resolved there). Refusing the
+				// creation instead leaves Dolibarr unable to create any invoice at all -- that is what
+				// a database left un-migrated after a module update does, the module SQL then having a
+				// column the table does not have yet (issue #354). Log it loudly and let the invoice be.
 				$result = $einvoicing->setEInvoiceStatus($object, $statustouse, '');
 				if ($result < 0) {
-					$this->errors = array_merge($this->errors, $einvoicing->errors);
-					return -1;
+					$einvoicingerrors = array_filter(array_merge($einvoicing->errors, array($einvoicing->error)));
+					dol_syslog(
+						get_class($this) . '::runTrigger ' . $action . ' failed to record the e-invoice status of invoice id=' . $object->id
+						. ', the invoice is created anyway: ' . implode(', ', $einvoicingerrors),
+						LOG_ERR
+					);
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #354.

## Problem

The `BILL_CREATE` trigger records the e-invoice status of the new invoice and returns `-1` when that write fails, which aborts the creation of the invoice itself.

A database left un-migrated after a module update is enough to trigger it: the module SQL then writes a column its own table does not have yet — `Unknown column 'ap_precheck_status' in 'field list'` — and Dolibarr can no longer create **any** invoice, by hand or from a recurring template, until the module is disabled. That is exactly what #354 reports (the migration itself is a separate matter, replaying the module SQL fixes it).

## What this does

Logs the failure with its database error and lets the creation through.

What is recorded at that point is the e-invoice status of a *draft*, and `BILL_VALIDATE` computes it again when the invoice is validated — an unknown or not-generated status is resolved there. Losing that row is not worth losing the invoice, all the more so as the module is the one that cannot write to its own table.

`BILL_VALIDATE` is deliberately left as it is: at validation the status is about to matter.

## Testing

`php -l` and `phan --quick` clean.
