### PR TITLE
[einvoicing] NEW: run the recipient reachability pre-check on Esalink too

### DIFF
--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -67,6 +67,10 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 			'prod_api_url' => 'https://hubtimize.fr/api/orchestrator/v1/',
 			'test_auth_url' => 'https://ppd.hubtimize.fr/api/orchestrator/v1/',
 			'test_api_url' => 'https://ppd.hubtimize.fr/api/orchestrator/v1/',
+			// The AFNOR Directory Service (XP Z12-013) is served from the same base as the flows on this
+			// platform, so the recipient reachability pre-check of AbstractPDPProvider works here too.
+			'prod_afnor_directory_url' => 'https://hubtimize.fr/api/orchestrator/v1/',
+			'test_afnor_directory_url' => 'https://ppd.hubtimize.fr/api/orchestrator/v1/',
 			'username' => getDolGlobalString('EINVOICING_ESALINK_USERNAME'.(getDolGlobalInt('EINVOICING_LIVE') ? '_PROD' : '')),
 			'password' => getDolGlobalString('EINVOICING_ESALINK_PASSWORD'.(getDolGlobalInt('EINVOICING_LIVE') ? '_PROD' : '')),
 			'api_key'  => getDolGlobalString('EINVOICING_ESALINK_API_KEY'.(getDolGlobalInt('EINVOICING_LIVE') ? '_PROD' : '')),
@@ -698,6 +702,13 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 		require_once DOL_DOCUMENT_ROOT . '/core/lib/geturl.lib.php';
 
 		$url = $this->getApiUrl(($callType == 'get_access_token') ? 'auth' : 'api') . $resource;
+		if (strpos($resource, 'afnor-directory/v1/') === 0) {
+			// Standardized AFNOR Directory Service (XP Z12-013). The 'afnor-directory/v1/' prefix is only a
+			// routing marker used by AbstractPDPProvider::checkRecipientDirectory(): this platform serves the
+			// directory from its regular versioned base, so the marker is stripped instead of appended (the
+			// prefixed path itself answers 403 here).
+			$url = $this->getApiUrl('afnor_directory') . substr($resource, strlen('afnor-directory/v1/'));
+		}
 
 		$httpheader = array(
 			'hubtimize-api-key: ' . $this->config['api_key']


### PR DESCRIPTION
## Problem

The pre-check that tells whether a recipient can receive an e-invoice was only wired for one Access Point. On an Esalink instance `getApiUrl('afnor_directory')` answered nothing, so `checkRecipientDirectory()` returned `unsupported` and the invoice card said *"Directory lookup is not available for the current platform"* — while the platform does serve the AFNOR Directory Service (XP Z12-013), from its regular versioned base rather than under an `afnor-directory/` path (which answers 403 there).

## Change

The two directory bases are declared, and the `afnor-directory/v1/` routing marker of the standardized check is stripped instead of appended, the same way the other provider remaps it. Nothing else changes: the search body, the answer parsing and the statuses all come from the shared implementation in `AbstractPDPProvider`.

## Measured on the sandbox

The sandbox does report `directoryLineStatus`, so the check is fully informative there:

| SIREN | result |
|---|---|
| 552081317 | `routable`, 3 lines, 3 `Enabled`, address `552081317` |
| 000000002 | `routable`, 1 line |
| 892304189 | `absent`, 0 line |

Two notes:

- the consultation that tells a SIREN unknown to the directory from one merely without a line (`GET siren/code-insee:`) is not exposed by this platform, so a recipient with no line is reported `absent` rather than `inactive`. Both mean not reachable and neither blocks anything: the lookup is read-only unless the opt-in `EINVOICING_REQUIRE_ROUTABLE_RECIPIENT` is set.
- the sandbox directory is a test dataset — the real SIREN 892304189 has no line there but is published in the production directory — which is what `EINVOICING_PRECHECK_DIRECTORY_HELP` already warns about for test mode.

phpcs and phan clean; verified live on a sandbox instance of that platform.