### PR TITLE
FIX: refuse a duplicate e-invoicing document cleanly instead of throwing from a trigger

### DIFF
--- a/einvoicing/class/helpers/SupplierInvoiceHelper.class.php
+++ b/einvoicing/class/helpers/SupplierInvoiceHelper.class.php
@@ -394,12 +394,15 @@ class SupplierInvoiceHelper
 	 *
 	 * @param int 	$supplierInvoiceId 				The id of the supplier invoice
 	 * @param bool 	$checkLinkedDolObjectExistance 	Also check if linked Dol object really exists or not
-	 * @throws Exception
+	 * @param bool 	$duplicate 						Set to true when several e-invoicing documents describe the
+	 *												same supplier invoice, so the caller can refuse the operation
 	 * @return bool									True if invoice found.
 	 */
-	public static function isEInvoice(int $supplierInvoiceId, bool $checkLinkedDolObjectExistance = false): bool
+	public static function isEInvoice(int $supplierInvoiceId, bool $checkLinkedDolObjectExistance = false, bool &$duplicate = false): bool
 	{
 		global $db;
+
+		$duplicate = false;
 
 		$sql = "SELECT rowid FROM " . $db->prefix() . "einvoicing_document";
 		$sql .= " WHERE fk_element_type = 'invoice_supplier'";
@@ -408,25 +411,35 @@ class SupplierInvoiceHelper
 		$sql .= " LIMIT 2";
 
 		$resql = $db->query($sql);
-		if ($resql) {
-			if ($db->num_rows($resql) == 1) {
-				$db->free($resql);
-				if ($checkLinkedDolObjectExistance) {
-					$factureFournisseur = new FactureFournisseur($db);
-					if ($factureFournisseur->fetch((int) $supplierInvoiceId) > 0) {
-						return true;
-					}
-				} else {
-					return true;
-				}
-			} elseif ($db->num_rows($resql) > 1) {
-				$db->free($resql);
-				throw new Exception('Duplicate entry in einvoicing_document for supplier invoice with id '.$supplierInvoiceId);
-			} else {
-				$db->free($resql);
-			}
+		if (!$resql) {
+			return false;
 		}
-		return false;
+
+		$num = $db->num_rows($resql);
+		$db->free($resql);
+
+		if ($num > 1) {
+			// Several e-invoicing documents for the same supplier invoice is a data integrity problem that
+			// needs a manual fix in database: the same invoice may hold diverging statuses coming from two
+			// access points. The answer to "is this an e-invoice" is still yes, so this predicate says yes
+			// and reports the duplicate. Throwing from here would not help: run_triggers() calls runTrigger()
+			// without a try/catch, so the exception used to surface as an uncaught PHP fatal instead of the
+			// message the user needs. Refusing the operation belongs to the caller.
+			$duplicate = true;
+			dol_syslog(__METHOD__ . ' duplicate entry in einvoicing_document for supplier invoice with id ' . $supplierInvoiceId, LOG_ERR);
+		}
+
+		if ($num <= 0) {
+			return false;
+		}
+
+		if ($checkLinkedDolObjectExistance) {
+			$factureFournisseur = new FactureFournisseur($db);
+
+			return ($factureFournisseur->fetch((int) $supplierInvoiceId) > 0);
+		}
+
+		return true;
 	}
 
 	/**

--- a/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
+++ b/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
@@ -288,7 +288,13 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 		if ($action == 'BILL_SUPPLIER_VALIDATE') {
 			/** @var FactureFournisseur $object */
 			'@phan-var-force FactureFournisseur $object';
-			if (getDolGlobalInt('EINVOICING_SUPPLIER_INVOICE_CHECK_CONSISTENCY_ON_VALIDATION') && SupplierInvoiceHelper::isEInvoice($object->id)) {
+			$duplicate = false;
+			if (getDolGlobalInt('EINVOICING_SUPPLIER_INVOICE_CHECK_CONSISTENCY_ON_VALIDATION') && SupplierInvoiceHelper::isEInvoice($object->id, false, $duplicate)) {
+				if ($duplicate) {
+					// Comparing against one of two conflicting e-invoicing documents would be meaningless
+					$this->errors[] = $langs->trans('EinvoicingDuplicateDocumentForSupplierInvoice', $object->id);
+					return -1;
+				}
 				// Ensure e-invoice and dol-invoice contains consistent data
 				$resComparison = SupplierInvoiceHelper::checkDolInvoiceAndEInvoiceConsistency($object);
 				if (!$resComparison['identical']) {
@@ -304,8 +310,11 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 		if ($action == 'BILL_SUPPLIER_DELETE') {
 			/** @var FactureFournisseur $object */
 			'@phan-var-force FactureFournisseur $object';
-			if (SupplierInvoiceHelper::isEInvoice($object->id, true)) {
-				$this->errors[] = $langs->trans('EinvoicingCantDeleteASupplierInvoice');
+			$duplicate = false;
+			if (SupplierInvoiceHelper::isEInvoice($object->id, true, $duplicate)) {
+				$this->errors[] = $duplicate
+					? $langs->trans('EinvoicingDuplicateDocumentForSupplierInvoice', $object->id)
+					: $langs->trans('EinvoicingCantDeleteASupplierInvoice');
 				return -1;
 			}
 		}
@@ -316,8 +325,11 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 			 * @var Document $object
 			 */
 			'@phan-var-force Document $object';
-			if ($object->fk_element_type == 'invoice_supplier' && SupplierInvoiceHelper::isEInvoice($object->fk_element_id, true)) {
-				$this->errors[] = $langs->trans('EinvoicingCantDeleteADocumentLinkedToAnExistingSupplierInvoice', $object->id, $object->fk_element_id);
+			$duplicate = false;
+			if ($object->fk_element_type == 'invoice_supplier' && SupplierInvoiceHelper::isEInvoice($object->fk_element_id, true, $duplicate)) {
+				$this->errors[] = $duplicate
+					? $langs->trans('EinvoicingDuplicateDocumentForSupplierInvoice', $object->fk_element_id)
+					: $langs->trans('EinvoicingCantDeleteADocumentLinkedToAnExistingSupplierInvoice', $object->id, $object->fk_element_id);
 				return -1;
 			}
 		}

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -344,6 +344,7 @@ SupplierInvoiceComparisonVatRateNotFound=VAT rate of %s%% not found in the Dolib
 SupplierInvoiceComparisonSuggestVatCalculationMode=recalculate invoice using Mode %s to get VAT amounts corresponding to e-invoice
 EinvoicingCantDeleteADocumentLinkedToAnExistingSupplierInvoice=Document n° %s can't be deleted because it is linked to the Dolibarr supplier invoice n° %s
 EinvoicingCantDeleteASupplierInvoice=A supplier EInvoice can't be deleted. Please approve or reject this invoice
+EinvoicingDuplicateDocumentForSupplierInvoice=Several e-invoicing documents were found for the supplier invoice %s. This should never happen and needs to be fixed in database before this invoice can be validated or deleted.
 EinvoicingCantDeleteATransmittedInvoice=You try to delete an invoice that is locked once the invoice has been transmitted to the Access Point
 EInvoiceSupplierInvoiceLinkedToOrder=The supplier invoice was automatically linked to purchase order %s (matching order reference BT-13).
 EInvoiceSupplierOrderLinkAmbiguous=Several purchase orders match the order reference %s for this supplier; the invoice was not auto-linked. Please link it manually.

--- a/einvoicing/test/phpunit/SupplierInvoiceHelperTest.php
+++ b/einvoicing/test/phpunit/SupplierInvoiceHelperTest.php
@@ -155,6 +155,83 @@ class SupplierInvoiceHelperTest extends CommonClassTest
 	}
 
 	/**
+	 * Insert an e-invoicing document row pointing at a supplier invoice. The whole class runs inside
+	 * the transaction opened by CommonClassTest::setUpBeforeClass(), so nothing survives the run.
+	 *
+	 * @param	int		$supplierInvoiceId	Id of the supplier invoice the document describes
+	 * @return	void
+	 */
+	private function addEInvoicingDocument($supplierInvoiceId)
+	{
+		global $db;
+
+		$now = $db->idate(dol_now());
+
+		$sql = "INSERT INTO " . MAIN_DB_PREFIX . "einvoicing_document";
+		$sql .= " (fk_element_type, fk_element_id, flow_type, date_creation, fk_user_creat, status, submittedat, provider)";
+		$sql .= " VALUES ('invoice_supplier', " . ((int) $supplierInvoiceId) . ", 'SupplierInvoice', '" . $now . "', 1, 0, '" . $now . "', 'PHPUNIT')";
+
+		$this->assertNotFalse($db->query($sql), (string) $db->lasterror());
+	}
+
+	/**
+	 * A supplier invoice with no e-invoicing document is not an e-invoice, and nothing is reported.
+	 *
+	 * @return void
+	 */
+	public function testNoEInvoicingDocumentIsNotAnEInvoice()
+	{
+		$invoice = $this->createSpecimenSupplierInvoice();
+
+		$duplicate = false;
+		$this->assertFalse(SupplierInvoiceHelper::isEInvoice($invoice->id, false, $duplicate));
+		$this->assertFalse($duplicate);
+	}
+
+	/**
+	 * One e-invoicing document: the answer is yes, with or without the existence check, and no
+	 * duplicate is reported. The variant without the existence check is the one that used to fall
+	 * through to false in the change this replaces.
+	 *
+	 * @return void
+	 */
+	public function testSingleEInvoicingDocumentIsAnEInvoice()
+	{
+		$invoice = $this->createSpecimenSupplierInvoice();
+		$this->addEInvoicingDocument($invoice->id);
+
+		$duplicate = false;
+		$this->assertTrue(SupplierInvoiceHelper::isEInvoice($invoice->id, false, $duplicate));
+		$this->assertFalse($duplicate);
+
+		$duplicate = false;
+		$this->assertTrue(SupplierInvoiceHelper::isEInvoice($invoice->id, true, $duplicate));
+		$this->assertFalse($duplicate);
+	}
+
+	/**
+	 * Two e-invoicing documents for the same supplier invoice: still an e-invoice - the question the
+	 * predicate is asked has not changed - and the duplicate is reported so the caller can refuse the
+	 * operation with an actionable message instead of the predicate throwing from inside a trigger.
+	 *
+	 * @return void
+	 */
+	public function testDuplicateEInvoicingDocumentsAreReported()
+	{
+		$invoice = $this->createSpecimenSupplierInvoice();
+		$this->addEInvoicingDocument($invoice->id);
+		$this->addEInvoicingDocument($invoice->id);
+
+		$duplicate = false;
+		$this->assertTrue(SupplierInvoiceHelper::isEInvoice($invoice->id, false, $duplicate));
+		$this->assertTrue($duplicate);
+
+		$duplicate = false;
+		$this->assertTrue(SupplierInvoiceHelper::isEInvoice($invoice->id, true, $duplicate));
+		$this->assertTrue($duplicate);
+	}
+
+	/**
 	 * A draft invoice, once refused and confirmed, is validated then abandoned with the
 	 * dedicated close code and the refusal reason kept as the close note.
 	 *


### PR DESCRIPTION
Implements what was agreed with @eldy on #304, and builds on the diagnosis of @defrance there. Opened as a new PR because #304 sits on `defrance:patch-3`, which I cannot push to; #304 can be closed in favour of this one, or kept open, as you prefer.

## Problem

`SupplierInvoiceHelper::isEInvoice()` answers "is this supplier invoice an e-invoice?", but threw an `Exception` when it found several `einvoicing_document` rows for the same invoice. Two things are wrong with that:

**The answer is still yes.** A duplicate does not make the invoice stop being an e-invoice.

**Throwing does not produce the clean stop it looks like.** `Interfaces::run_triggers()` calls `runTrigger()` **without a `try/catch`** (`core/class/interfaces.class.php:193`), so the exception propagated uncaught and surfaced as a PHP fatal. On the two callers whose whole purpose is to say "you cannot delete this", the user got a stack trace instead of the message. That is how @defrance ran into it: validating a supplier invoice was blocked by an exception.

## What does not change

@eldy's point stands and is kept: a duplicate is a data integrity problem that needs a manual database fix, and **nothing must proceed on it**. Only the mechanism moves, to a place where the refusal can be clean and explained.

## The change

The predicate answers the question and reports the duplicate through a by-reference flag. Each caller refuses the operation with a translated message and `return -1`, which is how a trigger refuses: the validation or the deletion is blocked, the transaction is rolled back, and the user reads what to do.

The three callers, all in `interface_98_modEInvoicing_EInvoicingTriggers.class.php` - **none of them a synchronization path**, which was the concern raised on #304:

| Context | What it does |
|---|---|
| `BILL_SUPPLIER_VALIDATE` | guard before `checkDolInvoiceAndEInvoiceConsistency()`, which compares and writes nothing |
| `BILL_SUPPLIER_DELETE` | blocks the deletion of the supplier invoice |
| `DOCUMENT_DELETE` | blocks the deletion of the linked document |

## Measured

On Dolibarr **18.0.10** and **20.0.5**, identical on both:

| einvoicing_document rows | `isEInvoice()` | `$duplicate` | `isEInvoice(…, true)` | `$duplicate` |
|---|---|---|---|---|
| none | `false` | `false` | `false` | `false` |
| one | `true` | `false` | `true` | `false` |
| two | `true` | **`true`** | `true` | **`true`** |

Three phpunit tests cover those three states. Full suite green on both versions: **39 tests, 205 assertions**. Negative control done: with the previous code the duplicate test errors out on the exception.

`phan --quick` and `phpcs` clean.

## One correction to something I wrote on #304

I said twice that this also fixes a pre-existing latent bug, where "with `checkLinkedDolObjectExistance = false` the `return true` is nested inside the wrong `if`, so a single matching row still returns `false`". I checked before writing this: **that bug does not exist on `main`** - the current code does carry the `else { return true; }`. It would have been *introduced* by the diff of #304, which drops that `else`. My apologies for the noise; the version here does not have it, and `testSingleEInvoicingDocumentIsAnEInvoice` pins that case.

## Note on #304's CI

Its `Run phan` failure is not caused by its change: the run dates from 2026-06-29 and fails on `PhanUndeclaredConstantOfClass: \CommonObject::CLOSECODE_BANKCHARGE` / `CLOSECODE_WITHHOLDINGTAX` in the trigger, which has been fixed on `main` since. phan is clean on today's `main`. The branch is also 4 weeks behind, hence the conflict on a file that moved a lot in the meantime - this PR is based on current `main`.
