### PR TITLE
[einvoicing] NEW: tell the operator when the document does not claim the amount of the invoice

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -117,6 +117,16 @@ It carries the amount paid and its date, and is sent once per invoice. Optional 
 it is off by default and enabled with EINVOICING_SEND_PAYMENT_SENT_STATUS. It can also be sent by hand
 from the supplier invoice card, where it was missing from the list of sendable statuses.
 
+NEW: The local check run at generation time now also verifies that the generated document claims the
+amount the invoice claims, and says so when it does not. No rule of the standard can catch that: the
+rules relate the amounts of the document to each other, so a document wrong by a cent is as consistent
+as a correct one and the platform accepts it without a word. The remaining known cause is a currency
+accuracy for totals (MAIN_MAX_DECIMALS_TOT) other than 2, which puts a third decimal on the invoice
+where EN 16931 allows two on every amount, the rounding amount (BT-114) included: no computation can
+make the two equal, so the operator is told rather than left with a document quietly claiming something
+else. It follows EINVOICING_BR_CHECK like the other checks, so it warns by default and aborts on an
+instance set to "blocking" (issue #506).
+
 ## 1.0.0
 
 Initial version

--- a/einvoicing/class/protocols/AbstractProtocol.class.php
+++ b/einvoicing/class/protocols/AbstractProtocol.class.php
@@ -189,11 +189,16 @@ abstract class AbstractProtocol
 	 * "warning_only" (default) reports violations as non-blocking warnings, and "blocking" aborts
 	 * the generation (the exception is caught by generateInvoice() which returns -1 with the messages).
 	 *
-	 * @param	string	$xmlcontent		Generated CII XML content
+	 * The check also covers what no rule of the standard can see: that the document claims the amount
+	 * the invoice claims. A document can be perfectly conformant and still state another total than the
+	 * invoice it stands for, and the platform accepts it without a word.
+	 *
+	 * @param	string			$xmlcontent		Generated CII XML content
+	 * @param	?CommonInvoice	$invoice		Invoice the document was built from, to compare the amounts
 	 * @return	void
 	 * @throws	Exception				When violations are found and mode is "blocking"
 	 */
-	protected function checkBusinessRules($xmlcontent)
+	protected function checkBusinessRules($xmlcontent, $invoice = null)
 	{
 		global $langs;
 
@@ -205,6 +210,7 @@ abstract class AbstractProtocol
 		dol_include_once('einvoicing/class/utils/En16931Validator.class.php');
 		$validator = new En16931Validator();
 		$violations = $validator->validate($xmlcontent);
+		$violations = array_merge($violations, $this->checkDocumentClaimsTheInvoiceAmount($xmlcontent, $invoice));
 		if (empty($violations)) {
 			return;
 		}
@@ -218,6 +224,52 @@ abstract class AbstractProtocol
 		}
 
 		$this->warnings = array_merge((array) $this->warnings, $violations);
+	}
+
+	/**
+	 * Check that the generated document claims the amount the invoice claims.
+	 *
+	 * No rule of the standard can catch this: the rules relate the amounts of the document to each
+	 * other, and a document whose totals are wrong by a cent is as consistent as a correct one. The
+	 * platform therefore accepts it, and the discrepancy only surfaces later, on payment
+	 * reconciliation or on the buyer's side.
+	 *
+	 * The known cause left is a currency accuracy for totals (MAIN_MAX_DECIMALS_TOT) other than 2: the
+	 * invoice then carries a third decimal, and EN 16931 caps every amount at two, the rounding amount
+	 * (BT-114) included (BR-DEC-09 to BR-DEC-23). No computation can make the two equal, so the
+	 * operator is told instead of being left with a document that quietly claims something else
+	 * (issue #506).
+	 *
+	 * @param	string			$xmlcontent		Generated CII XML content
+	 * @param	?CommonInvoice	$invoice		Invoice the document was built from
+	 * @return	string[]						Violation messages, empty when the two agree
+	 */
+	protected function checkDocumentClaimsTheInvoiceAmount($xmlcontent, $invoice)
+	{
+		if (!is_object($invoice) || !isset($invoice->total_ttc)) {
+			return array();
+		}
+		if (!preg_match('#<ram:GrandTotalAmount[^>]*>([^<]*)</ram:GrandTotalAmount>#', $xmlcontent, $reg)) {
+			return array();
+		}
+
+		$claimedByDocument = (float) trim($reg[1]);
+		// A credit note is issued with positive amounts, where Dolibarr holds the invoice negative.
+		$claimedByInvoice = ((int) $invoice->type === $invoice::TYPE_CREDIT_NOTE) ? abs((float) $invoice->total_ttc) : (float) $invoice->total_ttc;
+
+		if (abs($claimedByInvoice - $claimedByDocument) < 0.0001) {
+			return array();
+		}
+
+		$message = 'The document claims '.price2num($claimedByDocument, 'MT').' where the invoice claims '.price2num($claimedByInvoice, 'MT')
+			.': the amount transmitted is not the amount invoiced';
+		$decimals = getDolGlobalInt('MAIN_MAX_DECIMALS_TOT', 2);
+		if ($decimals != 2) {
+			$message .= '. The currency accuracy for totals (MAIN_MAX_DECIMALS_TOT) is set to '.$decimals
+				.' decimals, where EN 16931 allows 2 on every amount, the rounding amount (BT-114) included';
+		}
+
+		return array($message);
 	}
 
 	/**

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -500,8 +500,9 @@ class CIIProtocol extends AbstractProtocol
 
 		$xmlcontent = $this->buildXML($invoiceData, $linesData, $this->getBuildXmlProfile(), $outputlangs);
 
-		// Local EN 16931 business rules safety net (warnings, or abort in strict mode)
-		$this->checkBusinessRules($xmlcontent);
+		// Local EN 16931 business rules safety net, and check that the document claims the amount the
+		// invoice claims (warnings, or abort in strict mode)
+		$this->checkBusinessRules($xmlcontent, $invoice);
 
 		file_put_contents($xmlfile, $xmlcontent);
 

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -576,7 +576,7 @@ class FacturXProtocol extends CIIProtocol
 
 			// Local EN 16931 business rules safety net on the final XML (warnings, or abort in strict mode),
 			// same as the native builder branch above, so the external builder is covered too.
-			$this->checkBusinessRules(file_get_contents($xmlfile));
+			$this->checkBusinessRules(file_get_contents($xmlfile), $invoice);
 
 			dolChmod($xmlfile);
 


### PR DESCRIPTION
Fixes #506. Last of the three divergences between the Dolibarr invoice and the document generated from it, after #504 and #507.

### Why this one is not a calculation

`MAIN_MAX_DECIMALS_TOT` sets the number of decimals Dolibarr keeps on the totals of a document. With anything other than 2, the invoice carries a third decimal — and EN 16931 caps **every** amount at two decimals: `BR-DEC-09` (BT-106), `BR-DEC-12` (BT-109), `BR-DEC-13` (BT-110), `BR-DEC-14` (BT-112), `BR-DEC-16` (BT-113), `BR-DEC-18` (BT-115), `BR-DEC-19` / `BR-DEC-20` (BT-116 / BT-117), `BR-DEC-23` (BT-131).

That includes `BR-DEC-17` on the rounding amount (BT-114), which was the one place the difference could plausibly have been carried. There is nowhere to put it.

Measured with the accuracy set to 3, one line of 10.005 EUR × 3 at 20%:

| | net | VAT | total |
|---|---|---|---|
| Dolibarr invoice | 30.015 | 6.003 | **36.018** |
| document | 30.02 | 6.00 | **36.02** |

No computation can make those equal. So the answer is not a better rounding, it is to stop being silent.

### What this adds

A check that the generated document claims the amount the invoice claims, run at generation time next to the existing EN 16931 safety net and driven by the same `EINVOICING_BR_CHECK` option: silent on `nocheck`, a warning by default, and it aborts the generation on an instance set to `blocking`. Both the native builder and the Factur-X one go through it.

No rule of the standard can catch this by construction: the rules relate the amounts of the document to each other, so a document wrong by a cent is as consistent as a correct one, the platform accepts it, and the discrepancy only surfaces later — on payment reconciliation, or on the buyer's side. That is exactly how #378 and #505 stayed unnoticed. This check would have caught both on the first invoice.

When the currency accuracy is the culprit the message names it:

```
The document claims 36.02 where the invoice claims 36.018: the amount transmitted is not the
amount invoiced. The currency accuracy for totals (MAIN_MAX_DECIMALS_TOT) is set to 3 decimals,
where EN 16931 allows 2 on every amount, the rounding amount (BT-114) included
```

### False positives

Every invoice of the three populated test instances was regenerated and put through the check — 63 invoices on Dolibarr 18.0.10, 20.0.5 and 23.0.3. It stays silent on all of them except two, which really are overstated: they carry a line with recoverable non-collected VAT (TVA NPR), where Dolibarr does not charge the VAT and the module adds it anyway. That is a genuine bug of its own, reported as #508, and the check finding it is the point.

### Checks

- The case above reproduces and the check fires with the message quoted, on Dolibarr 20.
- 63 invoices swept on three versions: no false positive.
- Module test suite green on Dolibarr 18.0.10, 20.0.5, 23.0.3 and 24.0.0-beta (24 tests, 92 assertions).
- `php -l` and phan (CI configuration) clean.

### Note on ordering

Independent of #504 and #507 and can be merged in any order, but it is worth the most once those two are in: on their own they remove the two causes, and this one makes sure a third never goes unnoticed.
