### PR TITLE
[einvoicing] FIX: regenerating a transmitted invoice no longer sends it twice

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -2,6 +2,16 @@
 
 ## 1.0.4
 
+FIX: Regenerating the document of an invoice already transmitted no longer sends it to the platform a
+second time. Automatic transmission on generation stopped at the sync status, which generateInvoice()
+resets to "generated" every time it runs, so from the second regeneration on the invoice looked as if it
+had never been sent. It was, and the platform, which registers a flow under the invoice reference,
+answered the duplicate with an HTTP 400 and no flow: an error raised to the operator on an invoice that
+was in fact transmitted and, when the first submission was still awaiting its outcome, a second useless
+call for every regeneration. The transmission now reads the flow identifier the platform assigned on the
+first submission, which nothing clears, exactly like the manual send button already did - and it honours
+the same EINVOICING_ALLOW_RESEND_TRANSMITTED opt-out.
+
 FIX: A line carrying recoverable non-collected VAT ("TVA non perçue récupérable", the overseas
 departments scheme of article 295 of the CGI) no longer makes the document claim a VAT the invoice does
 not charge. Dolibarr makes the total including tax of such a line equal to its net amount, where the

--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -179,9 +179,14 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 
 							// Optionally transmit to the Access Point right after generation (opt-in + idempotent) and if not yet generated.
 							// Without this, validation only generates the Factur-X; the invoice is never sent to the
-							// PA (transmission was a manual "send_to_pdp" click only). The 'transmitted' guard prevents
-							// re-sending (and creating duplicate flows) when the PDF is regenerated later.
-							if (getDolGlobalString('EINVOICING_AUTO_SEND_ON_GENERATION') && empty($currentStatusDetails['transmitted']) && $precheckresult >= 0) {
+							// PA (transmission was a manual "send_to_pdp" click only).
+							// Two guards, because one is not enough: 'transmitted' reads the syncstatus, which
+							// generateInvoice() just reset to GENERATED a few lines above, so it stops seeing a
+							// transmission from the second regeneration on. isTransmittedLockActive() reads the
+							// flow_id, which the first submission assigned and nothing clears, so it holds for good
+							// (and honors EINVOICING_ALLOW_RESEND_TRANSMITTED like the manual send does).
+							if (getDolGlobalString('EINVOICING_AUTO_SEND_ON_GENERATION') && empty($currentStatusDetails['transmitted'])
+								&& !$einvoicing->isTransmittedLockActive($invoiceObject->id, $invoiceObject->ref) && $precheckresult >= 0) {
 								dol_syslog("actions_einvoicing: Invoice seems not yet transmitted and EINVOICING_AUTO_SEND_ON_GENERATION is on, so we try to send it");
 
 								require_once __DIR__ . '/providers/PDPProviderManager.class.php';

--- a/einvoicing/test/phpunit/AllTests.php
+++ b/einvoicing/test/phpunit/AllTests.php
@@ -114,6 +114,8 @@ class AllTests
 		$suite->addTestSuite('RecipientDirectoryTest');
 		require_once dirname(__FILE__).'/SupplierInvoiceHelperTest.php';
 		$suite->addTestSuite('SupplierInvoiceHelperTest');
+		require_once dirname(__FILE__).'/TransmittedLockTest.php';
+		$suite->addTestSuite('TransmittedLockTest');
 
 		return $suite;
 	}

--- a/einvoicing/test/phpunit/TransmittedLockTest.php
+++ b/einvoicing/test/phpunit/TransmittedLockTest.php
@@ -1,0 +1,203 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/TransmittedLockTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for the already-transmitted guard: EInvoicing::isTransmittedLockActive()
+ *                  and the two flags fetchLastknownInvoiceStatus() derives from an extlink record,
+ *                  'transmitted' (from the resettable syncstatus) and 'everTransmitted' (from the
+ *                  flow_id the platform assigned, which nothing clears). Re-sending an invoice the
+ *                  platform already holds is refused as a duplicate, so only the second flag may gate
+ *                  a transmission.
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+// See RecipientDirectoryTest.php for why DOLIBARR_HTDOCS is honoured before the relative path.
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+dol_include_once('einvoicing/class/einvoicing.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+if (empty($user->id)) {
+	print "Load permissions for admin user nb 1\n";
+	$user->fetch(1);
+	// User::loadRights() only exists from Dolibarr 19 on, older versions name it getrights()
+	if (method_exists($user, 'loadRights')) {
+		$user->loadRights();
+	} else {
+		$user->getrights();
+	}
+}
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+
+
+/**
+ * Tests on the already-transmitted guard.
+ *
+ * Every test writes its extlink record on an element id that no invoice uses, inside the transaction
+ * CommonClassTest opens for the class and rolls back afterwards, so a run leaves nothing behind.
+ */
+class TransmittedLockTest extends CommonClassTest
+{
+	/** @var int Element id used by the records written here: high enough not to collide with a real invoice */
+	const TEST_ELEMENT_ID = 999999001;
+
+	/**
+	 * Set the two globals the tested code reads, and start from a clean record.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void
+	{
+		global $conf, $db;
+
+		parent::setUp();
+
+		$conf->global->EINVOICING_PDP = 'SUPERPDP';
+		unset($conf->global->EINVOICING_ALLOW_RESEND_TRANSMITTED);
+
+		$db->query("DELETE FROM " . $db->prefix() . "einvoicing_extlinks WHERE element_id = " . (int) self::TEST_ELEMENT_ID);
+	}
+
+	/**
+	 * Write the extlink record the way the module does, and read the status back.
+	 *
+	 * @param 	string 	$flowId 	Flow id assigned by the platform ('' = never submitted)
+	 * @param 	int 	$syncStatus	Current sync status
+	 * @return 	array<string,mixed>	What fetchLastknownInvoiceStatus() reports for that record
+	 */
+	private function statusFor($flowId, $syncStatus)
+	{
+		global $db;
+
+		$einvoicing = new EInvoicing($db);
+		$einvoicing->insertOrUpdateExtLink(self::TEST_ELEMENT_ID, 'facture', $flowId, $syncStatus, 'TEST-LOCK-0001');
+
+		return $einvoicing->fetchLastknownInvoiceStatus(self::TEST_ELEMENT_ID, 'TEST-LOCK-0001');
+	}
+
+	/**
+	 * An invoice generated but never submitted carries no flow_id: nothing to protect, auto-send may run.
+	 *
+	 * @return void
+	 */
+	public function testGeneratedButNeverSubmittedIsNotLocked()
+	{
+		global $db;
+
+		$status = $this->statusFor('', EInvoicing::STATUS_GENERATED);
+
+		$this->assertSame(0, $status['transmitted']);
+		$this->assertSame(0, $status['everTransmitted']);
+
+		$einvoicing = new EInvoicing($db);
+		$this->assertFalse($einvoicing->isTransmittedLockActive(self::TEST_ELEMENT_ID, 'TEST-LOCK-0001'));
+	}
+
+	/**
+	 * Right after a successful submission both flags agree: the invoice is at the platform.
+	 *
+	 * @return void
+	 */
+	public function testSubmittedInvoiceIsLocked()
+	{
+		global $db;
+
+		$status = $this->statusFor('i_159705', EInvoicing::STATUS_AWAITING_VALIDATION);
+
+		$this->assertSame('i_159705', $status['flow_id']);
+		$this->assertSame(1, $status['transmitted']);
+		$this->assertSame(1, $status['everTransmitted']);
+
+		$einvoicing = new EInvoicing($db);
+		$this->assertTrue($einvoicing->isTransmittedLockActive(self::TEST_ELEMENT_ID, 'TEST-LOCK-0001'));
+	}
+
+	/**
+	 * The regression this guards: regenerating the e-invoice sets the status back to GENERATED, which
+	 * makes 'transmitted' read 0 again on an invoice the platform already holds. The flow_id survives,
+	 * so 'everTransmitted' and the lock stay on, and a re-send that would come back as a duplicate is
+	 * still refused locally.
+	 *
+	 * @return void
+	 */
+	public function testRegeneratingDoesNotUnlockATransmittedInvoice()
+	{
+		global $db;
+
+		$this->statusFor('i_159705', EInvoicing::STATUS_AWAITING_VALIDATION);
+
+		// What CIIProtocol/FacturXProtocol::generateInvoice() does on every regeneration.
+		$einvoicing = new EInvoicing($db);
+		$einvoicing->insertOrUpdateExtLink(self::TEST_ELEMENT_ID, 'facture', '', EInvoicing::STATUS_GENERATED, 'TEST-LOCK-0001');
+
+		$status = $einvoicing->fetchLastknownInvoiceStatus(self::TEST_ELEMENT_ID, 'TEST-LOCK-0001');
+
+		$this->assertSame(EInvoicing::STATUS_GENERATED, $status['code']);
+		$this->assertSame(0, $status['transmitted'], "regeneration resets the status, so 'transmitted' cannot gate a transmission");
+		$this->assertSame('i_159705', $status['flow_id'], 'the flow_id assigned by the platform is never cleared');
+		$this->assertSame(1, $status['everTransmitted']);
+
+		$this->assertTrue($einvoicing->isTransmittedLockActive(self::TEST_ELEMENT_ID, 'TEST-LOCK-0001'));
+	}
+
+	/**
+	 * A rejected invoice stays locked too: the platform keeps the flow it already registered under that
+	 * reference, so re-sending the same reference is refused whatever the outcome of the first send.
+	 *
+	 * @return void
+	 */
+	public function testRejectedInvoiceStaysLocked()
+	{
+		global $db;
+
+		$status = $this->statusFor('i_159705', EInvoicing::STATUS_ERROR);
+
+		$this->assertSame(1, $status['everTransmitted']);
+
+		$einvoicing = new EInvoicing($db);
+		$this->assertTrue($einvoicing->isTransmittedLockActive(self::TEST_ELEMENT_ID, 'TEST-LOCK-0001'));
+	}
+
+	/**
+	 * The documented opt-out lifts the lock, for an operator deliberately testing the platform retry.
+	 *
+	 * @return void
+	 */
+	public function testOptOutLiftsTheLock()
+	{
+		global $conf, $db;
+
+		$this->statusFor('i_159705', EInvoicing::STATUS_AWAITING_VALIDATION);
+
+		$conf->global->EINVOICING_ALLOW_RESEND_TRANSMITTED = 1;
+
+		$einvoicing = new EInvoicing($db);
+		$this->assertFalse($einvoicing->isTransmittedLockActive(self::TEST_ELEMENT_ID, 'TEST-LOCK-0001'));
+	}
+}


### PR DESCRIPTION
## Problem

With `EINVOICING_AUTO_SEND_ON_GENERATION` on, regenerating the document of an invoice that has
already been transmitted sends it to the platform again. The platform registers a flow under the
invoice reference and refuses the second one:

```
POST /flows  →  400  {"errorCode":"CREATE_ERROR","errorMessage":"La facture est déjà existante (id 159705)"}
```

So the operator gets a transmission error on an invoice that is, in fact, correctly deposited — and
one useless call to the platform per regeneration.

## Why the existing guard misses it

The auto-send in `afterPDFCreation()` gates on `$currentStatusDetails['transmitted']`, which
`fetchLastknownInvoiceStatus()` derives from the **sync status**:

```php
if (!in_array((int) $obj->syncstatus, array(STATUS_UNKNOWN, STATUS_IGNORE, STATUS_IGNORE_2, STATUS_NOT_GENERATED, STATUS_GENERATED))) {
    $tmpstatus['transmitted'] = 1;
} else {
    $tmpstatus['transmitted'] = 0;
}
```

`STATUS_GENERATED` is in that list, and it is exactly what `CIIProtocol::generateInvoice()` /
`FacturXProtocol::generateInvoice()` write back on every run:

```php
$einvoicing->setEInvoiceStatus($invoice, $einvoicing::STATUS_GENERATED, 'Invoice status set to Generated by generateInvoice()');
```

The hook reads the status *before* generating, so the first regeneration after a send is still
protected — it reads the post-send status. The second one is not: it reads the `GENERATED` the first
regeneration wrote, concludes the invoice was never sent, and sends it.

That is the very distinction the transmitted lock introduced for the manual path: `everTransmitted`
is the `flow_id` the platform assigned on the first successful submission, which
`insertOrUpdateExtLink()` never clears (`if (!empty($flowId))` on update). The manual `send_to_pdp`
button has gated on it since; this call site was left on the resettable flag.

## Change

One condition. The auto-send now also asks `isTransmittedLockActive()`, so it gates on the
persistent `flow_id` rather than only on the status the generation just reset:

```php
if (getDolGlobalString('EINVOICING_AUTO_SEND_ON_GENERATION') && empty($currentStatusDetails['transmitted'])
    && !$einvoicing->isTransmittedLockActive($invoiceObject->id, $invoiceObject->ref) && $precheckresult >= 0) {
```

Both guards are kept: they answer different questions, and the cheap one still short-circuits.
Nothing else changes — `isTransmittedLockActive()` already honours the documented
`EINVOICING_ALLOW_RESEND_TRANSMITTED` opt-out, so an operator deliberately testing the platform
retry behaviour keeps the same escape hatch on both paths.

A never-submitted invoice carries no `flow_id`, so the normal case — validate, generate, transmit
once — is untouched.

## Tests

New `test/phpunit/TransmittedLockTest.php`, 5 tests / 15 assertions, registered in `AllTests.php`.
It pins the semantics of the two flags on a record written the way the module writes it:

- generated but never submitted → not locked (auto-send must stay available);
- submitted → both flags agree, locked;
- **submitted then regenerated → `transmitted` falls back to 0 while `everTransmitted` and the lock
  stay on** (the regression);
- submitted then rejected → still locked, the platform keeps the flow under that reference;
- opt-out set → lock lifted.

Green on Dolibarr 23 / PHP 8.4. phpcs clean on the three PHP files.

The one-line guard itself sits in a hook that needs a full PDF generation cycle, so it is not
covered by the unit test; it is verified by reading and by the field evidence below.

## Field evidence

Live instance, production mode, 27/07/2026, on an invoice of 159,83 € — the two calls are the
module's own `einvoicing_call` traces:

| time | call | sha256 of the sent XML | platform answer |
|---|---|---|---|
| 11:29:47 | `send_invoice` | `f95eec06…` | `200` — `{"flowId":"i_159705", …}` |
| 14:29:40 | `send_invoice` | `726304726e…` | `400 CREATE_ERROR "La facture est déjà existante (id 159705)"` |

Same `trackingId`, different document (the invoice had been regenerated in between), and the
`einvoicing_extlinks` record still carried `flow_id = i_159705` throughout — which is what the fix
now reads.
