### PR TITLE
[einvoicing] FIX : send a conformant "Encaissée" (212) status, with its amount and its parties

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -2,6 +2,13 @@
 
 ## 1.0.3
 
+FIX: The "Cashed in" (212) status sent to the platform now carries the cashed amount broken down by
+VAT rate (MDG-43 blocks with MDT-207 = MEN, MDT-215 amount and MDT-224 rate) and the status detail
+sequence number, as required by the rules BR-FR-CDV-14 and BR-FR-CDV-16. Without them the platform
+rejected the CDAR with a HTTP 400. It is also issued as the seller of the invoice and addressed to its
+buyer, instead of reusing the supplier invoice mapping (us as the buyer, addressed to ourselves) which
+made the platform answer "no matching invoices found".
+
 FIX: The flowProfile declared to the platform is now read from the guideline URN of the document
 being transmitted instead of being hardcoded, so the declaration and the file can no longer
 contradict each other. A profile with no AFNOR flowProfile omits the field (issue #395).

--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -822,10 +822,11 @@ abstract class AbstractPDPProvider
 	 * @param mixed $object Invoice object (CustomerInvoice or SupplierInvoice)
 	 * @param int $statusCode   Status code to send (see class constants for available codes)
 	 * @param string $reasonCode Reason code to send (optional)
+	 * @param array{amount?:float,breakdown?:array<array{vatrate:float,amount:float}>} $paymentData Cashed amount (TTC) for status 212 (Encaissee), mandatory content of the CDAR (rule BR-FR-CDV-14)
 	 *
 	 * @return array{res:int, message:string}       Returns array with 'res' (1 on success, -1 on failure) with a 'message'.
 	 */
-	abstract public function sendStatusMessage($object, $statusCode, $reasonCode = '');
+	abstract public function sendStatusMessage($object, $statusCode, $reasonCode = '', $paymentData = array());
 
 	/**
 	 * Clear the fixed "last invoice that could not be processed" diagnostic files at the start of a

--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -1604,10 +1604,11 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 	 * @param mixed $object Invoice object (CustomerInvoice or SupplierInvoice)
 	 * @param int $statusCode   Status code to send (see class constants for available codes)
 	 * @param string $reasonCode Reason code to send (optional)
+	 * @param array{amount?:float,breakdown?:array<array{vatrate:float,amount:float}>} $paymentData Cashed amount (TTC) for status 212 (Encaissee), mandatory content of the CDAR (rule BR-FR-CDV-14)
 	 *
 	 * @return array{res:int, message:string}       Returns array with 'res' (1 on success, -1 on failure) with a 'message'.
 	 */
-	public function sendStatusMessage($object, $statusCode, $reasonCode = '')
+	public function sendStatusMessage($object, $statusCode, $reasonCode = '', $paymentData = array())
 	{
 		global $langs, $db;
 
@@ -1639,7 +1640,7 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 
 		dol_include_once('/einvoicing/class/utils/CdarHandler.class.php');
 		$cdarHandler = new CdarHandler($db);
-		$result = $cdarHandler->generateCdarFile($object, $statusCode, $reasonCode);
+		$result = $cdarHandler->generateCdarFile($object, $statusCode, $reasonCode, $paymentData);
 		if ($result['res'] < 0) {
 			$res = -1;
 			$message = 'Failed to generate CDAR file: ' . $result['message'];

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -2182,10 +2182,11 @@ class SuperPDPProvider extends AbstractPDPProvider
 	 * @param mixed $object Invoice object (CustomerInvoice or SupplierInvoice)
 	 * @param int $statusCode   Status code to send (see class constants for available codes)
 	 * @param string $reasonCode Reason code to send (optional)
+	 * @param array{amount?:float,breakdown?:array<array{vatrate:float,amount:float}>} $paymentData Cashed amount (TTC) for status 212 (Encaissee), mandatory content of the CDAR (rule BR-FR-CDV-14)
 	 *
 	 * @return array{res:int, message:string}       Returns array with 'res' (1 on success, -1 on failure) with a 'message'.
 	 */
-	public function sendStatusMessage($object, $statusCode, $reasonCode = '')
+	public function sendStatusMessage($object, $statusCode, $reasonCode = '', $paymentData = array())
 	{
 		global $langs, $db;
 
@@ -2217,7 +2218,7 @@ class SuperPDPProvider extends AbstractPDPProvider
 
 		dol_include_once('/einvoicing/class/utils/CdarHandler.class.php');
 		$cdarHandler = new CdarHandler($db);
-		$result = $cdarHandler->generateCdarFile($object, $statusCode, $reasonCode);
+		$result = $cdarHandler->generateCdarFile($object, $statusCode, $reasonCode, $paymentData);
 		if ($result['res'] < 0) {
 			$res = -1;
 			$message = 'Failed to generate CDAR file: ' . $result['message'];

--- a/einvoicing/class/utils/CdarHandler.class.php
+++ b/einvoicing/class/utils/CdarHandler.class.php
@@ -211,10 +211,11 @@ class CdarHandler
 	 * @param Facture|FactureFournisseur    $object       Invoice object (CustomerInvoice or SupplierInvoice)
 	 * @param int                           $statusCode     Status code to send
 	 * @param string                        $reasonCode Reason code to send (optional)
+	 * @param array{amount?:float,breakdown?:array<array{vatrate:float,amount:float}>}  $paymentData  Cashed amount (TTC, in the company currency) for status 212, with an optional ready-made breakdown by VAT rate
 	 *
 	 * @return  array{res:int<-1,1>, message:string, file?:string}   Returns array with 'res' (1 on success, -1 on failure) with a 'message' and 'file' with the path.
 	 */
-	public function generateCdarFile($object, $statusCode, $reasonCode = '')
+	public function generateCdarFile($object, $statusCode, $reasonCode = '', $paymentData = array())
 	{
 		global $conf, $mysoc;
 
@@ -240,16 +241,24 @@ class CdarHandler
 		// We use same as ID for Name as its not required to be different
 		$Name = $ID;
 
+		// 212 (Encaissee) is the only status we send on one of OUR OWN invoices: we are then the seller and
+		// the CDAR is addressed to our customer. Every other status is sent on a supplier invoice, where we
+		// are the buyer and the CDAR goes back to the vendor. Getting those two parties the wrong way round
+		// makes the platform answer "no matching invoices found": it cannot find the invoice the status is
+		// about. See the XP Z12-012 annex B examples, UC1 205/211 (issued by the buyer) versus UC1 212
+		// (issued by the seller).
+		$isOurOwnInvoice = ($statusCode == CdarHandler::PROC_PAID);
+
 		// SIREN (0002)
 		$mysocGlobalID = idprof($mysoc);
 
-		// Issuer SIREN (0002)
-		$InvoiceIssuerGlobalID = $statusCode == 212	// Customer invoices management (Only 212 for now)
-			? idprof($mysoc)
+		// Issuer SIREN (0002) of the invoice the status is about: us when we sell, the vendor otherwise
+		$InvoiceIssuerGlobalID = $isOurOwnInvoice
+			? $mysocGlobalID
 			: thirdpartyidprof($object);
 
 		// Invoice reference
-		$IssuerAssignedID = $statusCode == 212	// Customer invoices management (Only 212 for now)
+		$IssuerAssignedID = $isOurOwnInvoice
 			? $object->ref
 			: $object->ref_supplier;
 
@@ -288,6 +297,60 @@ class CdarHandler
 			}
 		}
 
+		// MDG-43 blocks. Rule BR-FR-CDV-14: a "Encaissee" status (212) must carry at least one block with
+		// MDT-207 = MEN, and every MEN block must hold both an amount (MDT-215) and a VAT rate (MDT-224).
+		// Without them the platform rejects the CDAR with a 400.
+		$SpecifiedDocumentStatus = array();
+		if (!empty($reasonCode)) {
+			$SpecifiedDocumentStatus['ReasonCode'] = $reasonCode;
+			//$SpecifiedDocumentStatus['Reason'] = 'Taux de TVA erroné';
+		}
+		if ($statusCode == CdarHandler::PROC_PAID) {
+			$cashedAmounts = $this->getCashedAmountCharacteristics($object, $paymentData);
+			if (empty($cashedAmounts)) {
+				// Better to fail here than to have the platform reject the CDAR on BR-FR-CDV-14.
+				return array('res' => -1, 'message' => 'Cannot compute the cashed amount (MEN) per VAT rate for invoice ' . $object->ref);
+			}
+			$SpecifiedDocumentStatus['SpecifiedDocumentCharacteristic'] = $cashedAmounts;
+		}
+		if (!empty($SpecifiedDocumentStatus)) {
+			// Rule BR-FR-CDV-16: any status detail block must be numbered (MDT-124-2). Only one block is sent.
+			$SpecifiedDocumentStatus['SequenceNumeric'] = 1;
+		}
+
+		if ($isOurOwnInvoice) {
+			// We issue the status as the SELLER, and it is addressed to the buyer of the invoice
+			$CdarIssuerTradeParty = [
+				'GlobalID' => $mysocGlobalID,
+				'SchemeID' => CdarHandler::SCHEME_SIREN_0002,
+				'RoleCode' => CdarHandler::ROLE_SE
+			];
+
+			$buyerGlobalID = thirdpartyidprof($object);
+			$buyerURIID = $einvoicing->getBuyerCommunicationURI($object->thirdparty, $object);
+			$CdarRecipientTradeParty = [
+				'GlobalID'     => $buyerGlobalID,
+				'SchemeID'     => CdarHandler::SCHEME_SIREN_0002,
+				'RoleCode'     => CdarHandler::ROLE_BY,
+				'URIID'        => $buyerURIID !== '' ? $buyerURIID : $buyerGlobalID,
+				'URISchemeID'  => CdarHandler::SCHEME_SIREN_0225
+			];
+		} else {
+			// We issue the status as the BUYER of a supplier invoice, and it goes back to the vendor
+			$CdarIssuerTradeParty = [
+				'GlobalID' => $mysocGlobalID, // GlobalID of CDAR SENDER
+				'RoleCode' => CdarHandler::ROLE_BY
+			];
+
+			$CdarRecipientTradeParty = [
+				'GlobalID'     => $InvoiceIssuerGlobalID, // GlobalID of CDAR RECIPIENT
+				'SchemeID'     => CdarHandler::SCHEME_SIREN_0002,
+				'RoleCode'     => CdarHandler::ROLE_SE,
+				'URIID'        => $RecipientURIID,	// The routing of the vendor, its SIREN when none is recorded
+				'URISchemeID'  => CdarHandler::SCHEME_SIREN_0225
+			];
+		}
+
 		$data = [
 			'GuidelineID' => 'urn.cpro.gouv.fr:1p0:CDV:invoice',
 
@@ -300,18 +363,9 @@ class CdarHandler
 					'RoleCode' => CdarHandler::ROLE_WK
 				],
 
-				'IssuerTradeParty' => [
-					'GlobalID' => $mysocGlobalID, // GlobalID of CDAR SENDER
-					'RoleCode' => CdarHandler::ROLE_BY
-				],
+				'IssuerTradeParty' => $CdarIssuerTradeParty,
 
-				'RecipientTradeParty' => [
-					'GlobalID'     => $InvoiceIssuerGlobalID, // GlobalID of CDAR RECIPIENT
-					'SchemeID'     => CdarHandler::SCHEME_SIREN_0002,
-					'RoleCode'     => CdarHandler::ROLE_SE,
-					'URIID'        => $RecipientURIID,
-					'URISchemeID'  => CdarHandler::SCHEME_SIREN_0225
-				]
+				'RecipientTradeParty' => $CdarRecipientTradeParty
 			],
 
 			'AcknowledgementDocument' => [
@@ -328,11 +382,7 @@ class CdarHandler
 					'ProcessConditionCode' => $statusCode,
 					'ProcessCondition' => $ProcessCondition,
 
-					'SpecifiedDocumentStatus' => !empty($reasonCode) ? [
-						'ReasonCode' => $reasonCode,
-						//'Reason' => 'Taux de TVA erroné',
-						'SequenceNumeric' => 1
-					] : [],
+					'SpecifiedDocumentStatus' => $SpecifiedDocumentStatus,
 
 					'IssuerTradeParty' => [
 						'GlobalID' => $InvoiceIssuerGlobalID, // GlobalID of invoice sender (Supplier)
@@ -358,6 +408,93 @@ class CdarHandler
 		//echo "CDAR file generated: " . $filename;
 
 		return array('res' => 1, 'message' => 'CDAR file generated successfully', 'file' => $filename);
+	}
+
+	/**
+	 * Build the MDG-43 "cashed amount" (MEN) blocks of a status 212 (Encaissee) CDAR.
+	 *
+	 * The reform asks the seller to declare what was actually cashed, broken down by VAT rate: one block per
+	 * rate, holding the TTC amount (MDT-215) and the rate itself (MDT-224). Dolibarr only records a payment as
+	 * a single TTC amount, so the amount is spread over the VAT rates of the invoice proportionally to their
+	 * TTC weight: exact for a fully paid invoice, prorata otherwise (a partial payment is not attached to
+	 * given lines in Dolibarr). Rounding differences are absorbed by the largest block so the blocks always
+	 * sum up to the cashed amount.
+	 *
+	 * @param  Facture|FactureFournisseur $object       Invoice the payment belongs to
+	 * @param  array{amount?:float,breakdown?:array<array{vatrate:float,amount:float}>}  $paymentData  Cashed amount (TTC, company currency) and/or a ready-made breakdown. Defaults to the sum of the payments of the invoice.
+	 * @return array<array{TypeCode:string,ValueAmount:string,CurrencyID:string,ValuePercent:string}>  MEN blocks, empty if they cannot be computed
+	 */
+	public function getCashedAmountCharacteristics($object, $paymentData = array())
+	{
+		global $conf;
+
+		$breakdown = array();
+
+		if (!empty($paymentData['breakdown'])) {
+			$breakdown = $paymentData['breakdown'];
+		} else {
+			$cashedAmount = isset($paymentData['amount']) ? (float) $paymentData['amount'] : 0.0;
+			if (empty($cashedAmount) && method_exists($object, 'getSommePaiement')) {
+				$cashedAmount = (float) $object->getSommePaiement();
+			}
+			if ($cashedAmount <= 0) {
+				dol_syslog(__METHOD__ . ' No cashed amount found for invoice id=' . $object->id, LOG_WARNING, 0, '_einvoicing');
+				return array();
+			}
+
+			if (empty($object->lines)) {
+				$object->fetch_lines();
+			}
+
+			// TTC weight of each VAT rate of the invoice
+			$totalPerRate = array();
+			foreach ($object->lines as $line) {
+				$rate = (string) price2num($line->tva_tx, 'MU');
+				if (!isset($totalPerRate[$rate])) {
+					$totalPerRate[$rate] = 0.0;
+				}
+				$totalPerRate[$rate] += (float) $line->total_ttc;
+			}
+
+			$totalTtc = array_sum($totalPerRate);
+			if ($totalTtc <= 0) {
+				dol_syslog(__METHOD__ . ' Cannot split the cashed amount, invoice id=' . $object->id . ' has no positive TTC total', LOG_WARNING, 0, '_einvoicing');
+				return array();
+			}
+
+			$ratio = $cashedAmount / $totalTtc;
+			$rounded = 0.0;
+			$biggest = null;
+			foreach ($totalPerRate as $rate => $amountTtc) {
+				$amount = (float) price2num($amountTtc * $ratio, 'MT');
+				$rounded += $amount;
+				$breakdown[$rate] = array('vatrate' => (float) $rate, 'amount' => $amount);
+				if (is_null($biggest) || $amount > $breakdown[$biggest]['amount']) {
+					$biggest = $rate;
+				}
+			}
+
+			// Keep the sum of the blocks equal to what was really cashed
+			$residual = (float) price2num($cashedAmount - $rounded, 'MT');
+			if (!empty($residual) && !is_null($biggest)) {
+				$breakdown[$biggest]['amount'] = (float) price2num($breakdown[$biggest]['amount'] + $residual, 'MT');
+			}
+		}
+
+		$characteristics = array();
+		foreach ($breakdown as $entry) {
+			if (empty($entry['amount'])) {	// A rate that cashed nothing brings no information
+				continue;
+			}
+			$characteristics[] = array(
+				'TypeCode' => 'MEN',
+				'ValueAmount' => number_format((float) $entry['amount'], 2, '.', ''),
+				'CurrencyID' => $conf->currency,
+				'ValuePercent' => number_format((float) $entry['vatrate'], 2, '.', '')
+			);
+		}
+
+		return $characteristics;
 	}
 
 
@@ -769,6 +906,29 @@ class CdarHandler
 						(string) $doc['SpecifiedDocumentStatus']['SequenceNumeric']
 					)
 				);
+			}
+
+			// MDG-43 blocks (cashed amount per VAT rate for status 212). Element order follows the D22B
+			// DocumentCharacteristicType sequence: TypeCode, then ValueAmount, then ValuePercent.
+			if (!empty($doc['SpecifiedDocumentStatus']['SpecifiedDocumentCharacteristic'])) {
+				foreach ($doc['SpecifiedDocumentStatus']['SpecifiedDocumentCharacteristic'] as $characteristic) {
+					$characteristicElement = $dom->createElement('ram:SpecifiedDocumentCharacteristic');
+					$characteristicElement->appendChild($dom->createElement('ram:TypeCode', $characteristic['TypeCode']));
+
+					if (isset($characteristic['ValueAmount'])) {
+						$amountElement = $dom->createElement('ram:ValueAmount', (string) $characteristic['ValueAmount']);
+						if (!empty($characteristic['CurrencyID'])) {
+							$amountElement->setAttribute('currencyID', $characteristic['CurrencyID']);
+						}
+						$characteristicElement->appendChild($amountElement);
+					}
+
+					if (isset($characteristic['ValuePercent'])) {
+						$characteristicElement->appendChild($dom->createElement('ram:ValuePercent', (string) $characteristic['ValuePercent']));
+					}
+
+					$status->appendChild($characteristicElement);
+				}
 			}
 
 			$ref->appendChild($status);


### PR DESCRIPTION
Split of #457, part 3/5. Follows #476 and #477, both merged; independent of the two parts still to come.

## Problem

Recording a payment on an invoice already transmitted to the platform makes the lifecycle message fail with a HTTP 400:

```
[BR-FR-CDV-14/MDT-207] : Si le statut est 'Encaissé' (MDT-105 = 212), ALORS il doit y avoir au moins 1 Bloc MDG-43
avec une valeur de MDT-207 = MEN et tous les blocs MDG-43 avec une valeur MDT-207 = 'MEN' doivent contenir une
valeur MDT-215 (Montant) et une valeur de MDT-224 (pourcentage de TVA).
```

The CDAR built for the status 212 carries no amount at all: `generateCdarFile()` only knows the invoice reference and the status code. Fixing that surfaces a second broken rule, `BR-FR-CDV-16` (MDT-124-2, the status detail sequence number), which the module only emits when a reason code is present — so never for a 212. And once the message is schema-valid, the platform answers `no matching invoices found`: the CDAR declares **us as the buyer issuing the status to ourselves as the seller**, which is the mapping of a *supplier* invoice status, so the platform cannot find the invoice the status is about.

## What this does

- **Cashed amount (MDG-43 / MEN).** `CdarHandler::getCashedAmountCharacteristics()` spreads the cashed amount over the VAT rates of the invoice proportionally to their TTC weight — exact on a full payment, prorata otherwise, since Dolibarr does not attach a payment to given lines. The rounding residual is absorbed by the largest block so the blocks always sum up to what was really cashed. Generation now refuses to build a 212 it cannot fill instead of letting the platform reject it.
- **Sequence number (MDT-124-2).** Emitted for any status detail block, not only for the ones carrying a reason code.
- **Parties of the cash-in.** A 212 is the only status we send on one of our *own* invoices: issuer = our SIREN with role `SE`, recipient = the buyer SIREN with role `BY` and its routing ID (`0225`). Supplier invoice statuses keep the mapping they are already accepted with (us as `BY`, addressed to the vendor as `SE`), including the recipient address merged in #476.

The amount is passed through `sendStatusMessage()` as an optional `$paymentData` argument; when it is absent the sum of the payments recorded on the invoice is used, so the existing caller keeps working unchanged.

## Testing

The generated message was validated against the UN/CEFACT **CDAR D22B XSD** and the full **FNFE `BR-FR-CDV` schematron** (`fnfempe/France_RFE`): 26 rules fired, 0 failed assert. Its structure was diffed against the official **XP Z12-012 annex B** example `UC1_F202500003_07-CDV-212_Encaissee.xml`. Both the full-payment and the partial-payment breakdowns were checked (blocks summing exactly to the cashed amount).

End to end: the cash-in of a real invoice was accepted by the platform (`acknowledgement: Ok`) after having been rejected on each of the three points above. `phan --quick` clean.

## What is not in this PR

Reporting a status per payment instead of once when the invoice becomes fully paid, and the options framing the scope of the obligation, are a behaviour change of their own and come in the next part of the split.
