### PR TITLE
FIX: stop reading the undeclared FactureLigne::$subprice_ttc

### DIFF
--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -321,7 +321,9 @@ foreach ($object->lines as $line) {
 	// For credit notes EN16931 requires positive amounts
 	if ($object->type == $object::TYPE_CREDIT_NOTE) {
 		$line->subprice     = abs($line->subprice);
-		$line->subprice_ttc = abs($line->subprice_ttc);
+		if (isset($line->subprice_ttc)) {	// See the note on BT-148 below: usually not set at all
+			$line->subprice_ttc = abs($line->subprice_ttc);
+		}
 		$line->total_ht     = abs($line->total_ht);
 		$line->total_ttc    = abs($line->total_ttc);
 		$line->total_tva    = abs($line->total_tva);
@@ -470,7 +472,12 @@ foreach ($object->lines as $line) {
 	$line_unit_price = $line->subprice;
 	//$line_unit_price = price2num($line_unit_price, 4);			// Note, 4 digits seems common accuracy for unit price with einvoice, but default dolibarr setup is 'MU' so 5.
 
-	$line_unit_price_ttc = $line->subprice_ttc;
+	// BT-148 gross unit price. subprice_ttc is not a declared property of FactureLigne in any
+	// Dolibarr version: compta/facture/card.php sets it dynamically on the line being edited, and
+	// nothing else does, so on a line read back from the database or built in memory it is simply
+	// absent. Reading it unguarded raised "Undefined property", which PHPUnit turns into an error.
+	// Absent means the gross unit price is unknown, which the test at the bottom already handles.
+	$line_unit_price_ttc = $line->subprice_ttc ?? 0;
 	//$line_unit_price_ttc = price2num($line_unit_price_ttc, 4);	// Note, 4 digits seems common accuracy for unit price with einvoice, but default dolibarr setup is 'MU' so 5.
 
 	$line_unit_price_with_discount = $line_unit_price;


### PR DESCRIPTION
Second of the two follow-ups announced in [my comment on #496](https://github.com/Dolibarr/dolibarr-community-modules/pull/496#issuecomment-5106210546), and the last step for the phpunit suite to be green on Dolibarr 18.

## Problem

`buildinvoicelines.inc.php` reads `$line->subprice_ttc` in two places, but **that property is not declared by `FactureLigne` in any Dolibarr version**. Checked on 18.0.10 and 20.0.5: the only place in the core that mentions it is `compta/facture/card.php`, which sets it dynamically on the line being edited. On a line read back from the database or built in memory it is simply absent, and every read raises

```
Undefined property: FactureLigne::$subprice_ttc
```

In normal execution that is only a warning, which is why it went unnoticed. PHPUnit turns it into an error, and `EInvoicingSamplesTest` errors out instead of running:

```
RuntimeException: EInvoicing::generateSampleInvoiceXml: sample invoice generation failed
  for options {"invoiceformat":"CII","invoicetype":3,"referencedinvoice":""}
  - Error when generating the e-invoice XML file.<br>Undefined property: FactureLigne::$subprice_ttc
```

## The change

Read it with the null coalescing operator, and take the absolute value on a credit note only when the property is actually set.

**The generated XML does not change**: absent already meant a falsy value, and the BT-148 block (gross unit price) is only emitted when it is truthy - the existing test at the bottom of the loop already handles it.

## Measured

On the module checkout at `main` (cffcfc1), with #500 and #501 in place - the `subprice_ttc` error is the last one in the chain on Dolibarr 18:

| Step | Dolibarr 18.0.10 | Dolibarr 20.0.5 |
|---|---|---|
| `main` | fatal, 0 test collected | OK (3 tests) |
| + #500 | 3 errors — `ExtraFields` | OK |
| + #501 | 3 errors — `subprice_ttc` | OK |
| + this PR | **OK (3 tests, 6 assertions)** | **OK (3 tests, 6 assertions)** |

As a side effect, this confirms the committed fixtures do not depend on the Dolibarr version: generated on 20.0.5, they are accepted as-is by 18.0.10.
