### PR TITLE
[einvoicing] Fix: two fields declared without the property the core reads

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -11,6 +11,16 @@ which Access point is unavailable and offers the ones that remain. The actions o
 (token, health check, sample invoice) are skipped in that state instead of being matched on an empty
 prefix.
 
+FIX: Two fields declared in the ->fields of an object had no property on the class, which the core
+notices for us: it reads $this->{$field} to build the INSERT, and the comment next to that line says
+a miss means "a bug into definition of ->fields or a missing declaration of property". Document
+declared response_for_debug in its fields only, so every document recorded logged "Undefined property:
+Document::$response_for_debug" on 18, where CommonObject has no magic getter (from 20 on the getter
+swallows it). Call is worse: its fields declare provider, its properties declared fk_provider - a
+column the table never had - so the provider name of every logged API call was written through a
+property PHP creates on the fly, which is deprecated since 8.2 and warns on all four versions.
+Both properties are now declared, and the stale fk_provider is gone.
+
 FIX: A synchronization no longer raises a PHP warning for every flow whose source invoice is not in
 this database. Such a flow is the ordinary case on a platform account shared with another system -
 the customer invoice behind it simply lives somewhere else - and syncFlow() notes it in a message

--- a/einvoicing/class/call.class.php
+++ b/einvoicing/class/call.class.php
@@ -169,7 +169,7 @@ class Call extends CommonObject
 	public $response;
 
 	public $processing_result;
-	public $fk_provider;
+	public $provider;
 	public $entity;
 	// END MODULEBUILDER PROPERTIES
 

--- a/einvoicing/class/document.class.php
+++ b/einvoicing/class/document.class.php
@@ -191,6 +191,7 @@ class Document extends CommonObject
 	public $cdar_reason_code;
 	public $cdar_reason_desc;
 	public $cdar_reason_detail;
+	public $response_for_debug;
 	// END MODULEBUILDER PROPERTIES
 
 	// Contains raw XML content (/!\ may not be identical to original XML content from AP file because it can be partially cleaned (like attachment files) to preserve XML size stored in database)


### PR DESCRIPTION
`CommonObject` builds the INSERT of a module object by reading `$this->{$field}` for every entry of
`->fields`, and the comment sitting right there says what a miss means:

```php
// Note: If $this->{$field} is not defined, it means there is a bug into definition of ->fields or a
// missing declaration of property
// We should keep the warning generated by this because it is a bug somewhere else in code, not here.
$queryarray[$field] = $this->{$field};
```

Two objects of the module have that bug.

**`Document`** declares `response_for_debug` in its `->fields`, and nowhere else. Recording a document
— every flow of every synchronization — therefore logged `Undefined property:
Document::$response_for_debug` on 18, where `CommonObject` has no magic getter to absorb it; from 20
on the getter swallows it silently. Same family as #531, other field.

**`Call`** declares `provider` in its `->fields`, but its property list declares `fk_provider`, the
name of a column its table never had (`llx_einvoicing_call` has `provider varchar(50) NOT NULL`; the
`fk_provider integer` next to it lives only in a commented-out `CREATE TABLE` left in
`modEInvoicing.class.php`). The provider name of every logged API call was thus written through a
property PHP creates on the fly, which is deprecated since 8.2 — on all four supported versions, not
just 18.

Both properties are now declared and the stale `fk_provider` is dropped. Nothing else changes: the
column names, the SQL and the values written are the same.

### Measured, before and after, on four live instances

Four Dolibarr instances sharing one deployment of the module: 18.0.10, 20.0.5, 23.0.3, 24.0.0-beta,
PHP 8.4.5. Creating one `Document` and one `Call` with an error handler that catches everything (the
default reporting hides `E_DEPRECATED`, so the second defect is invisible until you look):

| core | before | after |
|---|---|---|
| 18.0.10 | `Undefined property: Document::$response_for_debug` + `Creation of dynamic property Call::$provider is deprecated` | nothing |
| 20.0.5 | `Creation of dynamic property Call::$provider is deprecated` | nothing |
| 23.0.3 | idem | nothing |
| 24.0.0-beta | idem | nothing |

**On the real path**, a synchronization on 18.0.10 that records three flows:

```
before   PHP Warning:  Undefined property: Document::$response_for_debug in .../commonobject.class.php on line 9138   (x3)
         res: 1 - flows skipped: 7 - new flows synchronized: 3
after    (no PHP line)
         res: 1 - flows skipped: 2 - new flows synchronized: 2
```

**The values still land.** Set, created, re-fetched from the database, on the four cores:
`Document::$response_for_debug` comes back identical, `Call::$provider` reads back `'SUPERPDP'`; and
after the patched synchronization above, the rows recorded on 18.0.10 carry their provider
(`SuperPDP` on the calls, `SUPERPDPViaPartner` on the documents) as before.

**Test suite**, all 7 files one by one on the four instances, 28 runs: green, except
`EInvoicingSamplesTest` on 18.0.10 / 20.0.5 / 24.0.0-beta, which fails the same way on `main`
without this branch — that one is the subject of #532 and is untouched here.
