### PR TITLE
[einvoicing] FIX: take the amounts of a line from the core function that computed the invoice

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -10,6 +10,14 @@ EN 16931 offers no way to declare a VAT that is not claimed - the total with VAT
 the VAT total (BR-CO-15) - so the line is now issued exempt (category E, rate 0, no VAT amount) with the
 reason code the standard reserves for that article, VATEX-FR-CGI295 (issue #508).
 
+FIX: The amounts of a line are now asked to the core function that computed the invoice
+(calcul_price_total()) instead of being computed a second time in the module. The second
+implementation rounded the unit price after discount in every case, where the core only rounds it when
+the instance asks for it, so a discounted line could state a few cents less than the invoice it stands
+for - and an instance running a Dolibarr that does not know that option diverged by more, the module
+honouring a setting its core ignores. Nothing reported it: the document stayed internally consistent
+and the platform accepted it (issue #505).
+
 
 ## 1.0.3
 

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -51,6 +51,10 @@ if (!isset($outputlangs) || !($outputlangs instanceof Translate)) {
 }
 $newlang = '';
 
+// calcul_price_total(), used below to get the amounts of a line from the same place the invoice got
+// them. The protocols reach this file from several entry points, not all of which load the library.
+require_once DOL_DOCUMENT_ROOT.'/core/lib/price.lib.php';
+
 // Load EInvoicing class
 $einvoicing = new EInvoicing($db);
 
@@ -504,15 +508,21 @@ foreach ($object->lines as $line) {
 	}
 	$line_unit_price_with_discount = price2num($line_unit_price_with_discount, getDolGlobalString('MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY', 'MU'));
 
-	// We need to recalculate the total using the Unit price rounded after discount percent (netpriceamount) and the quantity, and rounding all temporary calculations after to 2
-	// according to EN16931 rules. This is a not accurate rule but it is the rule to follow for e-invoice.
-	// This means we may get a different result than Dolibarr default calculation if:
-	// - There is a discount percent AND the option MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY was not set or set to a value != MU
-	// or if
-	// - There is no discount percent but currency accuracy for total (MAIN_MAX_DECIMALS_UNIT) was not set to 2.
-	// TODO Use calculate_price() with a mode to round to 2 after each temporary calculation.
-	$line_total_ht = price2num((float) $line_unit_price_with_discount * $line->qty, 2);				// Need to round to 2 as defined by EN16931 rules after each calculation.
-	$line_total_tva = price2num((float) $line_unit_price_with_discount * $line->qty * ($line->tva_tx > 0 ? $line->tva_tx / 100 : 0), 2);
+	// Progress of the line, which only a situation invoice carries: calcul_price_total() applies it
+	// after the discount, exactly like the amounts of the invoice were computed.
+	$line_progress = ($object->type == $object::TYPE_SITUATION && $line->situation_percent) ? $line->situation_percent : 100;
+
+	// The amounts of the line are asked to the very function that computed the invoice
+	// (calcul_price_total(), the one update_price() calls), instead of being computed a second time
+	// here: the document has to state the amount the invoice states, and a second implementation
+	// misses the accuracies and the options of the instance, silently, by a few cents (issue #505).
+	// They are then rounded to the two decimals EN 16931 allows on an amount, which is a no-op on an
+	// instance keeping the default currency accuracy.
+	$localtaxes_array = array($line->localtax1_type, $line->localtax1_tx, $line->localtax2_type, $line->localtax2_tx);
+	$tmpcal = calcul_price_total($line->qty, $line->subprice, $line->remise_percent, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, 0, 'HT', $line->info_bits, $line->product_type, $mysoc, $localtaxes_array, $line_progress);
+
+	$line_total_ht = price2num((float) $tmpcal[0], 2);
+	$line_total_tva = price2num((float) $tmpcal[1], 2);
 	$line_total_ttc = price2num((float) $line_total_ht + (float) $line_total_tva, 2);
 
 	// Uncomment for test using the most accurate possible calculation (but not following the e-invoice rule to round to 2 digit at each step of calculation)


### PR DESCRIPTION
> Rebased on current `main`. The [answer to @eldy's question](https://github.com/Dolibarr/dolibarr-community-modules/pull/507#issuecomment-5132068378) is in the thread below: how the "default = Dolibarr rules, switch by constant" idea stands after this change.

Fixes #505. Second of the three divergences between the Dolibarr invoice and the document generated from it, after #504.

### What happens today

`buildinvoicelines.inc.php` recomputes the net amount and the VAT of every line from the unit price, rather than asking `calcul_price_total()` — the function `update_price()` calls to fill the invoice. A second implementation of a calculation drifts from the first one, and this one does, in two ways:

- it rounds the unit price after discount in every case, defaulting to `MU`, where the core only rounds it when `MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY` is set, and multiplies the untouched value otherwise;
- on a Dolibarr that does not implement that option at all, the module honours it anyway, so setting it moves the document alone while the invoice does not budge.

### Measurements

Same probe on four instances — Dolibarr 18.0.10, 20.0.5, 23.0.3 and 24.0.0-beta — one throwaway invoice per case, comparing `$object->total_ttc` with `ram:GrandTotalAmount` of the generated CII.

**One line, 9.99 EUR, quantity 100, 15% discount, VAT 20%, option set to `2`:**

| | 18.0.10 | 20.0.5 | 23.0.3 | 24.0.0-beta |
|---|---|---|---|---|
| Dolibarr invoice | 1018.98 | 1018.98 | 1018.80 | 1018.80 |
| document, before | **1018.80** | **1018.80** | 1018.80 | 1018.80 |
| document, after | 1018.98 | 1018.98 | 1018.80 | 1018.80 |

The option appeared in the core in 22.0.0: 18 and 20 ignore it, 23 and 24 apply it — the module applied it everywhere.

**One line, 9.99 EUR, quantity 2000, 33.333% discount, VAT 20%, option unset (default setup):**

| | 18.0.10 | 20.0.5 | 23.0.3 | 24.0.0-beta |
|---|---|---|---|---|
| Dolibarr invoice | 15984.08 | 15984.08 | 15984.08 | 15984.08 |
| document, before | **15984.07** | **15984.07** | **15984.07** | **15984.07** |
| document, after | 15984.08 | 15984.08 | 15984.08 | 15984.08 |

This one needs no option at all: the `MU` rounding of the discounted unit price is truncated at the fifth decimal, and the quantity multiplies what was dropped.

A control invoice with no discount, and the same discounted line with the option unset or explicitly set to `MU`, matched before and still match.

### Why nothing reported it

Same as #504: the generated document stays internally consistent, so no EN 16931 rule and no French rule is breached and the platform accepts it. The discrepancy only surfaces later.

### The fix

The line amounts now come from `calcul_price_total()` with the parameters of the line, then are rounded to the two decimals EN 16931 allows on an amount — a no-op on an instance keeping the default currency accuracy.

This is the `TODO Use calculate_price() ...` already sitting on that computation. Asking the core rather than reimplementing it also means the module follows any accuracy, any option and any version without having to know about them.

### Checks

- The two cases above, plus a control and two variants, measured on the four versions: every discount case now states the same total as the invoice, whatever the option.
- Module test suite green on the four (45 tests, 235 assertions).
- The invoices of the test instance carrying a line discount, a document level discount, a deposit and a credit note regenerated and passed through the FNFE `EN16931-CII-validation` and `BR-FR-Flux2-Schematron-CII` schematrons: no failed assertion.
- `php -l` and phan (CI configuration) clean.

### Not covered here

#506, the remaining divergence, is of another nature: with a currency accuracy for totals other than 2 the invoice carries a third decimal, which the standard does not allow on an amount, so no computation can make the document equal the invoice. It needs a decision, not a calculation.
