### PR TITLE
FIX #473 check the SIREN format of every party, not only the seller

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -5,6 +5,11 @@
 FIX: The triggers no longer fail with "Class EInvoicing / PDPProviderManager not found" when the action
 comes from a context that never went through the module screens (cron, CLI, REST API, bank import).
 
+FIX: The local check of the SIREN format now covers every party of the generated document instead of
+the seller alone. A customer whose professional id was not a 9 digit SIREN went through untouched and
+the invoice was refused by the platform (BR-FR-32), without the operator being told which party was at
+fault (issue #473).
+
 NEW: The generated invoices now tell when the VAT falls due, hence from when the buyer may deduct it:
 BT-8 is set to 72 (payment date) as soon as the invoice carries a service, and to 5 (invoice date) for a
 seller who opted for the "TVA d'après les débits" scheme (EINVOICING_VAT_ON_DEBITS), whose legal mention

--- a/einvoicing/class/utils/En16931Validator.class.php
+++ b/einvoicing/class/utils/En16931Validator.class.php
@@ -255,15 +255,43 @@ class En16931Validator
 		}
 
 		// ---------------------------------------------------------------
-		// CTC-FR: BR-FR-10 seller SIREN format (scheme 0002 = 9 digits)
+		// CTC-FR SIREN format, as published in the FNFE "BR-FR-Flux2-Schematron-CII" V1.4.0:
+		//  - BR-FR-10/BT-30 targets the seller SIREN,
+		//  - BR-FR-32/LEGALID targets the legal identifier (scheme 0002) of ANY party,
+		//  - BR-FR-32/GLOBALID targets any party identifier with scheme 0002 or 0231.
+		// The platform reports each of them separately, so the same value can raise both a
+		// BR-FR-10 and a BR-FR-32 message: this mirrors the report the operator will get back.
+		// BR-FR-10 also makes the seller SIREN mandatory, which only holds for a French seller
+		// (the module also serves other countries) and an empty professional id is already
+		// refused when the invoice data is built, so only the format is checked here.
 		// ---------------------------------------------------------------
-		$sellerLegalIds = $xp->query('//ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:SpecifiedLegalOrganization/ram:ID');
-		if ($sellerLegalIds !== false) {
-			foreach ($sellerLegalIds as $node) {
-				/** @var DOMElement $node */
-				if ($node->getAttribute('schemeID') === '0002' && !preg_match('/^\d{9}$/', trim($node->textContent))) {
-					$violations[] = 'BR-FR-10: seller legal registration identifier (scheme 0002) must be a 9 digit SIREN, found "'.trim($node->textContent).'"';
+		$sellerSirens = $xp->query('//ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:SpecifiedLegalOrganization/ram:ID[@schemeID="0002"]');
+		if ($sellerSirens !== false) {
+			foreach ($sellerSirens as $node) {
+				$value = trim($node->textContent);
+				if (!preg_match('/^\d{9}$/', $value)) {
+					$violations[] = 'BR-FR-10/BT-30: the seller SIREN (scheme 0002) must be exactly 9 digits, found "'.$value.'"';
 				}
+			}
+		}
+
+		$partySirens = $xp->query('//ram:SpecifiedLegalOrganization/ram:ID[@schemeID="0002"] | //ram:GlobalID[@schemeID="0002" or @schemeID="0231"]');
+		if ($partySirens !== false) {
+			foreach ($partySirens as $node) {
+				/** @var DOMElement $node */
+				$value = trim($node->textContent);
+				if (preg_match('/^\d{9}$/', $value)) {
+					continue;
+				}
+				// Name the party at fault: the identifier hangs either directly under the party
+				// (GlobalID) or under its SpecifiedLegalOrganization wrapper (ID).
+				$party = '';
+				$parent = $node->parentNode;
+				if ($parent !== null) {
+					$party = ($parent->localName === 'SpecifiedLegalOrganization' && $parent->parentNode !== null) ? $parent->parentNode->localName : $parent->localName;
+				}
+				$assert = ($node->localName === 'GlobalID') ? 'GLOBALID' : 'LEGALID';
+				$violations[] = 'BR-FR-32/'.$assert.': the identifier (scheme '.$node->getAttribute('schemeID').') of '.($party !== '' ? $party : 'a party').' must be exactly 9 digits, found "'.$value.'"';
 			}
 		}
 

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -408,7 +408,7 @@ InvoicePrecheckSuccessful=AP validator pre-check passed.
 InvoicePrecheckFailed=AP validator pre-check failed.
 # Local EN 16931 business rules check
 EINVOICING_BR_CHECK=Local validation of the generated e-invoice file
-EINVOICING_BR_CHECK_HELP=After generating the e-invoice XML, checks a subset of the EN 16931 business rules locally (totals arithmetic BR-CO-10 to BR-CO-17, line rules, VAT category and rate coherence, seller SIREN format), quoting the official rule id. Choose "No check" to disable it, "Warning only" (default) to report violations as warnings, or "Blocking" to abort the generation on any violation. This is a fast local safety net for any platform; the official Schematron validation of the Approved Platform remains the reference.
+EINVOICING_BR_CHECK_HELP=After generating the e-invoice XML, checks a subset of the EN 16931 business rules locally (totals arithmetic BR-CO-10 to BR-CO-17, line rules, VAT category and rate coherence, SIREN format of every party BR-FR-10 and BR-FR-32), quoting the official rule id. Choose "No check" to disable it, "Warning only" (default) to report violations as warnings, or "Blocking" to abort the generation on any violation. This is a fast local safety net for any platform; the official Schematron validation of the Approved Platform remains the reference.
 EINVOICING_BR_CHECK_NOCHECK=No check
 EINVOICING_BR_CHECK_WARNING_ONLY=Warning only
 EINVOICING_BR_CHECK_BLOCKING=Blocking (abort generation on violation)


### PR DESCRIPTION
Closes #473

## Problem

The 9 digit check on a legal registration identifier declared with `schemeID="0002"` was anchored on the seller:

```php
$xp->query('//ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:SpecifiedLegalOrganization/ram:ID');
```

so a malformed **buyer** identifier reached the platform untouched, and came back refused with a rule id the operator never saw locally. Hit on production data (a customer recorded with `idprof1 = 1`).

## What the rule actually says

Checked against the FNFE `BR-FR-Flux2-Schematron-CII` V1.4.0 (published under EUPL in [fnfempe/France_RFE](https://github.com/fnfempe/France_RFE)), which is what the platform applies. It is not one rule but three:

| assert | context | scope |
| --- | --- | --- |
| `BR-FR-10_BT-30` | `.../SellerTradeParty/SpecifiedLegalOrganization/ID[@schemeID='0002']` | seller: mandatory **and** 9 digits |
| `BR-FR-32-LEGALID` | `//ram:SpecifiedLegalOrganization/ram:ID[@schemeID='0002']` | **any** party: 9 digits |
| `BR-FR-32-GLOBALID` | `//ram:GlobalID[@schemeID='0002' or @schemeID='0231']` | **any** party: 9 digits |

All three are `flag="fatal"`. So the existing `BR-FR-10` label was right for the seller, and a second, wider rule was simply missing. Both are now reported, exactly as the platform reports them, with the party at fault named in the message.

Scheme `0231` is included because it is the identifier of a member of a French VAT group ("assujetti unique", cf. `BR-FR-CO-15/BT-29-1`).

## Deliberately not implemented

The presence requirement that `BR-FR-10` also carries. It only holds for a French seller, while the module also serves other countries, and an empty professional id is already refused when the invoice data is built (`buildinvoicelines.inc.php`). Only the format is checked here.

## Validation

Twenty scenarios generated from real invoices on a dev instance, each generated XML then passed through the official FNFE XSLT with Saxon. The local check and the official schematron agree on all fifteen documents that could be generated:

| scenario | emitted identifier | module | FNFE schematron |
| --- | --- | --- | --- |
| untouched invoices | `0002:000000002` | clean | clean |
| buyer SIREN `1` | `0002:1` | `BR-FR-32/LEGALID` | `BR-FR-32-LEGALID` |
| `12345678A`, `1234567890`, `000-000-002`, `00000000O`, a SIRET pasted in the SIREN field | as recorded | `BR-FR-32/LEGALID` | `BR-FR-32-LEGALID` |
| SIREN typed with spaces | `000000002` | clean | clean |
| German / Belgian buyer | `0000:1` / `0008:1` | clean | clean |
| `000000000` (well formed, meaningless) | as recorded | clean | clean |

No false positive on a foreign buyer, and the untouched invoices stay silent. The cases already refused upstream by an exception (empty buyer id, malformed seller id, SIRET not starting with the SIREN) are unchanged.

Note that `BR-FR-11` (buyer SIREN mandatory under a B2B invoicing framework) never fires today, since the module emits no `BAR` note: `BR-FR-32` is currently the only net on the buyer identifier.

phpcs clean with the repository ruleset.