### PR TITLE
FIX #471 do not emit CategoryTradeTax on a line-level allowance

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -5,6 +5,11 @@
 FIX: The triggers no longer fail with "Class EInvoicing / PDPProviderManager not found" when the action
 comes from a context that never went through the module screens (cron, CLI, REST API, bank import).
 
+FIX: A discount on an invoice line no longer emits a ram:CategoryTradeTax inside its
+allowance block. That element belongs to a document-level allowance or charge and the CII syntax
+binding forbids it on a line (CII-SR-191); the VAT of the discount is already carried by the line
+itself (issue #471).
+
 NEW: When the e-invoicing platform (PDP/PA) confirms the refusal of a received supplier invoice,
 the corresponding Dolibarr supplier invoice is automatically validated then abandoned (with a
 dedicated close code, keeping the refusal and its reason as trace) and is excluded from the

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -2353,6 +2353,9 @@ class CIIProtocol extends AbstractProtocol
 	 * @param string|null       $reasonCode 	Code for the reason (optional, can be used instead of reason or together with reason)
 	 * @param string            $taxCategory 	Tax category code
 	 * @param float             $taxRate 		Tax rate applicable to this discount/charge
+	 * @param bool              $withCategoryTradeTax	Whether to emit ram:CategoryTradeTax. Mandatory on a document-level
+	 *                                                  allowance/charge (BT-95/BT-96, BT-102/BT-103), forbidden on a
+	 *                                                  line-level one (CII-SR-191)
 	 *
 	 * @return \DOMElement
 	 */
@@ -2365,7 +2368,8 @@ class CIIProtocol extends AbstractProtocol
 		$reason = null,
 		$reasonCode = null,
 		$taxCategory = 'S',
-		$taxRate = 20.0
+		$taxRate = 20.0,
+		$withCategoryTradeTax = true
 	) {
 		$node = $doc->createElement('ram:SpecifiedTradeAllowanceCharge');
 
@@ -2400,14 +2404,17 @@ class CIIProtocol extends AbstractProtocol
 			$node->appendChild($doc->createElement('ram:Reason', $reason));
 		}
 
-		// Tax (important Factur-X)
-		$taxNode = $doc->createElement('ram:CategoryTradeTax');
+		// Tax (important Factur-X). Document level only: on a line the VAT of the discount is already
+		// carried by the line's own ram:ApplicableTradeTax, and CII-SR-191 forbids it here.
+		if ($withCategoryTradeTax) {
+			$taxNode = $doc->createElement('ram:CategoryTradeTax');
 
-		$taxNode->appendChild($doc->createElement('ram:TypeCode', 'VAT'));
-		$taxNode->appendChild($doc->createElement('ram:CategoryCode', $taxCategory));
-		$taxNode->appendChild($doc->createElement('ram:RateApplicablePercent', number_format($taxRate, 2, '.', '')));
+			$taxNode->appendChild($doc->createElement('ram:TypeCode', 'VAT'));
+			$taxNode->appendChild($doc->createElement('ram:CategoryCode', $taxCategory));
+			$taxNode->appendChild($doc->createElement('ram:RateApplicablePercent', number_format($taxRate, 2, '.', '')));
 
-		$node->appendChild($taxNode);
+			$node->appendChild($taxNode);
+		}
 
 		return $node;
 	}
@@ -2433,7 +2440,8 @@ class CIIProtocol extends AbstractProtocol
 			$discount['reason'] ?? null,
 			$discount['code'] ?? null,
 			$discount['taxCategory'] ?? 'S',
-			$discount['taxRate'] ?? 20.0
+			$discount['taxRate'] ?? 20.0,
+			false			// No ram:CategoryTradeTax on a line-level allowance (CII-SR-191)
 		);
 
 		$lineTradeAgreement->appendChild($node);


### PR DESCRIPTION
Fixes #471.

`buildAllowanceChargeNode()` always appended `ram:CategoryTradeTax`, and it is shared by both callers. That sub-element is mandatory on a **document-level** allowance or charge (BT-95/BT-96, BT-102/BT-103) but forbidden on a **line-level** one (`CII-SR-191`), where the VAT is already carried by the line's own `ram:ApplicableTradeTax`.

Emission is now driven by a `$withCategoryTradeTax` argument that defaults to `true`, so `addHeaderDiscount()` is untouched, and `addLineDiscount()` passes `false`. Any invoice with a percentage discount on a line was affected.

Reading is not concerned: `resolveLineDiscountPercent()` only looks at `indicator`, `basisAmount` and `actualAmount` of a parsed line allowance, so our own documents still round-trip.

### Validation

Two invoices generated by the module on a dev instance, both checked against the CII D22B XSD, the `EN16931-CII` / `EXTENDED-CTC-FR-CII` schematron and `BR-FR-Flux2-CII`:

| Case | before | after |
|---|---|---|
| line with a 15 % discount | **`CII-SR-191`** | 0 failed-assert |
| document-level allowance (absolute discount consumed) | 0 failed-assert | 0 failed-assert, `CategoryTradeTax` still present |

The whole XML diff on the first case is the removal of the five-line tax block inside the line allowance.
