### PR TITLE
FIX #462 stop emitting the seller fax number in the generated XML

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -54,6 +54,10 @@ CII, EXTENDED for Factur-X). Setting EXTENDEDFR switches the document to EXTENDE
 profile the French mandate expects, including on the Factur-X path whose PDF/A-3 attachment step
 used to refuse that guideline.
 
+FIX: The seller fax number is no longer written into the generated XML. EN16931 has no business
+term for a fax and the CII syntax binding forbids the element (CII-SR-236), so any instance with a
+fax filled in the company setup was emitting a non-conformant document (issue #462).
+
 NEW: When the e-invoicing platform (PDP/PA) confirms the refusal of a received supplier invoice,
 the corresponding Dolibarr supplier invoice is automatically validated then abandoned (with a
 dedicated close code, keeping the refusal and its reason as trace) and is excluded from the

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -2252,11 +2252,13 @@ class CIIProtocol extends AbstractProtocol
 		// (e.g. specimen seller with a phone but no contact person name).
 		// Skipped in minimal mode: the deliver-to party is a stripped-down copy of the buyer, and the
 		// CII syntax binding forbids a contact there (CII-SR-312), as it does a legal organization.
+		// The fax number is deliberately not part of this list: EN16931 has no business term for it
+		// and the CII syntax binding forbids ram:FaxUniversalCommunication (CII-SR-236 / CII-SR-265),
+		// so a party known only by its fax gets no contact block at all.
 		if (!$minimal
 			&& (!empty($data[$prefix . 'contactpersonname'])
 			|| !empty($data[$prefix . 'contactdepartmentname'])
 			|| !empty($data[$prefix . 'contactphoneno'])
-			|| !empty($data[$prefix . 'contactfaxno'])
 			|| !empty($data[$prefix . 'contactemailaddr']))) {
 			$contact = $doc->createElement('ram:DefinedTradeContact');
 			$node->appendChild($contact);
@@ -2275,11 +2277,9 @@ class CIIProtocol extends AbstractProtocol
 				$phone->appendChild($doc->createElement('ram:CompleteNumber', $data[$prefix . 'contactphoneno']));
 			}
 
-			if (!empty($data[$prefix . 'contactfaxno'])) {
-				$fax = $doc->createElement('ram:FaxUniversalCommunication');
-				$contact->appendChild($fax);
-				$fax->appendChild($doc->createElement('ram:CompleteNumber', $data[$prefix . 'contactfaxno']));
-			}
+			// No ram:FaxUniversalCommunication here on purpose, see the comment above. The
+			// 'contactfaxno' key is still filled and still read back from incoming invoices
+			// (CommonProtocol::...), it is only never written out.
 
 			if (!empty($data[$prefix . 'contactemailaddr'])) {
 				$email = $doc->createElement('ram:EmailURIUniversalCommunication');

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -410,12 +410,14 @@ class FacturXProtocol extends CIIProtocol
 				}
 			}
 
-			// Set Trade Contact details (sale representative)
+			// Set Trade Contact details (sale representative). No fax: EN16931 has no business term
+			// for it and the CII syntax binding forbids ram:FaxUniversalCommunication (CII-SR-236),
+			// same as for the buyer contact below.
 			$facturxpdf->setDocumentSellerContact(
 				$invoiceData['sellercontactpersonname'],
 				"",
 				$invoiceData['sellercontactphoneno'],
-				$invoiceData['sellercontactfaxno'],
+				"",
 				$invoiceData['sellercontactemailaddr']
 			);
 


### PR DESCRIPTION
Fixes #462.

EN16931 has no business term for a fax, and the CII syntax binding forbids `ram:FaxUniversalCommunication` (`CII-SR-236` for the seller, `CII-SR-265` for the buyer). A fax number filled in Home > Setup > Company was enough to emit it — no other configuration involved — so a fair number of instances are producing that element today.

- `CIIProtocol::buildParty()`: the fax node is gone, and the fax no longer counts towards creating the `ram:DefinedTradeContact` wrapper (a party known only by its fax would otherwise get an empty contact block).
- `FacturXProtocol`: the deprecated external builder path passes an empty fax to `setDocumentSellerContact()`, which is already what the buyer contact does two lines below.

The `sellercontactfaxno` key stays: it is still read from *incoming* invoices to fill the thirdparty fax (`CommonProtocol.class.php:610,657,721`). Only the outgoing emission is removed.

### Validation

Same invoice generated by the module on a dev instance, with a fax set on the company, before and after:

| | schematron `EN16931-CII` | `BR-FR-Flux2-CII` | XSD D22B |
|---|---|---|---|
| before | **`CII-SR-236`** | 0 | OK |
| after | 0 | 0 | OK |

The output is now byte-identical to the same invoice generated with no fax configured.
