### PR TITLE
FIX: claim the already-paid billing frame (BT-23) only when BR-FR-CO-09 is satisfied

### DIFF
--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -69,10 +69,13 @@ trait CommonProtocol
 	 *     S = Services
 	 *     M = Mixed (products + services non-accessory)
 	 *
-	 * @param  Facture $invoice Dolibarr invoice object
+	 * @param  Facture 		$invoice 		Dolibarr invoice object
+	 * @param  float|null	$alreadyPaid	Amount already received that the document will report as
+	 *                                      BT-113 (payments + used credit notes). Null recomputes the
+	 *                                      payments alone, which is enough for a standalone call.
 	 * @return string  BillingProcessID
 	 */
-	public function getBillingProcessID($invoice)
+	public function getBillingProcessID($invoice, $alreadyPaid = null)
 	{
 		$hasProduct  = false;
 		$hasService  = false;
@@ -101,7 +104,27 @@ trait CommonProtocol
 		}
 
 		// Determine suffix 1 (initial invoice) or 2 (already paid invoice) according to invoice status and payment information and if the invoice contain a line a deposit (prepayment) so final invoice after deposit then suffix is 4
-		if ($invoice->status == Facture::STATUS_CLOSED && empty($invoice->close_code)) {
+		//
+		// BT-23 describes the billing case of the document, it is not a payment status: in the AFNOR
+		// nominal use case (XP Z12-012 annexe B, UC1_F202500003) the invoice is issued in frame S1 and
+		// stays S1 while the CDAR lifecycle reports 211 "Paiement transmis" then 212 "Encaissée" — the
+		// document is never re-issued in S2. So "already paid" only covers an invoice whose amount was
+		// already received when it was issued, and BR-FR-CO-09 makes that concrete and mandatory:
+		// with B2/S2/M2 the amount already paid (BT-113) must equal the total (BT-112) and the amount
+		// due (BT-115) must be 0, both fatal.
+		//
+		// Deriving the suffix from Facture::STATUS_CLOSED alone broke that: an invoice closed as paid
+		// without matching payment records — what "Classify as paid" does, and what the deposit turned
+		// into a discount does — still reports BT-113 = 0, so the document declared itself already paid
+		// while claiming the full amount was due, and was rejected. Claim the frame only when the
+		// amount the document will actually carry in BT-113 covers the total.
+		$totalTtc = (float) price2num($invoice->total_ttc, 'MT');
+		if ($alreadyPaid === null) {
+			$alreadyPaid = (float) $invoice->getSommePaiement();
+		}
+		$isFullyPaid = ($totalTtc != 0.0 && abs((float) $alreadyPaid - $totalTtc) < 0.005);
+
+		if ($invoice->status == Facture::STATUS_CLOSED && empty($invoice->close_code) && $isFullyPaid) {
 			return $prefix . '2';
 		} else {
 			// Check if the invoice contains a deposit (prepayment) line

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -670,7 +670,10 @@ $invoiceData = [
 	'invoicingPeriodStart' => null,
 	'invoicingPeriodEnd'   => null,
 
-	'businessProcessId'    => $this->getBillingProcessID($object),		// B1, B2, B3, B4 / S1, S2, S3, S4 / M1, M2, M3, M4
+	// $prepaidAmount is what the document reports in BT-113, and BR-FR-CO-09 ties the "already paid"
+	// frames to it, so the frame has to be decided from the same figure.
+	// Values allowed by BR-FR-08: B1, S1, M1, B2, S2, M2, S3, B4, S4, M4, S5, S6, B7, S7, B8, S8, M8, B9, S9, M9
+	'businessProcessId'    => $this->getBillingProcessID($object, $prepaidAmount),
 	'isTestDocument'       => !empty($object->specimen),
 
 	// Notes


### PR DESCRIPTION
## Problème

`CommonProtocol::getBillingProcessID()` renvoyait le suffixe `2` (« facture déjà payée ») dès que la facture était classée payée dans Dolibarr :

```php
if ($invoice->status == Facture::STATUS_CLOSED && empty($invoice->close_code)) {
    return $prefix . '2';
}
```

Or BT-113 (montant déjà payé) est construit à partir des **paiements réellement enregistrés**. Une facture close sans écriture de paiement — ce que fait le bouton « Classer payé », et ce que fait la facture d'acompte convertie en remise — se déclarait donc déjà payée tout en réclamant la totalité du montant.

## Référence normative

**1. BT-23 est le cadre de facturation, pas un statut de paiement.**

Cas nominal AFNOR, XP Z12-012 annexe B (`fnfempe/France_RFE`, `Z.example/XP_Z12-012_Annexe_B_EXEMPLES_V1.4.zip`), jeu `UC1_F202500003` : la facture est émise en cadre **S1**…

```xml
<ram:BusinessProcessSpecifiedDocumentContextParameter>
  <ram:ID>S1</ram:ID>
</ram:BusinessProcessSpecifiedDocumentContextParameter>
```

…puis le cycle de vie CDAR remonte `200 → 202 → 203 → 204 → 205 → 211 Paiement transmis → 212 Encaissée`. Il n'y a **qu'un seul document facture** (`UC1_F202500003_00-INV_20250701`), jamais réémis en S2. Le paiement postérieur se signale par les statuts de cycle de vie, pas en changeant BT-23.

Confirmation par contre-exemple dans le même corpus : l'autofacture `UC13_AUTOF202600028` est en cadre **B1** avec `TotalPrepaidAmount` = 244,67 et `DuePayableAmount` = 22 359,33. Un montant déjà encaissé ne fait pas basculer le cadre.

**2. Les cadres « déjà payée » imposent des montants cohérents.**

`BR-FR-Flux2-Schematron-CII.sch`, contexte `rsm:CrossIndustryInvoice`, `$isPaidMode = $frameworkCode = ('B2','S2','M2')` :

| Règle | `flag` | Test | Message |
|---|---|---|---|
| `BR-FR-CO-09_BT-23-1` | **fatal** | `not($isPaidMode) or (number($paidAmount) = number($totalAmount))` | *Si le cadre de facturation (BT-23) est B2, S2 ou M2 (facture déjà payée), alors le montant déjà payé (BT-113) doit être égal au montant total TTC (BT-112).* |
| `BR-FR-CO-09_BT-23-2` | **fatal** | `not($isPaidMode) or (number($dueAmount) = 0)` | *…alors le net à payer (BT-115) doit être égal à 0.* |
| `BR-FR-CO-09_BT-23-3` | **fatal** | `not($isPaidMode) or string($dueDate)` | *…alors la date d'échéance (BT-9) doit être renseignée et correspondre à la date de paiement.* |

Pour mémoire, `BR-FR-08/BT-23` fixe les valeurs autorisées : `B1, S1, M1, B2, S2, M2, S3, B4, S4, M4, S5, S6, B7, S7, B8, S8, M8, B9, S9, M9` (ni B3 ni M3, contrairement au commentaire présent dans le code — corrigé ici).

## Correctif

Le cadre se décide à partir du **montant que le document va effectivement porter en BT-113**, que `buildinvoicelines.inc.php` calcule déjà quelques lignes plus haut sous le nom `$prepaidAmount` (paiements + avoirs consommés). `getBillingProcessID()` prend ce montant en second paramètre optionnel ; sans lui, il retombe sur `getSommePaiement()` pour rester utilisable seul.

**Le cadre reste atteignable** : une facture encaissée à l'émission (paiement enregistré pour la totalité, puis clôture) sort toujours en `B2`, avec BT-113 = BT-112, BT-115 = 0 et BT-9 présent — les trois conditions de BR-FR-CO-09 satisfaites naturellement.

## Vérification

Même corpus que ci-dessus : 288 documents, 13 factures × 6 profils × CII et Factur-X, sur **Dolibarr 18.0.10 et 20.0.5**.

| | avant | après |
|---|---|---|
| `BR-FR-CO-09` en `fatal` | 24 | **0** |
| Autres règles touchées | — | **aucune** |

Facture d'acompte close par `setPaid()` sans paiement : passe de `B2 / prépayé 0,00 / dû 360,00` (rejeté) à `B1 / prépayé 0,00 / dû 360,00` (conforme). Facture partiellement payée : reste `B1`, prépayé 1 000,00, dû 1 220,00. Vente comptoir encaissée à l'émission : `B2`, prépayé 120,00 = total 120,00, dû 0,00.

`phan --quick` et `phpcs` propres.

## Tests

La couverture phpunit de ce correctif (`BillingProcessIdTest` : encaissée à l'émission pour les trois préfixes B/S/M, close sans paiement, partiellement payée, close pour un autre motif, validée impayée, et facture de solde après acompte) est portée par #499, avec l'include de compatibilité dont elle a besoin. Cette PR reste donc du code pur et **aucun ordre de fusion n'est imposé** entre les trois.

Contrôle négatif déjà effectué : sans ce correctif, 2 tests tombent sur `Failed asserting that two strings are identical: -'B1' +'B2'`.
