### PR TITLE
[einvoicing] Fix: the vendor created during a supplier invoice import was rolled back

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -650,7 +650,11 @@ class CIIProtocol extends AbstractProtocol
 	 */
 	public function createSupplierInvoiceFromSource($file, $ReadableViewFile = null, $flowId = '')
 	{
-		global $conf;
+		global $conf, $db;
+
+		// Transaction level before the import, to close only the transaction opened by
+		// doCreateSupplierInvoiceFromSource() and never one owned by a caller.
+		$transactionLevel = $db->transaction_opened;
 
 		$tempDir = $conf->einvoicing->dir_temp;
 		if (!dol_is_dir($tempDir)) {
@@ -670,6 +674,17 @@ class CIIProtocol extends AbstractProtocol
 		} finally {
 			$failed = !is_array($result) || !isset($result['res']) || $result['res'] < 0;
 			$this->cleanupIncomingTempFiles($tempDir, $tempFile, $tempFileReadableView, 'einvoice.' . static::INVOICE_FILE_EXTENSION, 'einvoice_readable.pdf', $failed);
+
+			// The invoice import transaction is opened by doCreateSupplierInvoiceFromSource() once the
+			// vendor has been synchronized. Close it here so every early return - and any exception -
+			// leaves a clean transaction state.
+			if ($db->transaction_opened > $transactionLevel) {
+				if ($failed) {
+					$db->rollback();
+				} else {
+					$db->commit();
+				}
+			}
 		}
 
 		return $result;
@@ -731,6 +746,8 @@ class CIIProtocol extends AbstractProtocol
 	/**
 	 * Build the supplier invoice from a received CII document written to a per-call working file.
 	 * The temp-file lifecycle is owned by createSupplierInvoiceFromSource() (the public wrapper).
+	 * The vendor synchronization runs in its own transaction, opened and closed here. The invoice
+	 * import transaction is opened here too, right after, but closed by that same wrapper.
 	 *
 	 * @param  string			$file                 Raw CII XML content
 	 * @param  string|null		$ReadableViewFile     Optional readable view (PDP-generated readable PDF)
@@ -771,11 +788,21 @@ class CIIProtocol extends AbstractProtocol
 		// Sync or create supplier based on seller info.
 		// Done before the duplicate/ref-docs checks below so those checks can be scoped to this supplier
 		// (ref_supplier is only unique per supplier, not globally - see issue about cross-supplier collisions).
+		//
+		// The vendor is reference data, not part of the invoice: it gets its own transaction, committed
+		// before the import starts. A business error raised further down - a product that cannot be
+		// auto-created, a referenced document missing - must not roll back the thirdparty the operator is
+		// precisely being asked to complete: the "create the product" and "map the product" links returned
+		// with that error carry its socid, so a rolled back vendor makes them point to a thirdparty that
+		// never existed.
+		$db->begin();
+
 		$syncSocRes = $this->_syncOrCreateThirdpartyFromEInvoiceSeller($parsedHeader, 'dolibarr', $flowId);
 
 		$socId = $syncSocRes['res'];
 		$return_messages[] = $syncSocRes['message'];
 		if ($socId < 0) {
+			$db->rollback();
 			return [
 				'res' => -1,
 				'message' => 'Thirdparty sync or creation error: ' . implode("<br>\n", $return_messages),
@@ -785,6 +812,13 @@ class CIIProtocol extends AbstractProtocol
 				'actiondata' => $syncSocRes['actiondata'] ?? null
 			];
 		}
+
+		$db->commit();
+
+		// From this point on, everything belongs to the invoice import (products, invoice, lines) and
+		// stays atomic. This second transaction is closed (commit or rollback) by
+		// createSupplierInvoiceFromSource(), the public wrapper.
+		$db->begin();
 
 		// Load supplier (thirdparty)
 		require_once DOL_DOCUMENT_ROOT . '/fourn/class/fournisseur.class.php';

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -1125,6 +1125,8 @@ class FacturXProtocol extends CIIProtocol
 	/**
 	 * Build the supplier invoice from a received Factur-X document written to a per-call working file.
 	 * The temp-file lifecycle is owned by createSupplierInvoiceFromSource() (the public wrapper).
+	 * The vendor synchronization runs in its own transaction, opened and closed here. The invoice
+	 * import transaction is opened here too, right after, but closed by that same wrapper.
 	 *
 	 * @param  string			$file                 Raw Factur-X PDF content
 	 * @param  string|null		$ReadableViewFile     Optional readable view (PDP-generated readable PDF)
@@ -1348,11 +1350,21 @@ class FacturXProtocol extends CIIProtocol
 		// Sync or create supplier based on seller info.
 		// Done before the duplicate/ref-docs checks below so those checks can be scoped to this supplier
 		// (ref_supplier is only unique per supplier, not globally - see issue about cross-supplier collisions).
+		//
+		// The vendor is reference data, not part of the invoice: it gets its own transaction, committed
+		// before the import starts. A business error raised further down - a product that cannot be
+		// auto-created, a referenced document missing - must not roll back the thirdparty the operator is
+		// precisely being asked to complete: the "create the product" and "map the product" links returned
+		// with that error carry its socid, so a rolled back vendor makes them point to a thirdparty that
+		// never existed.
+		$db->begin();
+
 		$syncSocRes = $this->_syncOrCreateThirdpartyFromEInvoiceSeller($parsedHeader, 'dolibarr', $flowId);
 
 		$socId = $syncSocRes['res'];
 		$return_messages[] = $syncSocRes['message'];
 		if ($socId < 0) {
+			$db->rollback();
 			return [
 				'res' => -1,
 				'message' => 'Thirdparty sync or creation error: ' . implode("<br>\n", $return_messages),
@@ -1362,6 +1374,13 @@ class FacturXProtocol extends CIIProtocol
 				'actiondata' => $syncSocRes['actiondata'] ?? null
 			];
 		}
+
+		$db->commit();
+
+		// From this point on, everything belongs to the invoice import (products, invoice, lines) and
+		// stays atomic. This second transaction is closed (commit or rollback) by
+		// createSupplierInvoiceFromSource(), the public wrapper.
+		$db->begin();
 
 		// Load supplier (thirdparty)
 		require_once DOL_DOCUMENT_ROOT . '/fourn/class/fournisseur.class.php';

--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -1198,8 +1198,10 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 				$exchangeProtocol = $tmpProtocolManager->getProtocol($detectedProtocol);
 
 				$exceptionmessage = '';
-				$db->begin();
 
+				// No transaction opened here: createSupplierInvoiceFromSource() owns it. It synchronizes
+				// the vendor first, out of transaction, then imports the invoice atomically - so a business
+				// error on the invoice (product not found, ...) no longer rolls back the created thirdparty.
 				try {
 					// Try to create the supplier + product + invoice
 					$res = $exchangeProtocol->createSupplierInvoiceFromSource($receivedFile, $ReadableViewFile, $flowId);
@@ -1213,7 +1215,6 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 						$retarray['action'] = $res['action'] ?? null;
 						$retarray['actiondata'] = $res['actiondata'] ?? null;
 
-						$db->rollback();
 						return $retarray;
 					} else {
 						// Complete the document object with the created supplier invoice details
@@ -1229,13 +1230,9 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 						//return array('res' => 0, 'message' => "supplier invoice already exists for flowId: " . $flowId . ". " . $res['message']);
 						$returnRes = 1;		// If invoice did already exists, we process one more line from list of flows, so we must return 1, even if nothing was done.
 						$returnMessage = "Supplier invoice " . $supplierInvoiceObj->ref . " created or already existing for flowId: " . $flowId . ". " . $res['message'];
-
-						$db->commit();
 					}
 				} catch (Exception $e) {
 					$exceptionmessage = $e->getMessage();
-
-					$db->rollback();
 				}
 
 				if ($exceptionmessage) {

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -1777,8 +1777,10 @@ class SuperPDPProvider extends AbstractPDPProvider
 				}
 
 				$exceptionmessage = '';
-				$db->begin();
 
+				// No transaction opened here: createSupplierInvoiceFromSource() owns it. It synchronizes
+				// the vendor first, out of transaction, then imports the invoice atomically - so a business
+				// error on the invoice (product not found, ...) no longer rolls back the created thirdparty.
 				try {
 					// Try to create the supplier + product + invoice
 					$res = $exchangeProtocol->createSupplierInvoiceFromSource($receivedFile, $ReadableViewFile, $flowId);
@@ -1793,7 +1795,6 @@ class SuperPDPProvider extends AbstractPDPProvider
 						$retarray['action'] = $res['action'] ?? null;
 						$retarray['actiondata'] = $res['actiondata'] ?? null;
 
-						$db->rollback();
 						return $retarray;
 					} else {
 						// Complete the document object with the created supplier invoice details
@@ -1809,13 +1810,9 @@ class SuperPDPProvider extends AbstractPDPProvider
 						//return array('res' => 0, 'message' => "supplier invoice already exists for flowId: " . $flowId . ". " . $res['message']);
 						$returnRes = 1;		// If invoice did already exists, we process one more line from list of flows, so we must return 1, even if nothing was done.
 						$returnMessage = "Supplier invoice " . $supplierInvoiceObj->ref . " created or already existing for flowId: " . $flowId . ". " . $res['message'];
-
-						$db->commit();
 					}
 				} catch (Exception $e) {
 					$exceptionmessage = $e->getMessage();
-
-					$db->rollback();
 				}
 
 				if ($exceptionmessage) {


### PR DESCRIPTION
Follow-up of #455, which it makes actually usable.

## Symptom

Synchronizing a received flow fails with:

```
ERROR_SYNCFLOW - Failed to synchronize flow i_163370: Failed to create supplier invoice
from E-invoice document for flowId: i_163370. Product sync or creation error:
Thirdparty SAS XXX created successfully
Unable to find product [Vendor id: 332 - Supplier ref: OKA-03-POULE - Name: POULE-POULE].
Auto-creation of products is disabled in settings.
```

The message says the thirdparty was created, but it is nowhere to be found: id 332 does not exist.

## Cause

`createSupplierInvoiceFromSource()` synchronizes (and creates if missing) the vendor, then imports the invoice. Both providers called it inside a **single** transaction covering the whole import (`SuperPDPProvider::syncFlow()` / `EsalinkPDPProvider::syncFlow()`), so the business error raised on the first line rolled the vendor back together with the invoice. The "created successfully" message had been collected before that, and is returned as part of the error.

Beyond the misleading message, this breaks the two recommended actions returned with a `PRODUCT_NOT_FOUND`: **"Create the product"** (prefilled `product/card.php?...&socid=332`) and the **vendor product mapping screen** (`product_mapping.php?flowid=...&socid=332`), both added in #455. They carry the socid of the vendor that was just rolled back, so the operator is asked to map a product onto a thirdparty that does not exist - and cannot create it either, since it only exists while the import is running. Meanwhile the flow is not marked as processed, so the next synchronization creates yet another vendor row (and burns another auto-increment id).

## Fix

The import now runs in **two transactions** instead of one:

1. the vendor synchronization, committed on its own. The vendor is reference data, not part of the invoice: it survives a failed import, the links offered to the operator point at a real thirdparty, and the next synchronization of the flow finds it instead of creating a new one;
2. the invoice import itself (products, invoice, lines), which stays atomic - a failure still leaves no partial invoice behind.

That second transaction is now owned by `createSupplierInvoiceFromSource()`, the public wrapper that already owns the temp-file lifecycle: `doCreateSupplierInvoiceFromSource()` opens it right after the vendor sync, the wrapper commits or rolls it back in its `finally`, so early returns and exceptions all leave a clean transaction state. Both providers no longer open a transaction of their own.

Behaviour is unchanged on the nominal path (invoice imported, everything committed) and on a failed import (invoice fully rolled back) - only the vendor now survives.

## Test

On a Dolibarr with `EINVOICING_AUTO_CREATE_PRODUCT` disabled, synchronize a received invoice from a vendor unknown in Dolibarr:

- before: the sync fails, no thirdparty in the database, both proposed links point to a missing socid;
- after: the sync still fails on the missing product, but the vendor is present, "Create the product" opens the form prefilled with that vendor, the mapping screen works, and re-synchronizing the flow after the product is created imports the invoice on the same vendor.

Checked with phan (same command as CI, `--quick` + baseline): no new issue.