### PR TITLE
Let the module be switched to the EXTENDED-CTC-FR profile

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -34,6 +34,12 @@ seller who opted for the "TVA d'après les débits" scheme (EINVOICING_VAT_ON_DE
 is also added to the invoice as a TXD note. A goods-only invoice sends nothing: its VAT falls due on the
 delivery it already dates.
 
+NEW: The profile used to build the XML can be set with EINVOICING_XML_PROFILE, which accepts
+MINIMUM, BASICWL, BASIC, EN16931, EXTENDED and EXTENDEDFR. The default does not change (EN16931 for
+CII, EXTENDED for Factur-X). Setting EXTENDEDFR switches the document to EXTENDED-CTC-FR, the
+profile the French mandate expects, including on the Factur-X path whose PDF/A-3 attachment step
+used to refuse that guideline.
+
 NEW: When the e-invoicing platform (PDP/PA) confirms the refusal of a received supplier invoice,
 the corresponding Dolibarr supplier invoice is automatically validated then abandoned (with a
 dedicated close code, keeping the refusal and its reason as trace) and is excluded from the

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -57,8 +57,11 @@ class CIIProtocol extends AbstractProtocol
 	/** @const string Generated invoice file name */
 	protected const GENERATED_INVOICE_XML_FILE_NAME = 'einvoice.xml';
 
-	/** @const string The profile used to generate XML */
+	/** @const string Default profile used to generate XML, overridable with EINVOICING_XML_PROFILE */
 	protected const BUILD_XML_PROFILE = 'EN16931';
+
+	/** @var string[] Profiles buildXML() knows how to emit, and accepted values of EINVOICING_XML_PROFILE */
+	public const SUPPORTED_XML_PROFILES = ['MINIMUM', 'BASICWL', 'BASIC', 'EN16931', 'EXTENDED', 'EXTENDEDFR'];
 
 	/**
 	 * Maximum number of decimals allowed for the unit prices: Item net price (BT-146),
@@ -495,7 +498,7 @@ class CIIProtocol extends AbstractProtocol
 		dol_mkdir(dirname($xmlfile));
 		dol_delete_file($xmlfile);
 
-		$xmlcontent = $this->buildXML($invoiceData, $linesData, static::BUILD_XML_PROFILE, $outputlangs);
+		$xmlcontent = $this->buildXML($invoiceData, $linesData, $this->getBuildXmlProfile(), $outputlangs);
 
 		// Local EN 16931 business rules safety net (warnings, or abort in strict mode)
 		$this->checkBusinessRules($xmlcontent);
@@ -1661,6 +1664,32 @@ class CIIProtocol extends AbstractProtocol
 	// =====================================================================
 	// XML GENERATION
 	// =====================================================================
+
+	/**
+	 * Profile actually used to build the XML.
+	 *
+	 * Defaults to the protocol's own BUILD_XML_PROFILE (EN16931 for CII, EXTENDED for Factur-X) and
+	 * can be overridden with EINVOICING_XML_PROFILE, so the module can be switched to the
+	 * EXTENDED-CTC-FR profile of the French mandate without editing the code. An unknown value is
+	 * logged and ignored rather than aborting the generation.
+	 *
+	 * @return 	string 		Profile name, uppercased
+	 */
+	protected function getBuildXmlProfile()
+	{
+		$configured = getDolGlobalString('EINVOICING_XML_PROFILE');
+		if ($configured === '') {
+			return static::BUILD_XML_PROFILE;
+		}
+
+		$configured = strtoupper(trim($configured));
+		if (!in_array($configured, self::SUPPORTED_XML_PROFILES, true)) {
+			dol_syslog(get_class($this).'::getBuildXmlProfile unknown EINVOICING_XML_PROFILE "'.$configured.'", falling back to '.static::BUILD_XML_PROFILE, LOG_WARNING);
+			return static::BUILD_XML_PROFILE;
+		}
+
+		return $configured;
+	}
 
 	/**
 	 * Build CII XML from invoice data.

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -41,13 +41,13 @@ use horstoeko\zugferd\ZugferdDocumentPdfBuilder;
 use horstoeko\zugferd\ZugferdDocumentValidator;
 use horstoeko\zugferd\ZugferdDocumentPdfReader;
 use horstoeko\zugferd\ZugferdDocumentPdfReaderExt;
-use horstoeko\zugferd\ZugferdDocumentPdfMerger;
 
 require __DIR__ . "/../../vendor/autoload.php";
 
 dol_include_once('einvoicing/class/protocols/CIIProtocol.class.php');
 dol_include_once('einvoicing/class/protocols/CommonProtocol.class.php');
 dol_include_once('einvoicing/class/utils/XmlPatcher.class.php');
+dol_include_once('einvoicing/class/utils/CtcFrPdfMerger.class.php');
 
 
 /**
@@ -811,7 +811,10 @@ class FacturXProtocol extends CIIProtocol
 				$creator = (string) pdfExtractMetadata($orig_pdf, 'Creator');
 			}
 
-			$merger = new ZugferdDocumentPdfMerger($xmlfile, $orig_pdf);
+			// CtcFrPdfMerger behaves exactly like ZugferdDocumentPdfMerger, except that it can still
+			// supply the attachment and XMP parameters when the guideline URN is one the library does
+			// not know — which is the case of EXTENDED-CTC-FR.
+			$merger = new CtcFrPdfMerger($xmlfile, $orig_pdf);
 
 			$merger->setKeywordTemplate($keywords);
 			$merger->setSubjectTemplate($subject);

--- a/einvoicing/class/utils/CtcFrPdfMerger.class.php
+++ b/einvoicing/class/utils/CtcFrPdfMerger.class.php
@@ -1,0 +1,104 @@
+<?php
+/* Copyright (C) 2026		Pierre Grasswill			<da.grumpf@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    einvoicing/class/utils/CtcFrPdfMerger.class.php
+ * \ingroup einvoicing
+ * \brief   Attach a CII XML to a PDF even when its guideline URN is unknown to horstoeko/zugferd
+ */
+
+use horstoeko\zugferd\ZugferdDocumentPdfMerger;
+use horstoeko\zugferd\ZugferdProfiles;
+use horstoeko\zugferd\exception\ZugferdUnknownProfileException;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+/**
+ * ZugferdDocumentPdfMerger that tolerates the EXTENDED-CTC-FR guideline.
+ *
+ * The parent class embeds the XML into the PDF and writes the Factur-X XMP block. To do so it needs
+ * three parameters — the attachment filename, the XMP conformance level and the XMP version — which
+ * it looks up by matching the guideline URN found in the XML against ZugferdProfiles::PROFILEDEF.
+ * That table has no entry for `urn:cen.eu:en16931:2017#conformant#urn.cpro.gouv.fr:1p0:extended-ctc-fr`,
+ * so a CTC-FR document makes it throw ZugferdUnknownProfileException and no Factur-X file is produced.
+ *
+ * EXTENDED-CTC-FR is a conformant extension built on top of the Factur-X EXTENDED profile, and the
+ * Factur-X XMP `ConformanceLevel` has no CTC-FR value of its own, so the EXTENDED parameters are the
+ * ones to use: attachment `factur-x.xml`, conformance level `EXTENDED`, version `1.0`.
+ *
+ * The lookup is only bypassed when the parent fails, so every profile the library does know keeps its
+ * own parameters, and the day horstoeko/zugferd learns about CTC-FR this class becomes a no-op.
+ */
+class CtcFrPdfMerger extends ZugferdDocumentPdfMerger
+{
+	/**
+	 * Attachment filename of the embedded XML.
+	 *
+	 * @return string	Attachment filename
+	 */
+	protected function getXmlAttachmentFilename(): string
+	{
+		try {
+			return parent::getXmlAttachmentFilename();
+		} catch (ZugferdUnknownProfileException $e) {
+			return self::extendedProfileParameter('attachmentfilename', 'factur-x.xml');
+		}
+	}
+
+	/**
+	 * XMP conformance level (fx:ConformanceLevel) of the embedded XML.
+	 *
+	 * @return string	Conformance level written into the XMP block
+	 */
+	protected function getXmlAttachmentXmpName(): string
+	{
+		try {
+			return parent::getXmlAttachmentXmpName();
+		} catch (ZugferdUnknownProfileException $e) {
+			return self::extendedProfileParameter('xmpname', 'EXTENDED');
+		}
+	}
+
+	/**
+	 * XMP version (fx:Version) of the embedded XML.
+	 *
+	 * @return string	Factur-X version written into the XMP block
+	 */
+	protected function getXmlAttachmentXmpVersion(): string
+	{
+		try {
+			return parent::getXmlAttachmentXmpVersion();
+		} catch (ZugferdUnknownProfileException $e) {
+			return self::extendedProfileParameter('xmpversion', '1.0');
+		}
+	}
+
+	/**
+	 * Read a parameter of the library's EXTENDED profile definition, so we follow it rather than
+	 * hardcode values that could drift.
+	 *
+	 * @param	string	$parameterName	Key of ZugferdProfiles::PROFILEDEF[PROFILE_EXTENDED]
+	 * @param	string	$default		Value to use if the library ever drops that key
+	 * @return	string					The parameter value
+	 */
+	private static function extendedProfileParameter(string $parameterName, string $default): string
+	{
+		$definition = ZugferdProfiles::PROFILEDEF[ZugferdProfiles::PROFILE_EXTENDED] ?? array();
+
+		return isset($definition[$parameterName]) ? (string) $definition[$parameterName] : $default;
+	}
+}


### PR DESCRIPTION
Follow-up to #461. Depends on it: #461 makes the XML builder handle `EXTENDEDFR`, this makes that profile reachable and usable.

Split out of #461 after @eldy's review, so each change answers one request and can be judged on its own.

### 1. `EINVOICING_XML_PROFILE`

Overrides the protocol's `BUILD_XML_PROFILE`. Defaults unchanged, unknown value logged and ignored, accepted values limited to what `buildXML()` can actually emit.

```
EINVOICING_XML_PROFILE=EXTENDEDFR  →  urn:cen.eu:en16931:2017#conformant#urn.cpro.gouv.fr:1p0:extended-ctc-fr
EINVOICING_XML_PROFILE=BOGUS       →  urn:cen.eu:en16931:2017   (default, with a syslog warning)
```

@eldy asked for the constant and suggested an option *"in a future"* — this is that option. Deliberately **not** added to the setup screen, so it stays an expert setting until the mandate makes CTC-FR the normal choice; exposing it is then a one-liner.

If you would rather keep only the constant for now, say so and I will drop this part and keep only the merger.

### 2. `CtcFrPdfMerger`

The blocker @Daoud-mohamed identified. To be precise about the mechanism, because it is what makes a fix possible without touching the library: it is not an XML validation. `ZugferdProfileResolver::resolve()` matches the guideline URN against `ZugferdProfiles::PROFILEDEF` to obtain three values — attachment filename, XMP conformance level, XMP version. `PROFILEDEF` only knows `urn:factur-x.eu:1p0:extended` and `urn:zugferd.de:2p0:extended`, so CTC-FR throws `ZugferdUnknownProfileException` and no Factur-X file is produced.

The subclass overrides only the three `getXmlAttachment*()` methods. Each defers to the parent and falls back **solely** on that exception, reusing the library's own EXTENDED definition rather than hardcoded strings. Every profile the library knows keeps its own parameters, and the class becomes a no-op the day `extended-ctc-fr` is added upstream.

Reusing EXTENDED is **reasoned, not attested**: CTC-FR is a conformant extension of EXTENDED and the Factur-X XMP `ConformanceLevel` enumeration has no CTC-FR value of its own. I checked the FNFE XP Z12-012 sample PDFs — `ConformanceLevel` follows the profile name (`EN 16931`, `EXTENDED`), `DocumentFileName` is always `factur-x.xml`, `Version` always `1.0` — but none of their sample PDFs carries the CTC-FR guideline. Worth a confirmation from FNFE or a real PDP acceptance before anyone flips the switch in production.

### Validation

Dolibarr **24.0.0-beta**, Factur-X protocol, same invoice, before and after:

```
before : THROWN ZugferdUnknownProfileException:
         Cannot determain the profile by urn:...urn.cpro.gouv.fr:1p0:extended-ctc-fr
after  : FILE=.../BQ-FA-2606-0003_facturx.pdf
         embedded guideline   : urn:cen.eu:en16931:2017#conformant#urn.cpro.gouv.fr:1p0:extended-ctc-fr
         XMP ConformanceLevel : EXTENDED | DocumentFileName: factur-x.xml | Version: 1.0
```

The embedded XML passes the CII D22B XSD, the `EXTENDED-CTC-FR-CII` schematron and `BR-FR-Flux2-CII` with 0 failed-assert.

### Known limitation

Reading is still blocked. `ZugferdDocumentPdfReader::readAndGuessFromFile()` throws the same exception on an incoming CTC-FR Factur-X PDF, and the inbound path calls it unconditionally (`FacturXProtocol.class.php:1170`) even when the module's own parser does the work. So a partner sending CTC-FR cannot be ingested — independently of what we emit. Not fixed here; the cheap part is to build that reader only inside the `EINVOICING_USE_EXTERNAL_FACTURX_READER` branch that consumes it. Tell me if you want it in this PR or a separate one.

The real fix for both directions is `extended-ctc-fr` landing in `ZugferdProfiles::PROFILEDEF` upstream. Happy to send that PR to horstoeko/zugferd if you think it is worth it.
