### PR TITLE
FIX the SIREN derived from a SIRET keeps the last 5 digits instead of the first 9

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -14,6 +14,9 @@ the seller alone. A customer whose professional id was not a 9 digit SIREN went 
 the invoice was refused by the platform (BR-FR-32), without the operator being told which party was at
 fault (issue #473).
 
+FIX: A French thirdparty recorded with a SIRET but no SIREN was identified in the generated invoice by
+the 5 digit establishment number instead of its SIREN, an identifier the platform refuses (BR-FR-32).
+
 NEW: The generated invoices now tell when the VAT falls due, hence from when the buyer may deduct it:
 BT-8 is set to 72 (payment date) as soon as the invoice carries a service, and to 5 (invoice date) for a
 seller who opted for the "TVA d'après les débits" scheme (EINVOICING_VAT_ON_DEBITS), whose legal mention

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -152,7 +152,7 @@ function idprof($thirdparty)
 			if (!empty($thirdparty->idprof1)) {
 				$retour = removeAllSpaces($thirdparty->idprof1); // SIREN
 			} else {
-				$retour = substr(removeAllSpaces($thirdparty->idprof2), 9); // 9 first chars of SIRET
+				$retour = substr(removeAllSpaces($thirdparty->idprof2), 0, 9); // SIREN = 9 first chars of the SIRET
 			}
 			break;
 		default:


### PR DESCRIPTION
## Problem

`idprof()` derives the SIREN of a French thirdparty from its SIRET when only the SIRET is recorded, and takes the wrong side of the string:

```php
$retour = substr(removeAllSpaces($thirdparty->idprof2), 9); // 9 first chars of SIRET
```

`substr($s, 9)` returns everything **from** offset 9, i.e. the 5 digit establishment number (NIC), not the first 9 characters the comment describes. A thirdparty holding SIRET `88261537000021` is therefore emitted as:

```xml
<ram:SpecifiedLegalOrganization>
  <ram:ID schemeID="0002">00021</ram:ID>
```

The platform Schematron refuses it (`BR-FR-32/LEGALID`: an identifier declared under scheme 0002 must be a 9 digit SIREN), and when the identifier is the buyer's it is also useless for routing.

The same derivation is written correctly elsewhere in the module (`einvoicing.class.php`, `substr(..., 0, 9)`); this call is the only outlier.

## Fix

Take the first 9 characters, and say so in the comment.

## Validation

Generated from a real invoice on a dev instance, with the buyer's SIREN cleared so the SIRET `88261537000021` is the only identifier left, then run through the official FNFE `BR-FR-Flux2-Schematron-CII` V1.4.0 (Saxon):

| | emitted identifier | schematron |
| --- | --- | --- |
| before | `0002:00021` | `BR-FR-32-LEGALID` fatal |
| after | `0002:882615370` | clean |

The derived value equals the SIREN the same thirdparty carries when it is recorded, which is the cross-check. Fifteen other generation scenarios (well formed SIREN, malformed SIREN, SIREN with spaces or dashes, foreign buyers, seller variants) were replayed before and after: no other document changed, against either the French rules or the EN 16931 Schematron.

Side effect worth noting: a thirdparty whose `idprof2` is shorter than 9 characters used to end up with an empty identifier, which surfaced as the misleading "the main professional ID of the buyer is empty" exception. It now keeps what was recorded and is reported by the business rules check as the malformed identifier it is.

phpcs clean with the repository ruleset.