### PR TITLE
FIX: make the sample-invoice fixtures reproducible on any instance

### DIFF
--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -3062,7 +3062,7 @@ class EInvoicing
 	 */
 	public static function generateSampleEInvoicesForTests()
 	{
-		global $conf, $db;
+		global $conf, $db, $langs;
 		require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
 		require_once DOL_DOCUMENT_ROOT . '/compta/facture/class/facture.class.php';
 
@@ -3096,6 +3096,17 @@ class EInvoicing
 		$conf->global->EINVOICING_PDP = 'SPECIMEN';
 		$conf->global->EINVOICING_SPECIMEN_ROUTING_ID = $seller->idprof2;
 
+		// Same reason for the language: CommonProtocol::generateSampleInvoice() builds the specimen
+		// with the ambient $langs, so the free text it carries (BT-20 payment terms, BT-22 notes,
+		// line descriptions) follows whatever language the instance runs in. The reference fixtures
+		// would then match only on an instance set to the language of whoever generated them.
+		// Pin en_US here, so the specimen is the same everywhere; the interactive sample generation
+		// keeps following the user language, it does not go through this method.
+		$savLangs = $langs;
+		$langs = new Translate('', $conf);
+		$langs->setDefaultLang('en_US');
+		$langs->loadLangs(array('main', 'dict', 'companies', 'bills', 'products', 'einvoicing@einvoicing'));
+
 		$depositXml = '';
 		$standardXml = '';
 		$creditnoteXml = '';
@@ -3121,6 +3132,7 @@ class EInvoicing
 		} finally {
 			$conf->global->EINVOICING_PDP = $savEinvoicingPdp;
 			$conf->global->EINVOICING_SPECIMEN_ROUTING_ID = $savEinvoicingRoutingId;
+			$langs = $savLangs;
 		}
 
 		return array(

--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -354,7 +354,12 @@ trait CommonProtocol
 		$tmpinvoice->contact = $tmpcontact;
 
 
-		// Generate the Dolibarr PDF of the invoice
+		// Generate the Dolibarr PDF of the invoice.
+		// The PDF models reach ExtraFields through CommonDocGenerator::getExtrafieldsInHtml(), and the
+		// core only autoloads that class on the paths that go through a real invoice card. Reached
+		// from a CLI script or a test that only included master.inc.php, the call fatals with
+		// 'Class "ExtraFields" not found', so require it explicitly here.
+		require_once DOL_DOCUMENT_ROOT . '/core/class/extrafields.class.php';
 		$tmpinvoice->generateDocument($tmpinvoice->model_pdf, $outputlangs);
 
 		// For invoice with ->specimen=1, the file is SPECIMEN.pdf so we rename it into ref

--- a/einvoicing/scripts/regenerate_einvoicing_fixtures.php
+++ b/einvoicing/scripts/regenerate_einvoicing_fixtures.php
@@ -35,6 +35,16 @@ if (PHP_SAPI !== 'cli') {
 
 // Load Dolibarr environment
 $res = 0;
+// This module is deployed by symlinking the repository into htdocs/custom/einvoicing, in which case
+// every relative path below resolves inside the repository instead of inside the Dolibarr instance
+// and the include fails. DOLIBARR_HTDOCS lets the developer/CI point explicitly at the instance to
+// run against, exactly like test/phpunit/EInvoicingSamplesTest.php already does.
+$dolibarrHtdocs = rtrim((string) getenv('DOLIBARR_HTDOCS'), '/');
+if (!$res && $dolibarrHtdocs && file_exists($dolibarrHtdocs.'/master.inc.php')) {
+	$_SERVER['DOCUMENT_ROOT'] = $dolibarrHtdocs;
+	chdir($dolibarrHtdocs);
+	$res = @include $dolibarrHtdocs.'/master.inc.php';
+}
 // Try main.inc.php into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
 if (!$res && !empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) {
 	$res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/master.inc.php";
@@ -74,7 +84,7 @@ if (!$res && file_exists("../../../../../../master.inc.php")) {
 	$res = @include "../../../../../../master.inc.php";
 }
 if (!$res) {
-	die("Include of master fails");
+	die("Include of master fails. When the module is deployed as a symlink into htdocs/custom/einvoicing, set DOLIBARR_HTDOCS to the htdocs directory of the Dolibarr instance to run against.\n");
 }
 /**
  * The main.inc.php has been included so the following variable are now defined:


### PR DESCRIPTION
First of the two follow-ups announced in [my comment on #496](https://github.com/Dolibarr/dolibarr-community-modules/pull/496#issuecomment-5106210546). **No fixture is modified here**: the ones committed on `main` are exactly what a correct regeneration produces, this PR only touches the tooling that makes them reproducible.

## Problem

`test/phpunit/README.md` now documents the workflow:

> - Set DOLIBARR_HTDOCS to the path of your dolibarr htdocs directory
> - To regenerate reference invoices : `scripts/regenerate_einvoicing_fixtures.php`

but the script cannot honour it. Three things stop a regeneration from producing the same result anywhere but on the machine of whoever ran it last.

**1. The script never finds `master.inc.php` under a symlinked deployment.** The module is deployed by symlinking the repository into `htdocs/custom/einvoicing`, and every relative path it tries then resolves inside the repository instead of inside the Dolibarr instance:

```
$ cd htdocs/custom/einvoicing/scripts && php regenerate_einvoicing_fixtures.php
Include of master fails
```

It now honours `DOLIBARR_HTDOCS` first, exactly like `EInvoicingSamplesTest.php` and the README already expect, and the `die()` says what to do. Without the variable, behaviour is unchanged.

**2. Even fixed, it fatals on the PDF step.** The PDF models reach `ExtraFields` through `CommonDocGenerator::getExtrafieldsInHtml()`, and the core only autoloads that class on the paths coming from a real invoice card. From a CLI script or a bare test bootstrap:

```
PHP Fatal error: Uncaught Error: Class "ExtraFields" not found
  in htdocs/core/class/commondocgenerator.class.php:1430
  #0 core/modules/facture/doc/pdf_sponge.modules.php(569): CommonDocGenerator->getExtrafieldsInHtml()
  #3 einvoicing/class/protocols/CommonProtocol.class.php(358): Facture->generateDocument()
```

`require_once` of the class where the specimen PDF is generated.

**3. The specimen followed the language of the instance.** `CommonProtocol::generateSampleInvoice()` builds it with the ambient `$langs` (`$outputlangs = $langs; // TODO Use the target language`), so the free text it carries - BT-20 payment terms, BT-22 notes - comes out in the language of whoever regenerates. The fixtures can then only match on their instance. The language is pinned to `en_US` around the generation and `$langs` restored afterwards, right next to the provider and the routing ID the method already pins for exactly the same reason.

## Measured

Module checkout at `main` (cffcfc1), Dolibarr 20.0.5 instance:

| | before | after |
|---|---|---|
| `regenerate_einvoicing_fixtures.php` through the symlink | `Include of master fails` | regenerates the 3 fixtures |
| same, with point 1 alone fixed | `Class "ExtraFields" not found` | — |
| same instance, `MAIN_LANG_DEFAULT` set to `en_US` then `fr_FR` | the 3 samples **differ** on every translated node | **byte-identical** |

And the guarantee that this does not touch the reference data: re-run against the fixtures currently committed, the script answers **`unchanged` three times**.

## Follow-up

Point 2 also unblocks `EInvoicingSamplesTest` on Dolibarr 18, where it was the first error after #500. One remains, handled separately in the next PR (`FactureLigne::$subprice_ttc`).
