### PR TITLE
[einvoicing] CHORE: finish cec18cb, XmlPatcher needs no composer import at all

### DIFF
--- a/einvoicing/class/utils/XmlPatcher.class.php
+++ b/einvoicing/class/utils/XmlPatcher.class.php
@@ -1,6 +1,4 @@
 <?php
-use Stripe\OAuthErrorObject;
-
 /* Copyright (C) 2025       Laurent Destailleur         <eldy@users.sourceforge.net>
  * Copyright (C) 2025       Mohamed DAOUD               <mdaoud@dolicloud.com>
  * Copyright (C) 2026		MDW							<mdeweerd@users.noreply.github.com>
@@ -28,6 +26,11 @@ use Stripe\OAuthErrorObject;
 
 /**
  * XmlPatcher
+ *
+ * This class must stay free of any composer import: CIIProtocol includes it, and the CII protocol
+ * works on an instance where the php prerequisites of the module were never installed. Patching is
+ * done with the native DOM extension only, and the horstoeko builder is received as a plain object
+ * from the caller (FacturXProtocol), which is the one loading vendor/autoload.php.
  */
 class XmlPatcher
 {


### PR DESCRIPTION
### What cec18cb was doing

`XmlPatcher.class.php` used to open with, at file scope:

```php
use horstoeko\zugferd\ZugferdDocumentBuilder;

require __DIR__ . "/../../vendor/autoload.php";
```

and `CIIProtocol.class.php:40` includes that file. So merely walking the **CII** path - which needs
no composer library at all, it patches XML with the native DOM extension - required the module php
prerequisites to be installed, and fataled when they were not. cec18cb removed both lines, relaxed
`$builder` to a plain object, and left the loading of `vendor/autoload.php` to `FacturXProtocol`,
the only caller that actually builds with horstoeko. That fix is right and this PR keeps it: the
CII path is now free of any composer coupling (checked, `CIIProtocol` references neither horstoeko
nor the autoloader anywhere else).

### What this PR changes

The same hunk left one line behind:

```php
use Stripe\OAuthErrorObject;
```

It came in exactly where the horstoeko import went out - an editor auto-import that picked the
wrong symbol from the index. It cannot be what was intended: nothing in the module references it
(single occurrence in the whole tree), and the Stripe SDK is not a dependency of `einvoicing` - the
class only exists in `dev/tools/phan/stubs/dolibarr.php`, which is precisely why phan resolves the
import, finds no use of it, and warns.

That warning is the **only** finding of the phan job. Here is the whole `_phan.xml` artifact of the
last run on `main`:

```xml
<checkstyle version="6.5">
  <file name="einvoicing/class/utils/XmlPatcher.class.php">
    <error line="2" severity="warning" message="Possibly zero references to use statement for classlike/namespace OAuthErrorObject (\Stripe\OAuthErrorObject)" source="PhanUnreferencedUseNormal"/>
  </file>
</checkstyle>
```

`cs2pr` then exits 1, so the job is red on `main` and on every open pull request.

So the import goes, and the constraint it contradicts is written on the class instead, so that the
next composer import does not creep back into a file the CII path loads.

`php -l` and `phpcs` (repo ruleset) clean, phan green on this branch.
