### PR TITLE
[einvoicing] FIX #410 : address a supplier invoice status to the routing ID of its vendor

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -6,6 +6,12 @@ FIX: The flowProfile declared to the platform is now read from the guideline URN
 being transmitted instead of being hardcoded, so the declaration and the file can no longer
 contradict each other. A profile with no AFNOR flowProfile omits the field (issue #395).
 
+FIX: A lifecycle message sent on a supplier invoice is now addressed (MDT-73) to the routing ID
+recorded for its vendor - the same address the module already uses to reach that third party - instead
+of its SIREN, which the platform only accepts when the vendor happens to be registered under it
+("L'adresse électronique (MDT-73) est invalide" otherwise). Vendors with no routing recorded keep the
+SIREN, as before (issue #410).
+
 FIX: The triggers no longer fail with "Class EInvoicing / PDPProviderManager not found" when the action
 comes from a context that never went through the module screens (cron, CLI, REST API, bank import).
 

--- a/einvoicing/class/utils/CdarHandler.class.php
+++ b/einvoicing/class/utils/CdarHandler.class.php
@@ -272,6 +272,21 @@ class CdarHandler
 		$ProcessCondition = str_replace(' ', '_', $ProcessCondition);
 		$ProcessCondition = preg_replace('/[^A-Za-z0-9_]/', '', $ProcessCondition); // Clean special chars
 
+		// Electronic address (MDT-73) of the CDAR recipient. Every status but the cash-in (212) is sent on a
+		// supplier invoice: we are the buyer and the CDAR goes back to the vendor, so it is addressed with
+		// the routing the module already resolves for that third party - the one recorded for it, its
+		// SIREN otherwise. Sending the SIREN blindly only works when the platform happens to know the
+		// vendor under that very address, and gets the message refused with "L'adresse electronique
+		// (MDT-73) est invalide" otherwise. getBuyerCommunicationURI() is called on the third party alone:
+		// the invoice-level routing override it also knows about is looked up among the customer invoices
+		// (element_type = 'facture'), which a supplier invoice must not read.
+		$RecipientURIID = $InvoiceIssuerGlobalID;
+		if ($statusCode != 212 && $object->thirdparty instanceof Societe) {
+			$vendorURIID = $einvoicing->getBuyerCommunicationURI($object->thirdparty);
+			if ($vendorURIID !== '') {	// Empty with EINVOICING_BLOCK_INVOICE_NO_ROUTING_ID and no routing: keep the SIREN, an empty MDT-73 is worse
+				$RecipientURIID = $vendorURIID;
+			}
+		}
 
 		$data = [
 			'GuidelineID' => 'urn.cpro.gouv.fr:1p0:CDV:invoice',
@@ -294,7 +309,7 @@ class CdarHandler
 					'GlobalID'     => $InvoiceIssuerGlobalID, // GlobalID of CDAR RECIPIENT
 					'SchemeID'     => CdarHandler::SCHEME_SIREN_0002,
 					'RoleCode'     => CdarHandler::ROLE_SE,
-					'URIID'        => $InvoiceIssuerGlobalID,
+					'URIID'        => $RecipientURIID,
 					'URISchemeID'  => CdarHandler::SCHEME_SIREN_0225
 				]
 			],


### PR DESCRIPTION
Split of #457, part 1/5. Independent of the others, can be reviewed and merged on its own.

## Problem

The electronic address (MDT-73) of a lifecycle message sent on a supplier invoice is the SIREN of the vendor. The platform only accepts it when the vendor happens to be registered under that very address; on a third party whose routing ID differs, it refuses the status with `L'adresse électronique (MDT-73) est invalide`. That is #410.

## What this does

It reuses the address the module already resolves for that third party everywhere else, `EInvoicing::getBuyerCommunicationURI()`:

1. the routing recorded for that third party;
2. otherwise its SIREN — which is what is sent today.

So **a vendor with no routing recorded keeps the exact address it has today**: nothing moves for an install that works. The SIREN is also kept when `EINVOICING_BLOCK_INVOICE_NO_ROUTING_ID` makes that helper return nothing, an empty MDT-73 being worse than a SIREN.

Only the statuses sent on a supplier invoice are concerned. The cash-in (212), the only status sent on one of our own invoices, keeps the address it uses today.

## Testing

End to end between two Dolibarr instances exchanging through the SuperPDP sandbox — one issues the invoice, the other receives it and answers with a status:

| step | result |
|---|---|
| A issues, generates and transmits invoice `BQ-FA-2607-0021` | flow `i_163442` |
| B synchronizes its flows | supplier invoice created, flow `i_163447` |
| B sends the "Approved" (205) status, **no routing recorded** → SIREN, as today | `400 L'adresse électronique (MDT-73) est invalide` |
| B sends the same status, **routing recorded** → this fix | acknowledged `Ok`, flow `ie_563698` |
| A synchronizes its flows | `lc_status=205 direction=In` on its own invoice |

Same invoice, same status, same instance: the only difference between the two sends is the address this patch resolves. `phan --quick` clean.

Fixes #410.
