### PR TITLE
[einvoicing] Fix: the sample invoice pins a discount rounding no supported core shares

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -11,6 +11,16 @@ Document::$flowId" once per flow; from 20 on the getter swallows it. The message
 caller discards today since the flow counts as synchronized, also lost the one identifier it exists
 to carry.
 
+FIX: The sample invoice no longer pins a discount rounding that no two Dolibarr versions agree on.
+It forced MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY to 2 - round the
+discounted unit price, then multiply - but 18 and 20 do not implement that option and round the line
+total instead, 23 rounds the unit price up and 24 rounds it down, so its single line (5 x 100.05 less
+10%) came out at 450.23, 450.25 or 450.20 depending on the core. The specimen is now computed with the
+default convention, the one all four return, and the setting of the instance is restored afterwards
+instead of being left changed for the rest of the request. The reference fixtures are updated
+accordingly, and EInvoicingSamplesTest, which passed on only one of the four versions tested, now
+passes on all of them, 18.0.10 to 24.0.0.
+
 NEW: A "Mapped vendor references" screen (Billing > E-invoice synchronization) lists every vendor
 product reference recorded on the products, i.e. the mappings the import of a supplier invoice relies
 on to find the product of a line. Until now they could only be read product by product, in the

--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -302,11 +302,21 @@ trait CommonProtocol
 		$line->fk_product = 0;
 
 		include_once DOL_DOCUMENT_ROOT.'/core/lib/price.lib.php';
-		// Force MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY, so we are sure sample is valid at the initial object.
-		// TODO Make this sample generation working with any configuration of discount.
-		$conf->global->MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY = 2;
+		// The specimen has to read the same everywhere, so the discount rounding is pinned instead of
+		// following the instance. It is pinned to the default convention - round the line total - and
+		// not to 2, "round the discounted unit price first", because no two supported cores agree on
+		// what 2 means: 18 and 20 do not implement the option at all and round the total, 23 rounds the
+		// unit price up and 24 rounds it down. On the line below (5 x 100.05 less 10%) that is three
+		// different totals, 450.23 / 450.25 / 450.20, for one specimen. The default is the one value
+		// the four of them return.
+		// Restored right after: this is a specimen, it has no business changing how the rest of the
+		// request computes its prices.
+		$savRoundDiscountOnUnitPrice = getDolGlobalString('MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY');
+		$conf->global->MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY = '0';
 
 		$tmp = calcul_price_total($line->qty, $line->subprice, $line->remise_percent, $line->tva_tx, 0, 0, 0, 'HT', 0, 0);
+
+		$conf->global->MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY = $savRoundDiscountOnUnitPrice;
 
 		$line->total_ht = (float) $tmp[0];
 		$line->total_ttc = (float) $tmp[2];

--- a/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_creditnote.xml
+++ b/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_creditnote.xml
@@ -66,7 +66,7 @@
           <ram:ReasonCode>95</ram:ReasonCode>
         </ram:SpecifiedTradeAllowanceCharge>
         <ram:SpecifiedTradeSettlementLineMonetarySummation>
-          <ram:LineTotalAmount>450.25</ram:LineTotalAmount>
+          <ram:LineTotalAmount>450.23</ram:LineTotalAmount>
         </ram:SpecifiedTradeSettlementLineMonetarySummation>
       </ram:SpecifiedLineTradeSettlement>
     </ram:IncludedSupplyChainTradeLineItem>
@@ -147,9 +147,9 @@
       <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
       <!--VAT rate: 20, VAT src code: , ExemptionReasonCode: -->
       <ram:ApplicableTradeTax>
-        <ram:CalculatedAmount>90.05</ram:CalculatedAmount>
+        <ram:CalculatedAmount>90.04</ram:CalculatedAmount>
         <ram:TypeCode>VAT</ram:TypeCode>
-        <ram:BasisAmount>450.25</ram:BasisAmount>
+        <ram:BasisAmount>450.23</ram:BasisAmount>
         <ram:CategoryCode>S</ram:CategoryCode>
         <ram:RateApplicablePercent>20.00</ram:RateApplicablePercent>
       </ram:ApplicableTradeTax>
@@ -162,14 +162,14 @@
       </ram:SpecifiedTradePaymentTerms>
       <!--Totals-->
       <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
-        <ram:LineTotalAmount>450.25</ram:LineTotalAmount>
+        <ram:LineTotalAmount>450.23</ram:LineTotalAmount>
         <ram:ChargeTotalAmount>0.00</ram:ChargeTotalAmount>
         <ram:AllowanceTotalAmount>0.00</ram:AllowanceTotalAmount>
-        <ram:TaxBasisTotalAmount>450.25</ram:TaxBasisTotalAmount>
-        <ram:TaxTotalAmount currencyID="EUR">90.05</ram:TaxTotalAmount>
-        <ram:GrandTotalAmount>540.30</ram:GrandTotalAmount>
+        <ram:TaxBasisTotalAmount>450.23</ram:TaxBasisTotalAmount>
+        <ram:TaxTotalAmount currencyID="EUR">90.04</ram:TaxTotalAmount>
+        <ram:GrandTotalAmount>540.27</ram:GrandTotalAmount>
         <ram:TotalPrepaidAmount>0.00</ram:TotalPrepaidAmount>
-        <ram:DuePayableAmount>540.30</ram:DuePayableAmount>
+        <ram:DuePayableAmount>540.27</ram:DuePayableAmount>
       </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
       <ram:InvoiceReferencedDocument>
         <ram:IssuerAssignedID>FA0000-SPECIMEN-STANDARD</ram:IssuerAssignedID>

--- a/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_deposit.xml
+++ b/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_deposit.xml
@@ -66,7 +66,7 @@
           <ram:ReasonCode>95</ram:ReasonCode>
         </ram:SpecifiedTradeAllowanceCharge>
         <ram:SpecifiedTradeSettlementLineMonetarySummation>
-          <ram:LineTotalAmount>450.25</ram:LineTotalAmount>
+          <ram:LineTotalAmount>450.23</ram:LineTotalAmount>
         </ram:SpecifiedTradeSettlementLineMonetarySummation>
       </ram:SpecifiedLineTradeSettlement>
     </ram:IncludedSupplyChainTradeLineItem>
@@ -147,9 +147,9 @@
       <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
       <!--VAT rate: 20, VAT src code: , ExemptionReasonCode: -->
       <ram:ApplicableTradeTax>
-        <ram:CalculatedAmount>90.05</ram:CalculatedAmount>
+        <ram:CalculatedAmount>90.04</ram:CalculatedAmount>
         <ram:TypeCode>VAT</ram:TypeCode>
-        <ram:BasisAmount>450.25</ram:BasisAmount>
+        <ram:BasisAmount>450.23</ram:BasisAmount>
         <ram:CategoryCode>S</ram:CategoryCode>
         <ram:RateApplicablePercent>20.00</ram:RateApplicablePercent>
       </ram:ApplicableTradeTax>
@@ -162,14 +162,14 @@
       </ram:SpecifiedTradePaymentTerms>
       <!--Totals-->
       <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
-        <ram:LineTotalAmount>450.25</ram:LineTotalAmount>
+        <ram:LineTotalAmount>450.23</ram:LineTotalAmount>
         <ram:ChargeTotalAmount>0.00</ram:ChargeTotalAmount>
         <ram:AllowanceTotalAmount>0.00</ram:AllowanceTotalAmount>
-        <ram:TaxBasisTotalAmount>450.25</ram:TaxBasisTotalAmount>
-        <ram:TaxTotalAmount currencyID="EUR">90.05</ram:TaxTotalAmount>
-        <ram:GrandTotalAmount>540.30</ram:GrandTotalAmount>
+        <ram:TaxBasisTotalAmount>450.23</ram:TaxBasisTotalAmount>
+        <ram:TaxTotalAmount currencyID="EUR">90.04</ram:TaxTotalAmount>
+        <ram:GrandTotalAmount>540.27</ram:GrandTotalAmount>
         <ram:TotalPrepaidAmount>0.00</ram:TotalPrepaidAmount>
-        <ram:DuePayableAmount>540.30</ram:DuePayableAmount>
+        <ram:DuePayableAmount>540.27</ram:DuePayableAmount>
       </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
     </ram:ApplicableHeaderTradeSettlement>
   </rsm:SupplyChainTradeTransaction>

--- a/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_standard.xml
+++ b/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_standard.xml
@@ -66,7 +66,7 @@
           <ram:ReasonCode>95</ram:ReasonCode>
         </ram:SpecifiedTradeAllowanceCharge>
         <ram:SpecifiedTradeSettlementLineMonetarySummation>
-          <ram:LineTotalAmount>450.25</ram:LineTotalAmount>
+          <ram:LineTotalAmount>450.23</ram:LineTotalAmount>
         </ram:SpecifiedTradeSettlementLineMonetarySummation>
       </ram:SpecifiedLineTradeSettlement>
     </ram:IncludedSupplyChainTradeLineItem>
@@ -147,9 +147,9 @@
       <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
       <!--VAT rate: 20, VAT src code: , ExemptionReasonCode: -->
       <ram:ApplicableTradeTax>
-        <ram:CalculatedAmount>90.05</ram:CalculatedAmount>
+        <ram:CalculatedAmount>90.04</ram:CalculatedAmount>
         <ram:TypeCode>VAT</ram:TypeCode>
-        <ram:BasisAmount>450.25</ram:BasisAmount>
+        <ram:BasisAmount>450.23</ram:BasisAmount>
         <ram:CategoryCode>S</ram:CategoryCode>
         <ram:RateApplicablePercent>20.00</ram:RateApplicablePercent>
       </ram:ApplicableTradeTax>
@@ -162,14 +162,14 @@
       </ram:SpecifiedTradePaymentTerms>
       <!--Totals-->
       <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
-        <ram:LineTotalAmount>450.25</ram:LineTotalAmount>
+        <ram:LineTotalAmount>450.23</ram:LineTotalAmount>
         <ram:ChargeTotalAmount>0.00</ram:ChargeTotalAmount>
         <ram:AllowanceTotalAmount>0.00</ram:AllowanceTotalAmount>
-        <ram:TaxBasisTotalAmount>450.25</ram:TaxBasisTotalAmount>
-        <ram:TaxTotalAmount currencyID="EUR">90.05</ram:TaxTotalAmount>
-        <ram:GrandTotalAmount>540.30</ram:GrandTotalAmount>
+        <ram:TaxBasisTotalAmount>450.23</ram:TaxBasisTotalAmount>
+        <ram:TaxTotalAmount currencyID="EUR">90.04</ram:TaxTotalAmount>
+        <ram:GrandTotalAmount>540.27</ram:GrandTotalAmount>
         <ram:TotalPrepaidAmount>0.00</ram:TotalPrepaidAmount>
-        <ram:DuePayableAmount>540.30</ram:DuePayableAmount>
+        <ram:DuePayableAmount>540.27</ram:DuePayableAmount>
       </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
     </ram:ApplicableHeaderTradeSettlement>
   </rsm:SupplyChainTradeTransaction>


### PR DESCRIPTION
`CommonProtocol::generateSampleInvoice()` forces the discount rounding before computing its one
line, *"so we are sure sample is valid at the initial object"*, with a TODO next to it asking for the
sample to work under any discount configuration:

```php
$conf->global->MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY = 2;
```

The value it picks is the one the supported cores read differently. On the specimen line — 5 × 100.05
less 10 % — `calcul_price_total()` returns:

| core | what it does with the option | line total |
|---|---|---|
| 18.0.10 | not implemented, rounds the line total | **450.23** |
| 20.0.5 | not implemented, rounds the line total | **450.23** |
| 23.0.3 | rounds the discounted unit price up, then × qty | **450.25** |
| 24.0.0-beta | rounds the discounted unit price down, then × qty | **450.20** |

So one module produced three different specimens, and `EInvoicingSamplesTest`, which compares the
generated XML against a committed fixture, could only pass on the version the fixture had been
captured on. A module that declares Dolibarr 18 as its minimum was failing its own regression test
there — and on 20, and on 24.

Pinning the **default** convention instead answers the TODO the other way round: it is the value all
four cores return, so the specimen no longer depends on the core, nor on the setting of the instance.
The fixtures are regenerated accordingly (450.25 → 450.23 and the totals that follow); nothing else in
them moves.

The setting is also **restored** after the call. It was left overwritten for the rest of the request,
so asking for a specimen quietly changed how everything computed afterwards rounded its discounts. The
method already saves and restores `EINVOICING_PDP`, the specimen routing id and `$langs` for exactly
that reason.

### Measured, before and after, on four live instances

Four Dolibarr instances sharing one deployment of the module: 18.0.10, 20.0.5, 23.0.3, 24.0.0-beta.

**The specimen is now the same everywhere.** Generated on the four cores with the patch: four
byte-identical XML documents (`md5 4e1454e7…`), equal to the regenerated fixtures. Before the patch
the same four differed, as the table above says.

**The suite passes everywhere.** All 7 test files run one by one on the four instances, 28 runs:
green, `EInvoicingSamplesTest` included. Before the patch it failed on 18.0.10, 20.0.5 and 24.0.0-beta.

**The setting no longer leaks.** With the instance set to `0`, asking for a sample invoice and then
computing an ordinary line, on 23.0.3:

| | before | after |
|---|---|---|
| setting after the sample | `'2'` — overwritten | `'0'` — intact |
| ordinary line computed next | 450.23 → **450.25** | 450.23 → 450.23 |

Same with the instance set to `1`. And when the instance carries no such setting at all — the common
case — the restore writes back `''`, which the four cores treat exactly as absent: the line still
totals 450.23 on all of them.

**Real invoices are untouched.** 8 validated customer invoices on 18.0.10 and 23.0.3, their documents
regenerated under both deployments, before and after: byte-identical, apart from the generation
timestamp the XML header comment carries.

Also run on the patched deployment, since the patch sits on the price path: sample generation over the
four CII profiles (MINIMUM, BASIC, EN16931, EXTENDED) on the four cores, 16/16; import of a real CII
through `createSupplierInvoiceFromSource()` on 18.0.10, with the invoice then checked from a **separate
process** so an uncommitted transaction would show; and the full exchange chain both ways between
18.0.10 and 23.0.3 from brand new invoices — emission, reception, lifecycle statuses 200/201/205/211
returned, and 212 emitted on payment, received and recorded on the other side. No transaction left open
at any step.
