### PR TITLE
[einvoicing] FIX: follow the rounding convention of the instance for the document totals

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -2,6 +2,14 @@
 
 ## 1.0.3
 
+FIX: The totals of the generated document now follow the rounding convention of the instance. Dolibarr
+sums the amounts already rounded on each line, unless MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND (or its
+_SUPPLIER variant) asks it to round the sum instead, and the invoice recorded, printed, booked and paid
+then carries that second convention. The module always applied the first one, so on such an instance the
+document transmitted claimed a cent less (or more) than the invoice it stands for. Nothing reported it:
+the document stayed internally consistent and the tolerance BR-CO-17 allows absorbs the gap, so the
+platform accepted it (issue #378).
+
 FIX: The reference a credit note makes to the invoice it corrects now carries that invoice issue date
 (BT-26) whatever the profile, and no longer only in EXTENDED. The date is allowed by EN 16931
 (CII-DT-027) and required by the French rule BR-FR-CO-05, which rejects a credit note whose reference

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -619,6 +619,29 @@ foreach ($object->lines as $line) {
 	$numligne++;
 }
 
+// Rounding convention of the totals.
+// Dolibarr sums the amounts already rounded on each line ("total of round", the default), unless
+// MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND is set, in which case it rounds the sum instead ("round of
+// total"). update_price() then writes the difference back onto the last line of the VAT rate, so on
+// such an instance the invoice recorded, printed, booked and paid carries the second convention.
+// The loop above always applied the first one, so the document transmitted claimed a cent less (or
+// more) than the invoice it stands for, and nothing reported it: the document stays internally
+// consistent, and the tolerance BR-CO-17 allows absorbs the gap (issue #378).
+// Only the VAT is concerned: on a document priced without tax update_price() never adjusts the net
+// amount of a line, so the line net amounts (BT-131) and their sum (BT-106) are the same either way.
+$roundTotalConstName = 'MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND';
+if (in_array($object->element, array('facture_fourn', 'invoice_supplier'))) {
+	$roundTotalConstName .= '_SUPPLIER';
+}
+if (getDolGlobalString($roundTotalConstName) == '1') {		// Same comparison as update_price(), which only treats '1' as "round of total"
+	$grand_total_tva = 0;
+	foreach ($taxBreakdown as $keyforvatrate => $vals) {
+		$taxBreakdown[$keyforvatrate]['totalTVA'] = (float) price2num((float) $vals['totalHT'] * (float) $vals['tva_tx'] / 100, 2);
+		$grand_total_tva += $taxBreakdown[$keyforvatrate]['totalTVA'];
+	}
+	$grand_total_ttc = (float) price2num($grand_total_ht + $grand_total_tva, 2);
+}
+
 // already used credit note amount
 $usedcreditnoteamount = 0;
 $usedcreditnote = array();


### PR DESCRIPTION
Fixes #378.

### What happens today

Dolibarr computes the totals of a document in one of two ways: the sum of the amounts already rounded on each line ("total of round", the default), or the rounding of the untouched sum ("round of total", when `MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND` is set — the `_SUPPLIER` variant for a supplier document). In the second mode `update_price()` writes the difference back onto the last line of the VAT rate, so the invoice **recorded, printed, booked and paid** carries that convention.

`buildinvoicelines.inc.php` recomputes every line and every total from the unit price with its own hardcoded first convention, and never reads back what Dolibarr stored. On an instance using the second one, the document transmitted therefore claimed a different amount than the invoice it stands for.

Measured on Dolibarr 20, three lines of 10.01 EUR at 20%:

| | Dolibarr invoice | transmitted document |
|---|---|---|
| option off (default) | 36.03 | 36.03 |
| option on | **36.04** | 36.03 |

### Why nothing reported it

The generated document stays internally consistent, so no rule is breached:

- `BR-CO-10`, `BR-CO-13`, `BR-CO-14` and `BR-CO-15` are strict equalities, and they hold on both sides;
- `BR-CO-17` carries a one currency unit tolerance in the CEN CII schematron, which absorbs the gap — it is in fact what lets the drift of the *default* convention through, since "round of total" gives `BT-117` exactly equal to `BT-116 x BT-119 / 100`;
- `BR-FR-Flux2` adds no arithmetic constraint on the totals outside the special contract case (`BR-FR-MV-*`).

So the platform accepts the document, silently, and the discrepancy only surfaces later — on payment reconciliation, or on the buyer's side.

### The fix

Read the convention of the instance from the same constant Dolibarr reads, with the same client/supplier switch and the same comparison to `'1'`, and apply it to the VAT breakdown.

Only the VAT is concerned: on a document priced without tax `update_price()` never adjusts the net amount of a line, so the line net amounts (BT-131) and their sum (BT-106) are identical under both conventions.

The issue suggests disabling the option when the module is enabled. That would change the totals of every document of the instance — invoices, orders, proposals, purchase documents — to accommodate one module, would leave documents already issued untouched, and would not address the other sources of divergence. The convention of the instance is a legitimate accounting choice; the module should follow it, not overrule it.

### Checks

- Both modes measured on Dolibarr 20: the generated document now matches the invoice (36.03 / 36.03 and 36.04 / 36.04).
- Both generated files pass the FNFE `EN16931-CII-validation` and `BR-FR-Flux2-Schematron-CII` schematrons with no failed assertion. Negative control run: a tampered `GrandTotalAmount` does raise `BR-CO-15` and `BR-CO-16`, so the green result is meaningful.
- `php -l` and phan (CI configuration) clean.

### Not covered here

Two other sources of divergence between the document and the invoice act on BT-131 rather than on the VAT, and have their own causes, so they are left to their own patches. Both are now measured and reported:

- #505 — a line discount percentage when `MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY` is not `MU` (18 cents on a 1000 EUR invoice, and it grows with the quantity);
- #506 — a currency accuracy for totals (`MAIN_MAX_DECIMALS_TOT`) other than 2, where no computation can make the document equal the invoice and the module says nothing.
