### PR TITLE
FIX #395 declare the flowProfile the transmitted document actually carries

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## 1.0.3
 
+FIX: The flowProfile declared to the platform is now read from the guideline URN of the document
+being transmitted instead of being hardcoded, so the declaration and the file can no longer
+contradict each other. A profile with no AFNOR flowProfile omits the field (issue #395).
+
 FIX: The triggers no longer fail with "Class EInvoicing / PDPProviderManager not found" when the action
 comes from a context that never went through the module screens (cron, CLI, REST API, bank import).
 

--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -865,4 +865,82 @@ abstract class AbstractPDPProvider
 
 		return $xmlData;
 	}
+
+	/**
+	 * AFNOR flowProfile to declare for a given CII guideline URN.
+	 *
+	 * The values are the ones the platforms actually accept: anything outside their enumeration is
+	 * answered with a HTTP 400 "invalid flowProfile". Profiles with no AFNOR equivalent (MINIMUM,
+	 * BASIC WL, and the generic Factur-X EXTENDED) are deliberately absent, so the field is omitted
+	 * for them, which both platforms accept.
+	 *
+	 * @var array<string,string>
+	 */
+	protected const FLOW_PROFILE_BY_GUIDELINE = array(
+		'urn:factur-x.eu:1p0:basic' => 'Basic',
+		'urn:cen.eu:en16931:2017' => 'CIUS',
+		'urn:cen.eu:en16931:2017#conformant#urn.cpro.gouv.fr:1p0:extended-ctc-fr' => 'Extended-CTC-FR',
+	);
+
+	/**
+	 * Read the guideline URN (BT-24) carried by the e-invoice about to be sent.
+	 *
+	 * Works on a standalone CII XML and on a Factur-X PDF, whose embedded XML is extracted first.
+	 *
+	 * @param	string		$invoicePath	Path of the file that will be transmitted
+	 * @return	string						Guideline URN, empty string when it cannot be read
+	 */
+	protected function readGuidelineUrn($invoicePath)
+	{
+		if (!is_readable($invoicePath)) {
+			return '';
+		}
+
+		$content = '';
+		if (strtolower(pathinfo($invoicePath, PATHINFO_EXTENSION)) === 'pdf') {
+			// Factur-X: the CII lives as a PDF/A-3 attachment
+			try {
+				require_once __DIR__ . '/../../vendor/autoload.php';
+				$content = (string) \horstoeko\zugferd\ZugferdDocumentPdfReaderExt::getInvoiceDocumentContentFromFile($invoicePath);
+			} catch (\Throwable $e) {
+				dol_syslog(get_class($this) . '::readGuidelineUrn could not extract the XML from ' . basename($invoicePath) . ': ' . $e->getMessage(), LOG_WARNING);
+				return '';
+			}
+		} else {
+			$content = (string) file_get_contents($invoicePath);
+		}
+
+		$reg = array();
+		if (preg_match('#GuidelineSpecifiedDocumentContextParameter>\s*<[^:>]*:?ID>([^<]*)<#', $content, $reg)) {
+			return trim($reg[1]);
+		}
+
+		return '';
+	}
+
+	/**
+	 * flowProfile to declare to the platform for the e-invoice about to be sent.
+	 *
+	 * Derived from what the document actually contains rather than hardcoded, so the declaration and
+	 * the transmitted file can never contradict each other (issue #395).
+	 *
+	 * @param	string		$invoicePath	Path of the file that will be transmitted
+	 * @return	string						AFNOR flowProfile, empty string when the field must be omitted
+	 */
+	public function resolveFlowProfile($invoicePath)
+	{
+		$guideline = $this->readGuidelineUrn($invoicePath);
+
+		if ($guideline === '') {
+			dol_syslog(get_class($this) . '::resolveFlowProfile no guideline found in ' . basename($invoicePath) . ', flowProfile omitted', LOG_WARNING);
+			return '';
+		}
+
+		if (!isset(self::FLOW_PROFILE_BY_GUIDELINE[$guideline])) {
+			dol_syslog(get_class($this) . '::resolveFlowProfile no AFNOR flowProfile for guideline "' . $guideline . '", field omitted', LOG_NOTICE);
+			return '';
+		}
+
+		return self::FLOW_PROFILE_BY_GUIDELINE[$guideline];
+	}
 }

--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -427,14 +427,24 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 		];
 
 		// Params
+		// The profile is declared from what the document actually carries, never hardcoded, so the
+		// declaration cannot contradict the transmitted file (issue #395). Empty means "omit it",
+		// which both platforms accept and which is the only correct answer for a profile that has
+		// no AFNOR flowProfile of its own.
+		$flowInfo = [
+			"flowSyntax" => $flowSyntax,			// CII or Factur-X
+			"trackingId" => $object->ref,
+			"name" => "Invoice_" . $object->ref,
+			"sha256" => hash_file('sha256', $invoice_path)
+		];
+
+		$flowProfile = $this->resolveFlowProfile($invoice_path);
+		if ($flowProfile !== '') {
+			$flowInfo = array("flowProfile" => $flowProfile) + $flowInfo;
+		}
+
 		$params = [
-			'flowInfo' => json_encode([
-				"flowProfile" => "Extended-CTC-FR",
-				"flowSyntax" => $flowSyntax,			// CII or Factur-X
-				"trackingId" => $object->ref,
-				"name" => "Invoice_" . $object->ref,
-				"sha256" => hash_file('sha256', $invoice_path)
-			]),
+			'flowInfo' => json_encode($flowInfo),
 			'file' => new CURLFile($invoice_path, $mime_type, basename($invoice_path))
 		];
 

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -852,15 +852,24 @@ class SuperPDPProvider extends AbstractPDPProvider
 		];
 
 		// Params
+		// The profile is declared from what the document actually carries, never hardcoded, so the
+		// declaration cannot contradict the transmitted file (issue #395). Empty means "omit it",
+		// which both platforms accept and which is the only correct answer for a profile that has
+		// no AFNOR flowProfile of its own.
+		$flowInfo = [
+			"flowSyntax" => $flowSyntax,			// CII or Factur-X
+			"trackingId" => $object->ref,
+			"name" => "Invoice_" . $object->ref,
+			"sha256" => hash_file('sha256', $invoice_path)
+		];
+
+		$flowProfile = $this->resolveFlowProfile($invoice_path);
+		if ($flowProfile !== '') {
+			$flowInfo = array("flowProfile" => $flowProfile) + $flowInfo;
+		}
+
 		$params = [
-			'flowInfo' => json_encode([
-				//"flowProfile" => "CIUS",
-				"flowProfile" => "Extended-CTC-FR",
-				"flowSyntax" => $flowSyntax,			// CII or Factur-X
-				"trackingId" => $object->ref,
-				"name" => "Invoice_" . $object->ref,
-				"sha256" => hash_file('sha256', $invoice_path)
-			]),
+			'flowInfo' => json_encode($flowInfo),
 			'file' => new CURLFile($invoice_path, $mime_type, basename($invoice_path))
 		];
 


### PR DESCRIPTION
Fixes #395. Independent of #461 and #474 — it reads the file, not the configured profile.

Both providers hardcoded `"flowProfile": "Extended-CTC-FR"` while the XML said EN16931. Now the value comes from the guideline URN of the document being sent (the XML, or the XML embedded in the Factur-X PDF). No AFNOR equivalent → field omitted, explicitly.

Mapping established by probing both sandboxes, because the field is checked against an enumeration and the vendors disagree:

| value | SuperPDP | Esalink |
|---|---|---|
| `CIUS`, `Extended-CTC-FR`, `Basic`, *omitted* | ✅ | ✅ |
| `BASIC` | 400 (case-sensitive) | ✅ |
| `EN16931`, `Minimum`, `BASICWL`, `Extended`, `Factur-X` | 400 | 400 |

So the `// (flowProfile = BASIC)` comment in `buildXML()`'s table is wrong (`Basic`), and MINIMUM / BASICWL have no value at all.

Real `sendInvoice()`, both platforms, both profiles — all accepted:

| | default → `CIUS` | `EXTENDEDFR` → `Extended-CTC-FR` |
|---|---|---|
| SuperPDP | ✅ `i_163272` | ✅ `i_163275` |
| Esalink | ✅ `66014c36…` | ✅ `18c5c4b3…` |

`sendSampleInvoice()` keeps its hardcoded `CIUS`: the sample is EN16931 and the value is valid on both.

Note: this is a correctness fix, not an outage — both platforms accept the current hardcoded value, and neither cross-checks the declaration against the document.
