### PR TITLE
FIX: route the sample-invoice test through the CommonClassTest compatibility include

### DIFF
--- a/einvoicing/test/phpunit/EInvoicingSamplesTest.php
+++ b/einvoicing/test/phpunit/EInvoicingSamplesTest.php
@@ -58,7 +58,7 @@ require_once $dolibarrHtdocs . '/master.inc.php';
  */
 
 dol_include_once('einvoicing/class/einvoicing.class.php');
-require_once DOL_DOCUMENT_ROOT . '/../test/phpunit/CommonClassTest.class.php';
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
 
 
 /**


### PR DESCRIPTION
Follow-up announced in [my comment on #496](https://github.com/Dolibarr/dolibarr-community-modules/pull/496#issuecomment-5106210546) and on #499: the merge order is now known, here is the one-line switch.

## Problem

#499 just made the phpunit suite runnable again on the Dolibarr versions the module claims to support (`need_dolibarr_version = array(17, -3)`). #496 landed right after with a test file still requiring `test/phpunit/CommonClassTest.class.php` directly, which does not exist in the core before Dolibarr 19. On `main` today, **the whole suite fatals again before a single test is collected**:

```
PHP Warning:  require_once(/var/www/dd3/htdocs/../test/phpunit/CommonClassTest.class.php): Failed to open stream: No such file or directory
              in einvoicing/test/phpunit/EInvoicingSamplesTest.php on line 61
PHP Fatal error: Uncaught Error: Failed opening required '.../test/phpunit/CommonClassTest.class.php'
```

## The change

One line, to align that file with the five others:

```diff
-require_once DOL_DOCUMENT_ROOT . '/../test/phpunit/CommonClassTest.class.php';
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
```

## Measured

Module checkout at `main` (28c0e9a), two instances:

| | Dolibarr 18.0.10 | Dolibarr 20.0.5 |
|---|---|---|
| before | **fatal, 0 test collected** | 36 tests collected |
| after | **36 tests collected and run** | 36 tests collected, unchanged |

Dolibarr 20 does not change: the include uses the core class whenever the instance ships one.

## What is still red, and does not belong to this PR

Once the suite is collected, failures remain on `main` that nobody should attribute to this switch:

- **3 failures on both versions** — `EInvoicingSamplesTest`: the committed fixtures no longer match what `main` generates (language frozen into the fixtures, `ram:FaxUniversalCommunication` that `buildParty()` no longer emits, `ram:CategoryTradeTax` removed from line level, `ram:FormattedIssueDateTime` added by #488). Detailed in the comment linked above, with the patch that lets the regeneration script run under a symlinked deployment.
- **3 failures on both versions** — `CIIProfileShapeTest` and `BillingProcessIdTest`: those suites describe the target of #497 and #498, still open. They go green as soon as those merge (measured: 36 tests, 183 assertions, only the 3 fixture failures left).
- **on Dolibarr 18 only**, the 3 sample tests go from failure to error, on two gaps of the module rather than of the test: `ExtraFields` not autoloaded on the PDF generation path, and `buildinvoicelines.inc.php` reading `FactureLigne::$subprice_ttc`, a property declared nowhere in the core. I can take them in a separate PR if you want.
