### PR TITLE
FIX: make the phpunit suite runnable on the Dolibarr versions the module claims to support, and cover #497 / #498

### DIFF
--- a/einvoicing/test/phpunit/BillingProcessIdTest.php
+++ b/einvoicing/test/phpunit/BillingProcessIdTest.php
@@ -1,0 +1,183 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/BillingProcessIdTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for the billing frame (BT-23).
+ *                  BT-23 describes the billing case of the document, not a payment status: in the
+ *                  AFNOR nominal use case (XP Z12-012 annexe B, UC1_F202500003) the invoice is
+ *                  issued in frame S1 and stays S1 while the CDAR lifecycle reports 211 then 212.
+ *                  The "already paid" frames B2/S2/M2 are therefore reserved to an invoice whose
+ *                  amount was already received when it was issued, which BR-FR-CO-09 makes
+ *                  concrete: BT-113 must equal BT-112 and BT-115 must be 0, both fatal.
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+// See the same block in CIIProtocolTest.php.
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+require_once DOL_DOCUMENT_ROOT . '/compta/facture/class/facture.class.php';
+dol_include_once('einvoicing/class/protocols/CIIProtocol.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class BillingProcessIdTest extends CommonClassTest
+{
+	/**
+	 * An in-memory invoice: getBillingProcessID() only reads lines, status, close_code and
+	 * total_ttc, so nothing has to be written to the database.
+	 *
+	 * @param	int		$status			Facture::STATUS_* value
+	 * @param	float	$totalTtc		Invoice total including VAT
+	 * @param	array	$productTypes	product_type of each line (0 goods, 1 service)
+	 * @param	string	$closeCode		Dolibarr close code, non-empty means closed for another reason than payment
+	 * @return	Facture					The stub invoice
+	 */
+	private function makeInvoice($status, $totalTtc, array $productTypes = [0], $closeCode = '')
+	{
+		global $db;
+
+		$invoice = new Facture($db);
+		$invoice->status     = $status;
+		$invoice->statut     = $status;
+		$invoice->close_code = $closeCode;
+		$invoice->total_ttc  = $totalTtc;
+		$invoice->lines      = [];
+
+		foreach ($productTypes as $type) {
+			$line = new FactureLigne($db);
+			$line->product_type = $type;
+			$invoice->lines[] = $line;
+		}
+
+		return $invoice;
+	}
+
+	/**
+	 * An invoice whose amount was already received when it was issued is the case B2/S2/M2
+	 * describes, and BR-FR-CO-09 is satisfied because BT-113 does equal BT-112.
+	 *
+	 * @return void
+	 */
+	public function testFullyPaidAtIssuanceUsesTheAlreadyPaidFrame()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$this->assertSame('B2', $protocol->getBillingProcessID($this->makeInvoice(Facture::STATUS_CLOSED, 120.0, [0]), 120.0));
+		$this->assertSame('S2', $protocol->getBillingProcessID($this->makeInvoice(Facture::STATUS_CLOSED, 120.0, [1]), 120.0));
+		$this->assertSame('M2', $protocol->getBillingProcessID($this->makeInvoice(Facture::STATUS_CLOSED, 120.0, [0, 1]), 120.0));
+	}
+
+	/**
+	 * An invoice closed as paid without matching payment records still reports BT-113 = 0, so it
+	 * must not claim the already-paid frame: that combination is a fatal BR-FR-CO-09. This is what
+	 * "Classify as paid" produces, and what a deposit invoice turned into a discount produces.
+	 *
+	 * @return void
+	 */
+	public function testClosedWithoutPaymentKeepsTheInitialFrame()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$this->assertSame('B1', $protocol->getBillingProcessID($this->makeInvoice(Facture::STATUS_CLOSED, 360.0, [0]), 0.0));
+		$this->assertSame('S1', $protocol->getBillingProcessID($this->makeInvoice(Facture::STATUS_CLOSED, 360.0, [1]), 0.0));
+	}
+
+	/**
+	 * A partially paid invoice is not "already paid" either.
+	 *
+	 * @return void
+	 */
+	public function testPartiallyPaidKeepsTheInitialFrame()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$this->assertSame('B1', $protocol->getBillingProcessID($this->makeInvoice(Facture::STATUS_CLOSED, 2220.0, [0]), 1000.0));
+	}
+
+	/**
+	 * An invoice closed for another reason than payment (close_code set, e.g. abandoned) never
+	 * claims the already-paid frame.
+	 *
+	 * @return void
+	 */
+	public function testClosedForAnotherReasonKeepsTheInitialFrame()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$invoice = $this->makeInvoice(Facture::STATUS_CLOSED, 120.0, [0], 'bankcharge');
+
+		$this->assertSame('B1', $protocol->getBillingProcessID($invoice, 120.0));
+	}
+
+	/**
+	 * A validated but unpaid invoice is the ordinary initial frame.
+	 *
+	 * @return void
+	 */
+	public function testValidatedUnpaidUsesTheInitialFrame()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$this->assertSame('B1', $protocol->getBillingProcessID($this->makeInvoice(Facture::STATUS_VALIDATED, 120.0, [0]), 0.0));
+	}
+
+	/**
+	 * A final invoice consuming a deposit keeps the "after deposit" frame, which BR-FR-CO-08 ties
+	 * to a document that is not itself a deposit invoice.
+	 *
+	 * @return void
+	 */
+	public function testFinalInvoiceAfterDepositUsesTheDepositFrame()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$invoice = $this->makeInvoice(Facture::STATUS_VALIDATED, 1200.0, [0]);
+		$invoice->lines[0]->desc = '(DEPOSIT)';
+
+		$this->assertSame('B4', $protocol->getBillingProcessID($invoice, 0.0));
+	}
+}

--- a/einvoicing/test/phpunit/CIIProfileShapeTest.php
+++ b/einvoicing/test/phpunit/CIIProfileShapeTest.php
@@ -1,0 +1,304 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/CIIProfileShapeTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for the groups a profile is allowed to carry.
+ *                  MINIMUM and BASIC WL are header-only Factur-X profiles: neither
+ *                  ram:IncludedSupplyChainTradeLineItem (BG-25) nor ram:DefinedTradeContact
+ *                  (BG-6 / BG-9) is declared in their XSD, so emitting either makes every
+ *                  generated document fail the profile schema. Every profile from BASIC upwards
+ *                  expects both.
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+// See the same block in CIIProtocolTest.php: DOLIBARR_HTDOCS lets the developer/CI point explicitly
+// at the Dolibarr instance to test against, otherwise we fall back to the relative path that is
+// valid when this file is reached through the htdocs/custom/einvoicing symlink.
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+dol_include_once('einvoicing/class/protocols/CIIProtocol.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class CIIProfileShapeTest extends CommonClassTest
+{
+	/**
+	 * Header data covering every key buildXML() reads, with a single-rate, no-discount,
+	 * no-reference baseline. Amounts are consistent so the document would also stand a
+	 * business-rule check, which is not what this test is about.
+	 *
+	 * @return array
+	 */
+	private function baseInvoiceData(): array
+	{
+		$date = new DateTime('2026-07-01');
+
+		return [
+			'documentno' => 'FA2607-0001',
+			'documenttypecode' => '380',
+			'documentdate' => $date,
+			'invoiceCurrency' => 'EUR',
+			'taxCurrency' => null,
+			'documentname' => null,
+			'documentlanguage' => 'fr',
+			'effectiveSpecifiedPeriod' => 'NA',
+			'documentDeliveryDate' => $date,
+			'invoicingPeriodStart' => null,
+			'invoicingPeriodEnd' => null,
+			'businessProcessId' => 'B1',
+			'isTestDocument' => false,
+			'documentNotePublic' => '',
+			'documentNotePMT' => '',
+			'documentNotePMD' => '',
+			'documentNoteAAB' => '',
+			'documentNoteTXD' => '',
+			'vatDueDateTypeCode' => '5',
+			'documentNotes' => [],
+
+			'sellername' => 'Brasserie du Test SAS',
+			'sellerids' => '892304189',
+			'sellerlineone' => '12 rue des Houblons',
+			'sellerlinetwo' => '',
+			'sellerlinethree' => '',
+			'sellerpostcode' => '86000',
+			'sellercity' => 'Poitiers',
+			'sellercountry' => 'FR',
+			'sellersubdivision' => null,
+			'sellercontactpersonname' => 'Service facturation',
+			'sellercontactdepartmentname' => null,
+			'sellercontactphoneno' => '+33549000000',
+			'sellercontactfaxno' => '',
+			'sellercontactemailaddr' => 'facturation@example.org',
+			'sellerCommunicationUriScheme' => '0225',
+			'sellerCommunicationUri' => '89230418900020',
+			'sellerGlobalIds' => [['schemeID' => '0225', 'value' => '89230418900020']],
+			'sellerTaxRegistrations' => [],
+			'sellervatnumber' => 'FR87892304189',
+			'sellerLegalOrgId' => '892304189',
+			'sellerLegalOrgScheme' => '0002',
+			'sellerTradingName' => 'Brasserie du Test SAS',
+
+			'buyername' => 'Tricaland SAS',
+			'buyerids' => '123456782',
+			'buyerlineone' => '5 avenue de la Distribution',
+			'buyerlinetwo' => '',
+			'buyerlinethree' => '',
+			'buyerpostcode' => '75011',
+			'buyercity' => 'Paris',
+			'buyercountry' => 'FR',
+			'buyersubdivision' => null,
+			'buyervatnumber' => 'FR32123456782',
+			'buyerGlobalIds' => [['schemeID' => '0225', 'value' => '12345678200019']],
+			'buyerLegalOrgId' => '123456782',
+			'buyerLegalOrgScheme' => '0002',
+			'buyerTradingName' => 'Tricaland SAS',
+			'buyerReference' => null,
+			'buyerCommunicationUriScheme' => '0225',
+			'buyerCommunicationUri' => '12345678200019',
+			'buyercontactpersonname' => 'Service achats',
+			'buyercontactemailaddr' => 'achats@example.org',
+			'buyercontactphoneno' => '+33100000000',
+
+			'grandTotalAmount' => 120.0,
+			'duePayableAmount' => 120.0,
+			'lineTotalAmount' => 100.0,
+			'chargeTotalAmount' => 0.0,
+			'allowanceTotalAmount' => 0.0,
+			'taxBasisTotalAmount' => 100.0,
+			'taxTotalAmount' => 20.0,
+			'roundingAmount' => null,
+			'totalPrepaidAmount' => 0.0,
+
+			'paymentMeansCode' => 30,
+			'paymentMeansText' => 'Virement bancaire',
+			'iban_id' => 1,
+			'iban' => 'FR7630003036200002012345652',
+			'bic' => 'SOGEFRPP',
+			'accountName' => 'Brasserie du Test SAS',
+			'accountRef' => 'BQTEST',
+			'accountLabel' => 'Compte courant',
+			'paymentDueDate' => $date,
+			'paymentTermsText' => '',
+			'headerAllowancesCharges' => [],
+			'invoiceRefDocs' => [],
+			'orderReference' => '',
+			'contractReference' => null,
+			'despatchAdviceRef' => null,
+			'taxBreakdown' => [
+				'20' => [
+					'tva_tx' => 20.0,
+					'vat_src_code' => '',
+					'categoryVAT' => 'S',
+					'ExemptionReasonCode' => '',
+					'ExemptionReason' => '',
+					'totalHT' => 100.0,
+					'totalTVA' => 20.0,
+				],
+			],
+			'_chorus' => false,
+			'_depositlines' => [],
+			'_globalDiscounts' => [],
+			'_customerOrderReferenceList' => [],
+			'_project' => null,
+		];
+	}
+
+	/**
+	 * One neutral invoice line.
+	 *
+	 * @return array
+	 */
+	private function baseLinesData(): array
+	{
+		return [
+			[
+				'lineid' => 1,
+				'prodsellerid' => '',
+				'prodname' => 'Biere blonde 33cl',
+				'proddesc' => '',
+				'netpriceamount' => 100.0,
+				'billedquantity' => 1.0,
+				'billedquantityunitcode' => 'C62',
+				'tva_tx' => 20.0,
+				'vat_src_code' => '',
+				'categoryCode' => 'S',
+				'rateApplicablePercent' => '20.00',
+				'discountPercent' => 0,
+				'lineTotalAmount' => 100.0,
+				'linePeriodStart' => null,
+				'linePeriodEnd' => null,
+				'isDepositLine' => false,
+			],
+		];
+	}
+
+	/**
+	 * Count the occurrences of an element in a generated document.
+	 *
+	 * @param	string	$xml	Generated XML
+	 * @param	string	$tag	Qualified tag name, e.g. 'ram:DefinedTradeContact'
+	 * @return	int				Number of occurrences
+	 */
+	private function countTag(string $xml, string $tag): int
+	{
+		$doc = new DOMDocument();
+		$this->assertTrue($doc->loadXML($xml), 'generated document is not well-formed XML');
+
+		return $doc->getElementsByTagName(explode(':', $tag)[1])->length;
+	}
+
+	/** @var string[] Elements the MINIMUM and BASIC WL schemas do not declare at all */
+	private static $headerOnlyForbidden = [
+		'ram:IncludedSupplyChainTradeLineItem',					// BG-25
+		'ram:DefinedTradeContact',								// BG-6 / BG-9
+		'ram:Information',										// BT-82
+		'ram:AccountName',										// BT-85
+		'ram:PayeeSpecifiedCreditorFinancialInstitution',		// BT-86
+	];
+
+	/**
+	 * The header-only profiles must carry none of the groups their XSD does not declare.
+	 *
+	 * @return void
+	 */
+	public function testHeaderOnlyProfilesCarryNoneOfTheForbiddenGroups()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		foreach (['MINIMUM', 'BASICWL'] as $profile) {
+			$xml = $protocol->buildXML($this->baseInvoiceData(), $this->baseLinesData(), $profile);
+
+			foreach (self::$headerOnlyForbidden as $tag) {
+				$this->assertSame(0, $this->countTag($xml, $tag), $profile . ' must not carry ' . $tag);
+			}
+			// BT-84 does exist there and must survive
+			$this->assertSame(1, $this->countTag($xml, 'ram:IBANID'), $profile . ' must keep the payment account IBAN');
+		}
+	}
+
+	/**
+	 * Every profile from BASIC upwards keeps those groups: the fix for the header-only profiles
+	 * must not strip them everywhere.
+	 *
+	 * @return void
+	 */
+	public function testOtherProfilesKeepTheFullGroups()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		foreach (['BASIC', 'EN16931', 'EXTENDED', 'EXTENDEDFR'] as $profile) {
+			$xml = $protocol->buildXML($this->baseInvoiceData(), $this->baseLinesData(), $profile);
+
+			$this->assertSame(1, $this->countTag($xml, 'ram:IncludedSupplyChainTradeLineItem'), $profile . ' must carry the invoice line');
+			foreach (['ram:DefinedTradeContact', 'ram:Information', 'ram:AccountName', 'ram:PayeeSpecifiedCreditorFinancialInstitution'] as $tag) {
+				$this->assertGreaterThan(0, $this->countTag($xml, $tag), $profile . ' must carry ' . $tag);
+			}
+		}
+	}
+
+	/**
+	 * The header totals do not depend on the line nodes, so dropping them must leave the
+	 * monetary summation untouched.
+	 *
+	 * @return void
+	 */
+	public function testHeaderTotalsAreUnchangedWithoutLines()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$withLines = $protocol->buildXML($this->baseInvoiceData(), $this->baseLinesData(), 'BASIC');
+		$without   = $protocol->buildXML($this->baseInvoiceData(), $this->baseLinesData(), 'BASICWL');
+
+		foreach (['LineTotalAmount', 'TaxBasisTotalAmount', 'GrandTotalAmount', 'DuePayableAmount'] as $tag) {
+			$a = new DOMDocument();
+			$a->loadXML($withLines);
+			$b = new DOMDocument();
+			$b->loadXML($without);
+
+			$va = $a->getElementsByTagName($tag)->item(0);
+			$vb = $b->getElementsByTagName($tag)->item(0);
+
+			$this->assertNotNull($va, $tag . ' missing from the BASIC document');
+			$this->assertNotNull($vb, $tag . ' missing from the BASICWL document');
+			$this->assertSame($va->nodeValue, $vb->nodeValue, $tag . ' must not depend on the line nodes');
+		}
+	}
+}

--- a/einvoicing/test/phpunit/CIIProtocolTest.php
+++ b/einvoicing/test/phpunit/CIIProtocolTest.php
@@ -47,7 +47,7 @@ if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
 
 require_once $dolibarrHtdocs . '/master.inc.php';
 dol_include_once('einvoicing/class/protocols/CIIProtocol.class.php');
-require_once DOL_DOCUMENT_ROOT . '/../test/phpunit/CommonClassTest.class.php';
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
 
 /**
  * Class for PHPUnit tests

--- a/einvoicing/test/phpunit/CommonClassTestCompat.inc.php
+++ b/einvoicing/test/phpunit/CommonClassTestCompat.inc.php
@@ -1,0 +1,98 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/CommonClassTestCompat.inc.php
+ *      \ingroup    test
+ *      \brief      Make CommonClassTest available whatever the Dolibarr version.
+ *      \remarks    The module supports Dolibarr >= 17 (see modEInvoicing::$need_dolibarr_version) but
+ *                  test/phpunit/CommonClassTest.class.php only appeared later: on Dolibarr 18 the
+ *                  require_once fatals and the whole suite is unrunnable. When the core class is
+ *                  there we use it, so the tests behave exactly like the core ones; otherwise we
+ *                  declare the small subset the module tests actually rely on ($savconf, $savuser,
+ *                  $savlangs, $savdb and the surrounding transaction).
+ *
+ *                  Include this instead of requiring CommonClassTest.class.php directly. Requires
+ *                  master.inc.php to have been included first (DOL_DOCUMENT_ROOT must be defined).
+ */
+
+if (!defined('DOL_DOCUMENT_ROOT')) {
+	throw new \RuntimeException('CommonClassTestCompat.inc.php must be included after master.inc.php');
+}
+
+$coreCommonClassTest = DOL_DOCUMENT_ROOT . '/../test/phpunit/CommonClassTest.class.php';
+
+if (file_exists($coreCommonClassTest)) {
+	require_once $coreCommonClassTest;
+} elseif (!class_exists('CommonClassTest', false)) {
+	/**
+	 * Minimal stand-in for the core CommonClassTest, for Dolibarr versions that do not ship it.
+	 *
+	 * Globals are captured in setUp() rather than in a constructor on purpose: the constructor
+	 * signature of PHPUnit\Framework\TestCase changed between PHPUnit major versions, and the tests
+	 * only read $this->sav* from inside the test methods anyway.
+	 */
+	abstract class CommonClassTest extends PHPUnit\Framework\TestCase
+	{
+		/** @var Conf 		Global $conf saved at setUp() */
+		protected $savconf;
+		/** @var User 		Global $user saved at setUp() */
+		protected $savuser;
+		/** @var Translate 	Global $langs saved at setUp() */
+		protected $savlangs;
+		/** @var DoliDB 	Global $db saved at setUp() */
+		protected $savdb;
+
+		/**
+		 * Open a transaction around the whole test class, like the core class does.
+		 *
+		 * @return void
+		 */
+		public static function setUpBeforeClass(): void
+		{
+			global $db;
+			$db->begin();
+		}
+
+		/**
+		 * Save the globals the tests read back.
+		 *
+		 * @return void
+		 */
+		protected function setUp(): void
+		{
+			global $conf, $user, $langs, $db;
+
+			$this->savconf  = $conf;
+			$this->savuser  = $user;
+			$this->savlangs = $langs;
+			$this->savdb    = $db;
+		}
+
+		/**
+		 * Roll the transaction back so a test run leaves no trace in the database.
+		 *
+		 * @return void
+		 */
+		public static function tearDownAfterClass(): void
+		{
+			global $db;
+			$db->rollback();
+		}
+	}
+}

--- a/einvoicing/test/phpunit/RecipientDirectoryTest.php
+++ b/einvoicing/test/phpunit/RecipientDirectoryTest.php
@@ -44,12 +44,17 @@ if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
 
 require_once $dolibarrHtdocs . '/master.inc.php';
 dol_include_once('einvoicing/class/providers/AbstractPDPProvider.class.php');
-require_once DOL_DOCUMENT_ROOT . '/../test/phpunit/CommonClassTest.class.php';
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
 
 if (empty($user->id)) {
 	print "Load permissions for admin user nb 1\n";
 	$user->fetch(1);
-	$user->loadRights();
+	// User::loadRights() only exists from Dolibarr 19 on, older versions name it getrights()
+	if (method_exists($user, 'loadRights')) {
+		$user->loadRights();
+	} else {
+		$user->getrights();
+	}
 }
 $conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 

--- a/einvoicing/test/phpunit/SupplierInvoiceHelperTest.php
+++ b/einvoicing/test/phpunit/SupplierInvoiceHelperTest.php
@@ -46,12 +46,17 @@ require_once $dolibarrHtdocs . '/master.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.facture.class.php';
 dol_include_once('einvoicing/class/einvoicing.class.php');
 dol_include_once('einvoicing/class/helpers/SupplierInvoiceHelper.class.php');
-require_once DOL_DOCUMENT_ROOT . '/../test/phpunit/CommonClassTest.class.php';
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
 
 if (empty($user->id)) {
 	print "Load permissions for admin user nb 1\n";
 	$user->fetch(1);
-	$user->loadRights();
+	// User::loadRights() only exists from Dolibarr 19 on, older versions name it getrights()
+	if (method_exists($user, 'loadRights')) {
+		$user->loadRights();
+	} else {
+		$user->getrights();
+	}
 }
 $conf->global->MAIN_DISABLE_ALL_MAILS = 1;
 


### PR DESCRIPTION
## Problème

`modEInvoicing` déclare :

```php
$this->need_dolibarr_version = array(17, -3);	// Minimum version of Dolibarr required by module
```

mais la suite phpunit du module ne peut pas s'exécuter en dessous de Dolibarr 19, pour deux raisons :

1. `test/phpunit/CommonClassTest.class.php` n'existe pas dans le cœur avant Dolibarr 19. Le `require_once` en tête des trois fichiers de test provoque un fatal **avant même la collecte des tests** :

   ```
   PHP Fatal error: Failed opening required '.../test/phpunit/CommonClassTest.class.php'
   ```

2. `User::loadRights()` a été introduite au même moment ; les versions antérieures la nomment `getrights()` :

   ```
   PHPUnit\TextUI\RuntimeException: Call to undefined method User::loadRights()
   ```

Sur Dolibarr 18.0.10, le résultat est **0 test exécuté**.

## Correctif

`CommonClassTestCompat.inc.php` : utilise la classe `CommonClassTest` du cœur quand l'instance en fournit une — les tests se comportent alors exactement comme les tests du cœur — et déclare sinon le sous-ensemble réellement utilisé par les tests du module : `$savconf` / `$savuser` / `$savlangs` / `$savdb`, et la transaction ouverte autour de la classe puis annulée, de sorte qu'un run ne laisse aucune trace en base.

Les globales sont capturées dans `setUp()` plutôt que dans un constructeur, parce que la signature du constructeur de `PHPUnit\Framework\TestCase` change d'une version majeure à l'autre et que les tests ne lisent `$this->sav*` que depuis les méthodes de test.

`loadRights()` n'est appelée que si elle existe.

## Vérification

Deux instances partageant le même checkout du module :

| Instance | Dolibarr | Chemin emprunté | Résultat |
|---|---|---|---|
| dd3 | 18.0.10 | repli (`CommonClassTest.class.php` absent du cœur) | **24 tests, 92 assertions — OK** |
| dd4 | 20.0.5 | classe du cœur | **24 tests, 92 assertions — OK** |

Avant le correctif, dd3 ne collectait aucun test.

Effet de bord utile : sur le chemin de repli la suite passe aussi sous PHPUnit 11, le repli ne portant pas la signature `onNotSuccessfulTest(Throwable): void` qui rend la classe du cœur incompatible au-delà de PHPUnit 9.

`phan --quick` et `phpcs` propres.

## Tests des deux correctifs en cours

Cette PR porte aussi les deux suites qui couvrent #497 (profils Factur-X sans lignes) et #498 (cadre de facturation BT-23). Elles sont ici plutôt qu'avec les correctifs pour qu'**aucun ordre de fusion ne soit imposé entre les trois** : #497 et #498 restent du code pur, et tout ce qui touche à phpunit atterrit au même endroit.

- `CIIProfileShapeTest` — sur un document généré : MINIMUM et BASIC WL ne portent aucun des cinq groupes que leur XSD ne déclare pas (BG-25 lignes, BG-6/BG-9 contacts, BT-82, BT-85, BT-86) mais conservent BT-84 ; BASIC et au-dessus les portent tous ; la somme monétaire d'en-tête ne dépend pas des nœuds de ligne.
- `BillingProcessIdTest` — le cadre BT-23 sur une facture en mémoire : les cadres « déjà payée » B2/S2/M2 seulement pour une facture encaissée à l'émission (le cas que BR-FR-CO-09 lie à BT-113 = BT-112 et BT-115 = 0), le cadre initial pour une facture close sans paiement correspondant, partiellement payée, close pour un autre motif, ou simplement validée ; plus le cadre B4 d'une facture de solde après acompte.

**Ces deux suites sont rouges tant que #497 et #498 ne sont pas fusionnées** (3 échecs), ce qui est le comportement attendu : elles décrivent la cible. Mesuré :

| État | Résultat |
|---|---|
| Cette PR seule | 33 tests, 3 échecs |
| Avec #497 et #498 | **33 tests, 177 assertions — OK**, sur Dolibarr 18.0.10 comme 20.0.5 |

Rien dans la CI n'en dépend : les workflows jouent `phan` et `phpcs`, pas phpunit. Aucune des trois PR ne peut donc casser le build, quel que soit l'ordre de fusion.
