### PR TITLE
[einvoicing] Fix: a flow whose invoice is not ours warns on every synchronization

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -2,6 +2,15 @@
 
 ## 1.0.4
 
+FIX: A synchronization no longer raises a PHP warning for every flow whose source invoice is not in
+this database. Such a flow is the ordinary case on a platform account shared with another system -
+the customer invoice behind it simply lives somewhere else - and syncFlow() notes it in a message
+built from $document->flowId, while the document object carries flow_id. On a Dolibarr whose
+CommonObject has no magic getter to absorb the miss (18) that logged "Undefined property:
+Document::$flowId" once per flow; from 20 on the getter swallows it. The message itself, which the
+caller discards today since the flow counts as synchronized, also lost the one identifier it exists
+to carry.
+
 NEW: A "Mapped vendor references" screen (Billing > E-invoice synchronization) lists every vendor
 product reference recorded on the products, i.e. the mappings the import of a supplier invoice relies
 on to find the product of a line. Until now they could only be read product by product, in the

--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -1170,13 +1170,13 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 						return array('res' => -1, 'message' => "ERROR_FETCH_INVOICE Failed to fetch customer invoice for flowId: " . $flowId);
 					} elseif ($res == 0) {
 						$returnRes = 1;
-						$returnMessage = 'Source invoice not found for '.$document->flowId;
+						$returnMessage = 'Source invoice not found for '.$document->flow_id;
 					} else {
 						// TODO: save received converted document as attachment to customer invoice
 					}
 				} else {
 					$returnRes = 1;
-					$returnMessage = 'Source invoice not found for '.$document->flowId;
+					$returnMessage = 'Source invoice not found for '.$document->flow_id;
 				}
 
 				$document->fk_element_id = !empty($factureObj->id) ? $factureObj->id : 0;

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -1773,7 +1773,7 @@ class SuperPDPProvider extends AbstractPDPProvider
 						return array('res' => -1, 'message' => "ERROR_FETCH_INVOICE Failed to fetch customer invoice for flowId: " . $flowId);
 					} elseif ($res == 0) {
 						$returnRes = 1;
-						$returnMessage = 'Source invoice not found for '.$document->flowId;
+						$returnMessage = 'Source invoice not found for '.$document->flow_id;
 					} else {
 						// TODO: save received converted document as attachment to customer invoice
 						/*
@@ -1789,7 +1789,7 @@ class SuperPDPProvider extends AbstractPDPProvider
 					}
 				} else {
 					$returnRes = 1;
-					$returnMessage = 'Source invoice not found for '.$document->flowId;
+					$returnMessage = 'Source invoice not found for '.$document->flow_id;
 				}
 
 				$document->fk_element_id = !empty($factureObj->id) ? $factureObj->id : 0;


### PR DESCRIPTION
> **Edited after opening.** The first version of this description claimed the operator read a
> truncated message in the synchronization report. Checking where the message actually goes proved
> that wrong: the caller discards it. The change is the same one-word fix, its benefit is narrower,
> and the text below says what it really is.

A flow that comes back for a customer invoice which does not exist in this database is an ordinary
situation, not an error: the platform account can be shared with another system, and the code says so
itself a few lines below — *"Probably the customer invoice was sent from another system that use the
same PDP account"*. `syncFlow()` notes it and returns 1.

The note is built like this:

```php
$returnMessage = 'Source invoice not found for '.$document->flowId;
```

`Document` carries `flow_id`, not `flowId`. The property does not exist, so:

- on a core whose `CommonObject` has no magic getter to absorb the miss — 18 — every such flow logs
  `Undefined property: Document::$flowId`. On an account where unmatched flows are the norm, that is
  one line of noise per flow, per synchronization;
- from 20 on the getter swallows it, and the sentence just loses its identifier: `Source invoice not
  found for ` followed by nothing.

**That sentence is not displayed today.** `syncFlows()` keeps the per-flow message for `res < 0` and
`res == 0` only; this branch returns 1, so the caller drops it. So what this patch buys is the warning
on 18, and a message that will be right the day it is surfaced instead of a second bug waiting behind
the first. Nothing more — I would rather say so than oversell four characters.

The same two occurrences, in the two branches of the same test, are in `SuperPDPProvider::syncFlow()`
and `EsalinkPDPProvider::syncFlow()`. Both now read `flow_id`, the property that very method assigns
from the flow identifier a few dozen lines earlier (`$document->flow_id = $flowId;`), so the message
cannot drift from the value it is meant to print.

### Reproduced, then verified, on real instances

Bench: two sandbox instances sharing one platform account, so one of them legitimately sees the
other's customer invoice flows. `syncFlow()` replayed on such a flow, before and after the change.

| | Dolibarr 18.0.10 | Dolibarr 23.0.3 |
|---|---|---|
| before — PHP | `Undefined property: Document::$flowId` (SuperPDPProvider.class.php:2137) | *(no warning: `CommonObject::__get` absorbs it)* |
| before — message built | `'Source invoice not found for '` | `'Source invoice not found for '` |
| after — PHP | no warning | no warning |
| after — message built | `'Source invoice not found for i_188027'` | `'Source invoice not found for i_190419'` |

`res` stays `1` and no transaction is left open in any of the runs — the branch is a note, not a
failure, and that does not change.

Checked separately that the divergence between the two cores is the magic getter and nothing else:
reading `Document::$flowId` warns on 18.0.10 and is silently `NULL` on 20.0.5, 23.0.3 and 24.0.0-beta.

### Regression run with the patch deployed

The patch was deployed for real — not loaded from a side tree — and the chain replayed on it, from
brand new invoices, in both directions between Dolibarr 18.0.10 and 23.0.3: emission → platform →
reception as a supplier invoice, the import checked from a **separate process** so an uncommitted
transaction would show; lifecycle statuses 200, 201, 205, 211 returned to the issuer, and 212 emitted
on payment, received and recorded on the other side (`llx_einvoicing_extlinks.syncstatus = 212`); no
transaction left open at any step.

PHPUnit, run file by file against the patched tree, passes on 18.0.10 and 23.0.3, with one exception
unrelated to this patch and present before it: `EInvoicingSamplesTest` fails on 18.0.10 because its
fixture depends on a rounding option that core does not implement. That one is #532.

The `EsalinkPDPProvider` half is the same two lines in the same shape, but it was **not executed** —
I have no Esalink sandbox credentials to drive a synchronization through that provider.
