### PR TITLE
[einvoicing] FIX : the CDAR document status code follows the lifecycle status it carries

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -10,6 +10,10 @@ the corresponding Dolibarr supplier invoice is automatically validated then aban
 dedicated close code, keeping the refusal and its reason as trace) and is excluded from the
 accountancy transfer screen (issue #286).
 
+FIX: The document status code (MDT-88) of a lifecycle message now follows the lifecycle status it goes
+with (deposited, received, made available, taken over, approved, paid), instead of always announcing
+"in process", and the referenced invoice date is sent as a plain date, as in the XP Z12-012 examples.
+
 ## 1.0.0
 
 Initial version

--- a/einvoicing/class/utils/CdarHandler.class.php
+++ b/einvoicing/class/utils/CdarHandler.class.php
@@ -84,8 +84,25 @@ class CdarHandler
 	const STATUS_ACCEPTED = '1';
 	const STATUS_REJECTED = '8';
 	const STATUS_RECEIVED = '43';
+	const STATUS_IN_PROCESS = '45';
 	const STATUS_PAID = '47';
 	const STATUS_ACKNOWLEDGED = '48';
+	const STATUS_DEPOSITED = '10';
+
+	/**
+	 * Document status code (MDT-88) that goes with a lifecycle status (MDT-105), as read from the
+	 * XP Z12-012 annex B reference examples. The lifecycle statuses those examples do not cover
+	 * (refusal, dispute, suspension...) keep the historical "in process", which the platforms accept.
+	 */
+	const STATUS_CODE_PER_PROCESS_CONDITION = [
+		self::PROC_DEPOSITED           => self::STATUS_DEPOSITED,
+		self::PROC_RECEIVED            => self::STATUS_RECEIVED,
+		self::PROC_AVAILABLE           => self::STATUS_ACKNOWLEDGED,
+		self::PROC_TAKEN_OVER          => self::STATUS_IN_PROCESS,
+		self::PROC_APPROVED            => self::STATUS_ACCEPTED,
+		self::PROC_PAYMENT_TRANSMITTED => self::STATUS_PAID,
+		self::PROC_PAID                => self::STATUS_PAID,
+	];
 
 	// XML Namespaces
 	private $namespaces = [
@@ -238,17 +255,15 @@ class CdarHandler
 
 		/**
 		 * MDT-88
-		 * TODO: Map status codes from Dolibarr to CDAR status codes
-		 * 45 (In Process) = Prise en charge
+		 * TODO: the lifecycle statuses with no reference example still fall back on "in process":
 		 * 39 (on hold) = Suspendue
 		 * 37 (Complete) = Complétée
 		 * 50 (Rejected / Refused) = Refusée (by C4)
 		 * 49 (Conditionally accepted) = Approuvée Partiellement
-		 * 47 (Paid) = Paiement Transmis ET Encaissée
 		 * 46 (Under Query) = En litige
-		 * 1 (accepted) = Approuvée
 		 */
-		$StatusCodeCdar = '45';
+		// The keys of the map are numeric strings, which PHP stores as integer array keys
+		$StatusCodeCdar = CdarHandler::STATUS_CODE_PER_PROCESS_CONDITION[(int) $statusCode] ?? CdarHandler::STATUS_IN_PROCESS;
 
 		// Label for ProcessCondition (Label of status code) we get it from class einvoicing
 		dol_include_once('/einvoicing/class/providers/PDPProviderManager.class.php');
@@ -293,7 +308,8 @@ class CdarHandler
 					'IssuerAssignedID' => $IssuerAssignedID,
 					'StatusCode' => $StatusCodeCdar,
 					'TypeCode' => CdarHandler::DOC_INVOICE, // TODO: map DOC_INVOICE with $object type
-					'FormattedIssueDateTime' => date('YmdHis', $object->date),
+					// Every XP Z12-012 reference example dates the referenced invoice with a plain date
+					'FormattedIssueDateTime' => date('Ymd', $object->date),
 					'ProcessConditionCode' => $statusCode,
 					'ProcessCondition' => $ProcessCondition,
 
@@ -706,7 +722,7 @@ class CdarHandler
 
 		$formattedDateTime = $dom->createElement('ram:FormattedIssueDateTime');
 		$dateTimeStr = $dom->createElement('qdt:DateTimeString', $doc['FormattedIssueDateTime']);
-		$dateTimeStr->setAttribute('format', self::FORMAT_DATETIME);
+		$dateTimeStr->setAttribute('format', self::FORMAT_DATE);
 		$formattedDateTime->appendChild($dateTimeStr);
 		$ref->appendChild($formattedDateTime);
 


### PR DESCRIPTION
Split of #457, part 2/5. Independent of the four others, can be reviewed and merged on its own.

## Problem

The document status code (MDT-88) of every lifecycle message is hardcoded to `45` ("in process"), whichever status it carries: a deposit, an approval or a payment all announce that the invoice is being processed. The `TODO: Map status codes from Dolibarr to CDAR status codes` left in the code says as much.

## What this does

MDT-88 now follows the lifecycle status (MDT-105) it goes with, as read from the **XP Z12-012 annex B** reference examples:

| lifecycle status | MDT-88 |
|---|---|
| 200 Deposited | 10 |
| 202 Received | 43 |
| 203 Made available | 48 |
| 204 Taken over | 45 (In process) |
| 205 Approved | 1 (Accepted) |
| 211 Payment transmitted | 47 (Paid) |
| 212 Cashed in | 47 (Paid) |

The lifecycle statuses those examples do not cover (refusal, dispute, suspension, partial approval) keep the historical `45`, which the platforms accept — the TODO is kept for them.

Second detail from the same examples: the referenced invoice is dated with a plain date (format `102`) instead of a datetime (`204`). Every annex B example does it that way.

## Testing

The generated messages were validated against the UN/CEFACT **CDAR D22B XSD** and the **FNFE `BR-FR-CDV` schematron** (`fnfempe/France_RFE`), and diffed against the annex B examples. Statuses generated with these codes were accepted by the platform. `phan --quick` clean.
