### PR TITLE
[einvoicing] FIX: consult the directory through the search form so every platform answers

### DIFF
--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -318,9 +318,15 @@ abstract class AbstractPDPProvider
 
 		// 2) No directory line: tell apart a legal unit known to the directory but not able to receive
 		//    yet (inactive) from a SIREN that is unknown to the directory (absent).
-		$consult = $this->callApi('afnor-directory/v1/siren/code-insee:' . urlencode($siren), 'GET', false, array(), 'precheck_directory');
+		//    The search form is used rather than the 'siren/code-insee:<siren>' consultation: both are
+		//    part of the same standardized service, but the consultation is not served by every Approved
+		//    Platform (one answers 404 on it while answering the search with the legal unit), so the
+		//    search is what keeps this second step meaningful everywhere. An unknown SIREN comes back
+		//    either as a 404 or as an empty result set depending on the platform, and both mean absent.
+		$consultbody = json_encode(array('filters' => array('siren' => array('op' => 'strict', 'value' => $siren))));
+		$consult = $this->callApi('afnor-directory/v1/siren/search', 'POST', $consultbody, array(), 'precheck_directory');
 		$consultcode = (int) (isset($consult['status_code']) ? $consult['status_code'] : 0);
-		if ($consultcode == 200 && !empty($consult['response']['siren'])) {
+		if ($consultcode == 200 && !empty($consult['response']['results'][0]['siren'])) {
 			$result['status'] = 'inactive';
 		} else {
 			$result['status'] = 'absent';

--- a/einvoicing/test/phpunit/RecipientDirectoryTest.php
+++ b/einvoicing/test/phpunit/RecipientDirectoryTest.php
@@ -409,7 +409,7 @@ class RecipientDirectoryTest extends CommonClassTest
 		$provider = new FakeDirectoryPDPProvider($db);
 		$provider->cannedResponses = array(
 			array('status_code' => 200, 'response' => array('results' => array(), 'totalNumberOfResults' => 0)),
-			array('status_code' => 200, 'response' => array('siren' => '552081317', 'businessName' => 'RENAULT')),
+			array('status_code' => 200, 'response' => array('results' => array(array('siren' => '552081317', 'businessName' => 'RENAULT')), 'totalNumberOfResults' => 1)),
 		);
 
 		$result = $provider->checkRecipientDirectory('552081317');
@@ -417,10 +417,12 @@ class RecipientDirectoryTest extends CommonClassTest
 		$this->assertSame('inactive', $result['status']);
 		$this->assertSame(0, $result['reachable']);
 		$this->assertSame(0, $result['entries']);
+		// The consultation goes through the search form, the only one every platform serves.
+		$this->assertSame('afnor-directory/v1/siren/search', $provider->calledResources[1]);
 	}
 
 	/**
-	 * No directory line and a SIREN unknown to the annuaire.
+	 * No directory line and a SIREN unknown to the annuaire, on a platform that says so with a 404.
 	 *
 	 * @return void
 	 */
@@ -432,6 +434,27 @@ class RecipientDirectoryTest extends CommonClassTest
 		$provider->cannedResponses = array(
 			array('status_code' => 200, 'response' => array('results' => array(), 'totalNumberOfResults' => 0)),
 			array('status_code' => 404, 'response' => ''),
+		);
+
+		$result = $provider->checkRecipientDirectory('123456789');
+
+		$this->assertSame('absent', $result['status']);
+		$this->assertSame(0, $result['reachable']);
+	}
+
+	/**
+	 * Same, on a platform that answers the consultation with an empty result set instead of a 404.
+	 *
+	 * @return void
+	 */
+	public function testNoLineAndEmptyConsultationIsAbsent()
+	{
+		global $db;
+
+		$provider = new FakeDirectoryPDPProvider($db);
+		$provider->cannedResponses = array(
+			array('status_code' => 200, 'response' => array('results' => array(), 'total_number_results' => 0)),
+			array('status_code' => 200, 'response' => array('results' => array(), 'total_number_results' => 0)),
 		);
 
 		$result = $provider->checkRecipientDirectory('123456789');


### PR DESCRIPTION
## Problem

When a recipient has no directory line, the reachability pre-check makes a second call to tell a legal unit the annuaire knows but that cannot receive yet (`inactive`) from a SIREN the annuaire does not know at all (`absent`). That second call used the consultation endpoint, `GET siren/code-insee:<siren>`.

Both endpoints belong to the same standardized service (AFNOR XP Z12-013), but the consultation is not served everywhere. Measured live on 2026-07-31 against two Approved Platforms:

| lookup | platform A | platform B |
|---|---|---|
| `GET siren/code-insee:892304189` | `200`, legal unit | `404` |
| `POST siren/search` (filter `siren` strict) | `200`, legal unit | `200`, legal unit |

On platform B — the one wired up in #512 — the second step could therefore only ever answer `absent`, which is the wrong word for a company that is in the annuaire and simply has no reception address open yet. This is the limitation noted in #512.

## Change

The consultation now uses the search form, with the same filter body as the directory-line search just above it. A SIREN that is unknown comes back either as a `404` or as an empty result set depending on the platform, and both keep meaning `absent`.

Nothing else moves: the two statuses this step produces mean "not reachable" either way, and neither blocks anything on its own — the lookup stays read-only unless the opt-in `EINVOICING_REQUIRE_ROUTABLE_RECIPIENT` of #513 is set.

## Measured

Live on both platforms, production directories, 2026-07-31:

| SIREN | consultation via search |
|---|---|
| 892304189 | `BRASSERIE X POITOU`, `administrativeStatus: A` — on both platforms |
| 393078647 | `MEDIACTIVE`, `administrativeStatus: A` — on both platforms |
| 123456782 | empty result set (unknown), on the platform that answers `200` |

## Tests

`RecipientDirectoryTest`: the two tests covering that second step now carry a search-shaped answer, one of them asserting the resource actually called, plus a new test for the platform that reports an unknown SIREN with an empty result set instead of a `404`.

phpunit run on Dolibarr 20.0.5: 58 tests, 404 assertions, the 3 `EInvoicingSamplesTest` failures are pre-existing on `main` (57 tests / 3 failures without this commit). phan clean.
