### PR TITLE
[einvoicing] Fix: reading an Access Point answer no longer assumes keys getURLContent may omit

### DIFF
--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -1170,11 +1170,16 @@ class SuperPDPProvider extends AbstractPDPProvider
 
 		$response = getURLContent($url, $method, $params, 1, $httpheader, array('http', 'https'), 0, -1, 0, 0, array(), '_einvoicing');
 
-		$status_code = $response['http_code'];
+		// Neither key is guaranteed: getURLContent() sets 'content' only when the body is not empty
+		// (an Access Point answering 200 with no body, as a healthcheck does, has none), and on a curl
+		// failure - timeout, DNS, refused connection - it returns the error keys without 'http_code'.
+		// Reading them raw turned those two ordinary situations into PHP warnings.
+		$status_code = $response['http_code'] ?? 0;
+		$content = $response['content'] ?? '';
 		$body = 'Error';
 
 		if ($status_code == 200 || $status_code == 202) {
-			$body = $response['content'];
+			$body = $content;
 			if (!isset($extraHeaders['Accept'])) { // Json if default format
 				$body = json_decode($body, true);
 			}
@@ -1186,7 +1191,7 @@ class SuperPDPProvider extends AbstractPDPProvider
 		} else {
 			$returnarray = array(
 				'status_code' => $status_code,
-				'response' => 'Error ' . $status_code . ' - ' . (string) $response['content']
+				'response' => 'Error ' . $status_code . ' - ' . (string) $content
 			);
 			if (!empty($response['curl_error_no'])) {
 				$returnarray['curl_error_no'] = $response['curl_error_no'];
@@ -1194,9 +1199,19 @@ class SuperPDPProvider extends AbstractPDPProvider
 			if (!empty($response['curl_error_msg'])) {
 				$returnarray['curl_error_msg'] = $response['curl_error_msg'];
 			}
-			if ($contentarray = json_decode((string) $response['content'], true)) {
-				$returnarray['errorCode'] = (string) $contentarray['errorCode'];
-				$returnarray['errorMessage'] = (string) $contentarray['errorMessage'];
+			// An error body is not always the {errorCode, errorMessage} pair this expects: a plain JSON
+			// string decodes into a string, and indexing that is a fatal on PHP 8, not a warning.
+			// Each key is set only when the body really carries it: callers tell "no message" from
+			// "empty message" with isset(), and would otherwise report an empty error instead of
+			// falling back on the HTTP code.
+			$contentarray = json_decode((string) $content, true);
+			if (is_array($contentarray)) {
+				if (isset($contentarray['errorCode'])) {
+					$returnarray['errorCode'] = (string) $contentarray['errorCode'];
+				}
+				if (isset($contentarray['errorMessage'])) {
+					$returnarray['errorMessage'] = (string) $contentarray['errorMessage'];
+				}
 			}
 		}
 


### PR DESCRIPTION
## The defect

`SuperPDPProvider::callApi()` reads `$response['http_code']` and `$response['content']` straight out of what `getURLContent()` returns. Neither key is guaranteed — from the core itself:

```php
$rep = $info;                              // no 'content' yet
if ($response) { $rep['content'] = $response; }     // only when the body is not empty
```
and on a curl error the function returns `array('content', 'curl_error_no', 'curl_error_msg')` — **no `http_code` at all**.

So two ordinary situations produced PHP warnings:

- **A 200 with an empty body**, which is exactly what a healthcheck answers → `Undefined array key "content"`.
- **Any network failure on the way to the platform** (timeout, DNS, refused connection) → `Undefined array key "http_code"`, and `$status_code` silently became `null` instead of a number.

Measured on the bench, before the fix:

```
empty body (204) : keys = url,content_type,http_code,...      has 'content'   = false
curl failure     : keys = content,curl_error_no,curl_error_msg  has 'http_code' = false
```

and, on a live Dolibarr 18 instance, every healthcheck logged `PHP Warning: Undefined array key "content"`.

## The fix

Both are read with a default. The error body is decoded defensively as well: it is not always the `{errorCode, errorMessage}` pair the code expected, and a plain JSON string decodes into a *string*, where indexing is a fatal on PHP 8 rather than a warning.

Each of the two keys is still set only when the body really carries it — callers use `isset()` to tell "no message" from "empty message" (`AbstractPDPProvider` falls back on `'HTTP ' . $code`), so always setting them would replace a useful HTTP code with an empty string.

## Tested

- The two failure shapes reproduced against the core function, then the healthcheck warning confirmed gone on Dolibarr 18.0.10 and 23.0.3, with the healthcheck still reporting the Access Point as reachable.
- Full chain **from a brand-new invoice**, in both directions between a 18.0.10 and a 23.0.3 instance through the sandbox Access Point: issue → transmit → receive as a supplier invoice → 202 / 205 / 211 / 212 all recorded on both sides. Every check read back from a separate process.
- Module PHPUnit files green on both versions.

`EsalinkPDPProvider` reads the same two keys the same way, but I have no Esalink account to prove a fix on, so this PR does not touch it.