### PR TITLE
[einvoicing] NEW: let an external module bring its own PDP provider (#448)

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -35,6 +35,18 @@ column the table never had - so the provider name of every logged API call was w
 property PHP creates on the fly, which is deprecated since 8.2 and warns on all four versions.
 Both properties are now declared, and the stale fk_provider is gone.
 
+NEW: Another module can add its own PDP / Access Point provider, without patching this one. It
+declares the hook context 'einvoicingproviders' and returns its entries from an addPDPProviders()
+method; the entry names the class and the directory it lives in ('classpath'), which until now was
+hardcoded to einvoicing/class/providers/, so a provider class could only exist inside this module. A
+hook rather than a scan of the module directories: it only exposes the providers of the modules that
+are enabled, and it costs nothing when no module implements it. An entry whose code is already taken
+by a provider of the module is ignored, and a class that does not extend AbstractPDPProvider is
+refused when it is loaded rather than failing later on a missing method. The TESTPDP entry, which
+pointed to a class that did not exist, is now the documented reference implementation: it calls
+nothing over the network and is offered only when the developer tools are enabled. The contract to
+implement is written down in einvoicing/doc/ADD-A-PDP-PROVIDER.md.
+
 FIX: A synchronization no longer raises a PHP warning for every flow whose source invoice is not in
 this database. Such a flow is the ordinary case on a platform account shared with another system -
 the customer invoice behind it simply lives somewhere else - and syncFlow() notes it in a message

--- a/einvoicing/class/providers/PDPProviderManager.class.php
+++ b/einvoicing/class/providers/PDPProviderManager.class.php
@@ -35,7 +35,7 @@ class PDPProviderManager
 	public $db;
 
 	/**
-	 * @var array<string,array{class:string,position:int,provider_countries:string[],provider_name:string,description:string,is_enabled:int<0,1>,prod_account_admin_url:?string,test_account_admin_url:?string}>	Provider list
+	 * @var array<string,array{class:string,classpath?:string,position:int,provider_countries:string[],provider_name:string,description:string,is_enabled:int<0,1>,prod_account_admin_url:?string,test_account_admin_url:?string}>	Provider list
 	 */
 	private $providersList;
 
@@ -85,13 +85,15 @@ class PDPProviderManager
 				'prod_account_admin_url' => 'https://www.superpdp.tech/app/users/create',
 				'test_account_admin_url' => 'https://www.superpdp.tech/app/users/create',
 			),
+			// Reference implementation, to copy when integrating a new platform. It talks to no platform,
+			// so it is only offered when the developer tools of the module are enabled.
 			'TESTPDP' => array(
 				'class' => 'TestPDPProvider',
 				'position' => 100,
 				'provider_countries' => array('all'),
-				'provider_name' => 'TESTPDP',
-				'description' => 'Another TESTPDP Integration',
-				'is_enabled' => 0,
+				'provider_name' => 'TESTPDP <span class="opacitymedium">(sample provider, sends nothing)</span>',
+				'description' => 'Sample PDP Integration',
+				'is_enabled' => getDolGlobalInt('EINVOICING_ALLOW_DEVTOOLS') ? 1 : 0,
 				'prod_account_admin_url' => 'https://example.com',
 				'test_account_admin_url' => 'https://example.com',
 			)
@@ -142,6 +144,11 @@ class PDPProviderManager
 			);
 		}
 
+		// Complete the list with the providers brought by external modules. Done before the "via partner
+		// only" filter below, so that filter covers them too: it is meant to leave one single tunnel
+		// offered to the client, whoever declared the other entries.
+		$this->addProvidersFromHooks();
+
 		// Grey-label "via partner only": when an operator ships the module pre-configured for delegated
 		// onboarding, hide every direct provider so the client is only offered the via-partner tunnel.
 		// Generic boolean flag: it points nowhere. The operator sets it (and the proxy URL) through its
@@ -159,9 +166,74 @@ class PDPProviderManager
 	}
 
 	/**
+	 * Complete the list of providers with the ones declared by external modules.
+	 *
+	 * An external module declares the hook context 'einvoicingproviders' in its descriptor
+	 * ($this->module_parts['hooks'] = array('einvoicingproviders');) and implements a method
+	 * addPDPProviders() into its /mymodule/class/actions_mymodule.class.php. The method fills
+	 * $this->results with entries keyed by the provider code, each one holding at least a 'class'
+	 * (a class extending AbstractPDPProvider) and a 'classpath' (directory of the class file,
+	 * relative to the Dolibarr document root).
+	 * See einvoicing/doc/ADD-A-PDP-PROVIDER.md for the complete contract.
+	 *
+	 * A hook is used rather than a scan of the module directories because it lists only the providers
+	 * of the modules that are enabled, it costs nothing when no module implements it, and it lets the
+	 * module build its own entry (position, urls, label translated in the language of the user).
+	 *
+	 * @return void
+	 */
+	private function addProvidersFromHooks()
+	{
+		require_once DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php';
+
+		// A dedicated hook manager and not the global $hookmanager: this class is also instantiated from
+		// inside hook methods (actions_einvoicing.class.php), so adding a context to the global manager
+		// would change the hooks executed by the caller afterwards.
+		$hookmanager = new HookManager($this->db);
+		$hookmanager->initHooks(array('einvoicingproviders'));
+
+		$parameters = array('providersList' => $this->providersList);
+		$object = null;
+		$action = '';
+		$hookmanager->executeHooks('addPDPProviders', $parameters, $object, $action);
+
+		if (empty($hookmanager->resArray) || !is_array($hookmanager->resArray)) {
+			return;
+		}
+
+		foreach ($hookmanager->resArray as $key => $entry) {
+			if (!is_string($key) || !is_array($entry)) {
+				continue;
+			}
+			if (isset($this->providersList[$key])) {
+				// A provider of the module is never redefined by an external module.
+				dol_syslog("A hook tried to redefine the existing PDP provider ".$key.". Entry ignored.", LOG_WARNING);
+				continue;
+			}
+			// Note: 'class' or 'classpath' is an array instead of a string when two modules declared the
+			// same provider code, because the hook manager merges the results of the hooks recursively.
+			if (empty($entry['class']) || !is_string($entry['class']) || empty($entry['classpath']) || !is_string($entry['classpath'])) {
+				dol_syslog("A hook declared the PDP provider ".$key." without a valid 'class' or 'classpath'. Entry ignored.", LOG_WARNING);
+				continue;
+			}
+
+			// Complete the entry with the defaults, so a provider declared with the 2 mandatory keys works.
+			$this->providersList[$key] = $entry + array(
+				'position' => 500,
+				'provider_countries' => array('all'),
+				'provider_name' => $key,
+				'description' => '',
+				'is_enabled' => 1,
+				'prod_account_admin_url' => null,
+				'test_account_admin_url' => null,
+			);
+		}
+	}
+
+	/**
 	 * Get all registered providers configuration.
 	 *
-	 * @return array<string,array{class:string,position:int,provider_countries:string[],provider_name:string,description:string,is_enabled:int<0,1>,prod_account_admin_url:?string,test_account_admin_url:?string}>	Provider list
+	 * @return array<string,array{class:string,classpath?:string,position:int,provider_countries:string[],provider_name:string,description:string,is_enabled:int<0,1>,prod_account_admin_url:?string,test_account_admin_url:?string}>	Provider list
 	 */
 	public function getAllProviders()
 	{
@@ -189,7 +261,11 @@ class PDPProviderManager
 			return null;
 		}
 
-		$resultinclude = dol_include_once('/einvoicing/class/providers/'.$classnametouse.'.class.php');
+		// The class of a provider brought by an external module lives in the directory of that module.
+		// The default keeps the providers of this module, declared without a 'classpath', working.
+		$classpath = $this->providersList[$name]['classpath'] ?? '/einvoicing/class/providers/';
+
+		$resultinclude = dol_include_once(rtrim($classpath, '/').'/'.$classnametouse.'.class.php');
 
 		if (!$resultinclude) {
 			dol_syslog("Failed to include provider class file for provider: ".$name, LOG_ERR);
@@ -197,6 +273,12 @@ class PDPProviderManager
 		}
 		if (!class_exists($classnametouse)) {
 			dol_syslog("Include provider class was done, but class is still not found: ".$classnametouse, LOG_ERR);
+			return null;
+		}
+		if (!is_subclass_of($classnametouse, 'AbstractPDPProvider')) {
+			// The rest of the module calls the methods of AbstractPDPProvider on this object, so a class
+			// that does not extend it would break later, far from the declaration that is at fault.
+			dol_syslog("Provider class ".$classnametouse." does not extend AbstractPDPProvider", LOG_ERR);
 			return null;
 		}
 

--- a/einvoicing/class/providers/TestPDPProvider.class.php
+++ b/einvoicing/class/providers/TestPDPProvider.class.php
@@ -1,0 +1,424 @@
+<?php
+/* Copyright (C) 2026       Pierre Grasswill            <da.grumpf@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    einvoicing/class/providers/TestPDPProvider.class.php
+ * \ingroup einvoicing
+ * \brief   Reference implementation of a PDP provider. Sends nothing, calls nothing.
+ */
+
+dol_include_once('einvoicing/class/providers/AbstractPDPProvider.class.php');
+dol_include_once('einvoicing/class/protocols/ProtocolManager.class.php');
+dol_include_once('einvoicing/class/einvoicing.class.php');
+// Needed by AbstractPDPProvider::logCall(), which records the API calls.
+dol_include_once('einvoicing/class/call.class.php');
+
+
+/**
+ * Reference implementation of a PDP provider.
+ *
+ * This class is the skeleton to copy to integrate a new platform, either here or from an external
+ * module (see einvoicing/doc/ADD-A-PDP-PROVIDER.md). It implements every method the rest of the
+ * module calls, with the smallest body that is still honest: nothing here reaches the network, and
+ * the methods that would need a platform to answer return an explicit error instead of pretending.
+ *
+ * What it does exercise for real, because it needs no platform: the configuration form of the setup
+ * page, the storage of a token, the generation of a sample invoice by the exchange protocol, and the
+ * logging of the API calls. That is enough to check that a new provider is correctly declared before
+ * writing a single line of HTTP.
+ */
+class TestPDPProvider extends AbstractPDPProvider
+{
+	/**
+	 * @var string		Name
+	 */
+	public $name = 'TestPDP';
+
+	/**
+	 * @var string		Help to get credentials and set up the provider configuration.
+	 */
+	public $helpToGetCredentials = '';
+
+
+	/**
+	 * Constructor
+	 *
+	 * Load setup properties and last token.
+	 *
+	 * @param DoliDB $db Database handler
+	 */
+	public function __construct($db)
+	{
+		parent::__construct($db);
+
+		// The keys read by AbstractPDPProvider and by the setup page. 'dol_prefix' is the important one:
+		// it is the prefix of every constant of this provider (EINVOICING_TESTPDP_API_KEY here), of the
+		// actions of the setup page (setEINVOICING_TESTPDP_TOKEN...) and of the rows storing its token.
+		$this->config = array(
+			'provider_url' => 'https://example.com',
+			'prod_auth_url' => 'https://example.com/api/v1/',
+			'prod_api_url' => 'https://example.com/api/v1/',
+			'test_auth_url' => 'https://sandbox.example.com/api/v1/',
+			'test_api_url' => 'https://sandbox.example.com/api/v1/',
+			'api_key' => getDolGlobalString('EINVOICING_TESTPDP_API_KEY'.(getDolGlobalInt('EINVOICING_LIVE') ? '_PROD' : '')),
+			'dol_prefix' => 'EINVOICING_TESTPDP',
+			'has_validator' => 0,
+			'live' => getDolGlobalInt('EINVOICING_LIVE', 0),
+		);
+
+		// Retrieve and complete the OAuth token information from the database
+		$this->tokenData = $this->fetchOAuthTokenDB();
+
+		// The protocol builds the XML (CII, Factur-X, UBL...). It is chosen by the user, not by the
+		// provider, so every provider loads it the same way.
+		$ProtocolManager = new ProtocolManager($this->db);
+		$this->exchangeProtocol = $ProtocolManager->getProtocol(getDolGlobalString('EINVOICING_PROTOCOL'));
+	}
+
+
+	/**
+	 * Set the setup factory specific to the provider.
+	 *
+	 * Called by admin/setup.php to build the second block of the setup page, the one holding the
+	 * parameters of the selected provider. Everything shown there is up to the provider.
+	 *
+	 * @param FormSetup $formSetup 			The form setup object to initialize
+	 * @param string 	$prefix 			The prefix for configuration keys ('EINVOICING_TESTPDP_' here)
+	 * @param string 	$prefixenv 			'prod' or 'test', depending on EINVOICING_LIVE
+	 * @param array 	$providersConfig 	The array containing providers configuration
+	 * @param array 	$TFieldProtocols 	The array of available protocols to set in the select field
+	 * @param array 	$TFieldProfiles 	The array of available profiles to set in the select field
+	 * @return void
+	 */
+	public function initFormSetup(&$formSetup, $prefix, $prefixenv, $providersConfig, $TFieldProtocols, $TFieldProfiles)
+	{
+		global $langs, $mysoc;
+
+		$langs->load("oauth");
+
+		$tokenData = $this->getTokenData();
+
+		// Printed above the form by admin/setup.php.
+		$url = $providersConfig[getDolGlobalString('EINVOICING_PDP')][$prefixenv.'_account_admin_url'] ?? '';
+		if ($url) {
+			$this->helpToGetCredentials = '<div class="formborderx info">';
+			$this->helpToGetCredentials .= img_picto('', 'url', 'class="pictofixedwidth"').'<a href="'.$url.'" target="_new">'.$url.'</a>';
+			$this->helpToGetCredentials .= '</div>';
+		}
+
+		// The address this company is reachable at on the platform. Left empty, the module falls back
+		// on the legal identifier of the company (idprof).
+		$item = $formSetup->newItem($prefix.'ROUTING_ID');
+		$item->nameText = $langs->transnoentities('EINVOICING_ROUTING_ID');
+		$item->helpText = $langs->transnoentities('EINVOICING_ROUTING_ID_HELP');
+		$item->fieldAttr['placeholder'] = idprof($mysoc);
+		$item->fieldParams['isMandatory'] = 0;
+		$item->cssClass = 'minwidth300';
+
+		// Credentials. The '_PROD' suffix keeps the production credentials apart from the test ones, so
+		// switching EINVOICING_LIVE does not make the module talk to a platform with the wrong keys.
+		$item = $formSetup->newItem($prefix.'API_KEY'.(getDolGlobalInt('EINVOICING_LIVE') ? '_PROD' : ''));
+		$item->nameText = $langs->transnoentities('EINVOICING_API_KEY');
+		$item->cssClass = 'minwidth500';
+
+		// Token. The link triggers the action set<prefix>TOKEN read by admin/setup.php, which calls
+		// getAccessToken() below.
+		if (!empty($this->config['api_key'])) {
+			$item = $formSetup->newItem($prefix.'TOKEN'.(getDolGlobalInt('EINVOICING_LIVE') ? '_PROD' : ''));
+			$item->nameText = $langs->trans('AccessToken');
+			$item->cssClass = 'maxwidth500';
+			$item->fieldOverride = '';
+			if (!empty($tokenData['token'])) {
+				$item->fieldOverride = htmlspecialchars('**************'.substr((string) $tokenData['token'], -4));
+				$item->fieldOverride .= ' &nbsp; '.img_picto('', 'delete', 'class="pictofixedwidth"');
+				$item->fieldOverride .= '<a href="'.$_SERVER["PHP_SELF"].'?action=delete'.$prefix.'TOKEN&token='.newToken().'">'.$langs->trans("ClickHereToRemoveConnection").'</a>';
+			} else {
+				$item->fieldOverride = '<a class="reposition" href="'.$_SERVER["PHP_SELF"].'?action=set'.$prefix.'TOKEN&token='.newToken().'">'.$langs->trans('generateAccessToken').'<i class="fa fa-key paddingleft"></i></a>';
+			}
+		}
+
+		// Actions offered once connected. Each link triggers an action read by admin/setup.php, which
+		// calls the matching method of this class.
+		if (!empty($tokenData['token'])) {
+			$item = $formSetup->newItem($prefix.'ACTIONS');
+			$item->nameText = "&nbsp;";
+			$item->cssClass = 'minwidth500';
+			$item->fieldOverride = '<a class="reposition" href="'.$_SERVER["PHP_SELF"].'?action=call'.$prefix.'HEALTHCHECK&token='.newToken().'"><i class="fa fa-heartbeat pictofixedwidth centerimp"></i>'.$langs->trans('testConnection').' (Healthcheck)</a><br>';
+			if (getDolGlobalString('EINVOICING_PROTOCOL') && getDolGlobalInt('EINVOICING_ALLOW_DEVTOOLS') && !getDolGlobalString('EINVOICING_LIVE')) {
+				$item->fieldOverride .= '<a class="reposition" href="'.$_SERVER["PHP_SELF"].'?action=make'.$prefix.'sampleinvoice&token='.newToken().'"><i class="fa fa-file pictofixedwidth centerimp"></i>'.$langs->trans('generateSampleInvoice').'</a><br>';
+			}
+		}
+	}
+
+
+	/**
+	 * Validate configuration parameters before API calls.
+	 *
+	 * @param 	int		$mode 	0 check that credentials are set, 1 check that token is set
+	 * @return 	bool 			True if configuration is valid.
+	 */
+	public function validateConfiguration($mode = 1)
+	{
+		global $langs;
+
+		if (empty($this->config['api_key'])) {
+			$this->errors[] = $langs->trans('ErrorFieldRequired', $langs->transnoentities('EINVOICING_API_KEY'));
+			return false;
+		}
+
+		if ($mode == 1 && empty($this->tokenData['token'])) {
+			$this->errors[] = $langs->trans('FailedToRetrieveAccessToken');
+			return false;
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Get access token from the platform and save it into database.
+	 *
+	 * A real provider posts its credentials to the auth endpoint here. This one derives a token from
+	 * the API key, so the storage and the expiration handling can be exercised without a platform.
+	 *
+	 * @return string|null 		Access token or null on failure.
+	 */
+	public function getAccessToken()
+	{
+		if (!$this->validateConfiguration(0)) {
+			return null;
+		}
+
+		$token = 'testpdp-'.dol_hash($this->config['api_key'].'-'.dol_now(), '5');
+		$expiresIn = 3600;
+
+		if (!$this->saveOAuthTokenDB($token, null, $expiresIn)) {
+			return null;
+		}
+
+		$this->tokenData = $this->fetchOAuthTokenDB();
+
+		return $token;
+	}
+
+
+	/**
+	 * Refresh access token.
+	 *
+	 * @return string|null 		New access token or null on failure.
+	 */
+	public function refreshAccessToken()
+	{
+		// No refresh token on this provider: a new token is simply asked for.
+		return $this->getAccessToken();
+	}
+
+
+	/**
+	 * Perform a health check call for the provider endpoint.
+	 *
+	 * @return array{status_code:int,message:string}	Result of the check
+	 */
+	public function checkHealth()
+	{
+		global $langs;
+
+		// A real provider calls its own endpoint here, for example:
+		// $response = $this->callApi('healthcheck', 'GET', false, array(), 'healthcheck');
+		// and maps the HTTP code it gets to the array returned below.
+		return array(
+			'status_code' => 200,
+			'message' => $langs->trans('APApiReachable', $this->name).' ('.$this->getApiUrl('api').')',
+		);
+	}
+
+
+	/**
+	 * Call the provider API.
+	 *
+	 * This is the single place where a provider talks to its platform: every other method goes through
+	 * it, which is what makes the call log of the module complete. A real implementation builds the
+	 * request with getURLContent() (or curl), then calls logCall() with the response.
+	 *
+	 * @param string 						$resource 	    Resource relative URL
+	 * @param 'POST'|'GET'|'HEAD'|'PUT'|'PUTALREADYFORMATED'|'POSTALREADYFORMATED'|'DELETE' $method	HTTP method
+	 * @param string|false 					$options 	    Options for the request (JSON encoded)
+	 * @param array<string, string>			$extraHeaders   Optional additional headers
+	 * @param string|null					$callType       Functional type of the API call for logging purposes
+	 * @return array{status_code:int,response:null|string|array<string,mixed>,call_id:null|string}
+	 */
+	public function callApi($resource, $method, $options = false, $extraHeaders = [], $callType = '')
+	{
+		$statusCode = 501;
+		$response = array('error' => 'This sample provider performs no API call');
+
+		// Record the call, so it shows up in the "API calls" list of the module. The log is written on
+		// its own database connection, so it survives a rollback of the business transaction.
+		$logres = $this->logCall($callType, $resource, $method, $options, $response, $statusCode);
+
+		return array('status_code' => $statusCode, 'response' => $response, 'call_id' => $logres['call_id'] ?? null);
+	}
+
+
+	/**
+	 * Send an electronic invoice.
+	 *
+	 * @param  Facture $object 	Invoice object
+	 * @return string|false		Flow id given by the platform, false on failure.
+	 */
+	public function sendInvoice($object)
+	{
+		global $langs;
+
+		// A real implementation: build the file with $this->exchangeProtocol, check the recipient with
+		// $this->checkRecipientDirectory(), POST it with $this->callApi(), then return the id the
+		// platform answers with. That id is stored on the document and every status message refers to it.
+		$this->errors[] = $langs->trans('FeatureNotYetAvailable').' - '.$this->name.'::sendInvoice';
+
+		return false;
+	}
+
+
+	/**
+	 * Send status message of an invoice to the platform (lifecycle of the e-invoice).
+	 *
+	 * @param mixed		$object			Invoice object (CustomerInvoice or SupplierInvoice)
+	 * @param int		$statusCode		Status code to send
+	 * @param string	$reasonCode		Reason code to send (optional)
+	 * @param array{amount?:float,breakdown?:array<array{vatrate:float,amount:float}>} $paymentData Cashed amount for status 212
+	 * @return array{res:int, message:string}	'res' 1 on success, -1 on failure
+	 */
+	public function sendStatusMessage($object, $statusCode, $reasonCode = '', $paymentData = array())
+	{
+		global $langs;
+
+		// A real implementation builds a CDAR with CdarHandler and posts it with $this->callApi().
+		return array('res' => -1, 'message' => $langs->trans('FeatureNotYetAvailable').' - '.$this->name.'::sendStatusMessage');
+	}
+
+
+	/**
+	 * Send a sample electronic invoice for testing purposes.
+	 *
+	 * The generation itself belongs to the exchange protocol, not to the provider, so this part is
+	 * identical for every provider and is worth keeping as is when copying this class.
+	 *
+	 * @param 	int 			$onlymake		1=to only make the sample
+	 * @return 	array|int						Array of messages, 0 on failure.
+	 */
+	public function sendSampleInvoice($onlymake = 0)
+	{
+		global $langs;
+
+		$outputLog = array();
+
+		$einvoicing = new EInvoicing($this->db);
+
+		try {
+			if ((float) DOL_VERSION < 24.0) {
+				$resarray = $this->exchangeProtocol->generateSampleInvoiceOld($einvoicing);
+			} else {
+				$resarray = $this->exchangeProtocol->generateSampleInvoice($einvoicing);
+			}
+			if ($resarray === -1) {
+				$this->errors[] = $this->exchangeProtocol->error;
+				return 0;
+			}
+			$invoice_path = (string) $resarray['path'];
+			$ref = $resarray['ref'];
+		} catch (Exception $e) {
+			$this->errors[] = $e->getMessage();
+			return 0;
+		}
+
+		if (empty($ref) || empty($invoice_path)) {
+			$this->errors[] = 'Failed to generate the sample invoice';
+			return 0;
+		}
+
+		$outputLog[] = "Sample invoice generated successfully: ".$invoice_path;
+
+		if ($onlymake) {
+			return $outputLog;
+		}
+
+		// A real implementation posts the generated file here, like sendInvoice() does.
+		$this->errors[] = $langs->trans('FeatureNotYetAvailable').' - '.$this->name.'::sendSampleInvoice';
+
+		return 0;
+	}
+
+
+	/**
+	 * Validate an electronic invoice file using the provider's validation service.
+	 *
+	 * Only called when the provider declares 'has_validator' => 1 in its config.
+	 *
+	 * @param 	int 	$idinvoice 	ID of the invoice to check
+	 * @param 	string 	$filePath 	Path to the invoice file to validate
+	 * @return 	array{res:int,message:string}	Validation result
+	 */
+	public function validateEInvoiceFile($idinvoice, $filePath)
+	{
+		global $langs;
+
+		return array('res' => -1, 'message' => $langs->trans('NoAvailableValidatorforThisAccessPoint'));
+	}
+
+
+	/**
+	 * Synchronize flows with the platform: the incoming documents (supplier invoices, status messages)
+	 * and the status of the ones already sent. Called by the cron job of the module.
+	 *
+	 * @param   int   $syncFromDate     Timestamp from which to start synchronization. 0 = from epoch.
+	 * @param   int   $limit            Maximum number of flows to synchronize. 0 means no limit.
+	 * @return 	array{res:int, messages:string[], totalFlows?:?int, alreadyExist?:int, syncedFlows?:int}
+	 */
+	public function syncFlows($syncFromDate = 0, $limit = 0)
+	{
+		// A real implementation asks the platform for the flows changed since $syncFromDate, then hands
+		// each one to syncFlow() below. Call clearIncomingDiagnosticFiles() first, so the diagnostic
+		// shown in the document list is the one of this run.
+		return array(
+			'res' => 1,
+			'messages' => array('This sample provider has no platform to synchronize with'),
+			'totalFlows' => 0,
+			'alreadyExist' => 0,
+			'syncedFlows' => 0,
+		);
+	}
+
+
+	/**
+	 * Synchronize one flow: download it, and either create the supplier invoice it carries or update
+	 * the status of the invoice it refers to.
+	 *
+	 * @param string		$flowId		Flow id on the platform
+	 * @param string|null	$call_id	Call ID for logging purposes
+	 * @return array{res:int, message:string, action:string|null}	'res' 1 on success, 0 if already known, -1 on failure
+	 */
+	public function syncFlow($flowId, $call_id = null)
+	{
+		global $langs;
+
+		return array(
+			'res' => -1,
+			'message' => $langs->trans('FeatureNotYetAvailable').' - '.$this->name.'::syncFlow',
+			'action' => null,
+		);
+	}
+}

--- a/einvoicing/doc/ADD-A-PDP-PROVIDER.md
+++ b/einvoicing/doc/ADD-A-PDP-PROVIDER.md
@@ -1,0 +1,184 @@
+# Add a PDP / Access Point provider from an external module
+
+The module ships with the providers it knows about (Esalink, SuperPDP...). Any other module can add
+its own without patching this one: it declares it through a hook, and ships a class extending
+`AbstractPDPProvider`.
+
+Everything else comes for free: the setup page of the module builds the configuration screen of the
+provider from the provider itself, the tokens are stored and refreshed by the base class, the API
+calls are logged in the "API calls" list, and the invoices, the status messages and the cron
+synchronization go through the provider exactly like for a native one.
+
+Reference implementation to copy: `einvoicing/class/providers/TestPDPProvider.class.php`. It is the
+`TESTPDP` entry of the provider list, offered in the setup page when the developer tools of the
+module are enabled (`EINVOICING_ALLOW_DEVTOOLS`). It calls nothing over the network, so it can be
+selected and clicked through to check a new integration is correctly wired before writing any HTTP.
+
+## 1. Declare the provider (hook)
+
+In the descriptor of your module (`core/modules/modMyModule.class.php`):
+
+```php
+$this->module_parts = array(
+    'hooks' => array('einvoicingproviders'),
+);
+```
+
+In `class/actions_mymodule.class.php`:
+
+```php
+/**
+ * Declare the PDP providers brought by this module.
+ *
+ * @param  array         $parameters   Parameters, holds 'providersList' (the providers already declared)
+ * @param  object|null   $object       Not used here
+ * @param  string        $action       Current action
+ * @param  HookManager   $hookmanager  Hook manager
+ * @return int                         0 to let the other hooks run
+ */
+public function addPDPProviders($parameters, &$object, &$action, $hookmanager)
+{
+    global $langs;
+
+    $this->results = array(
+        'MYPDP' => array(
+            'class'                  => 'MyPDPProvider',              // mandatory, extends AbstractPDPProvider
+            'classpath'              => '/mymodule/class/providers/',  // mandatory, relative to the Dolibarr root
+            'position'               => 50,
+            'provider_countries'     => array('FR'),
+            'provider_name'          => 'My PDP',                      // label shown in the provider selector
+            'description'            => 'My PDP Integration',
+            'is_enabled'             => 1,
+            'prod_account_admin_url' => 'https://mypdp.example.com/signup',
+            'test_account_admin_url' => 'https://sandbox.mypdp.example.com/signup',
+        ),
+    );
+
+    return 0;
+}
+```
+
+Only `class` and `classpath` are mandatory; the other keys fall back to a working default
+(`position` 500, `provider_countries` `array('all')`, `provider_name` the code of the provider,
+`is_enabled` 1, no account url).
+
+Rules:
+
+- the key of the entry (`MYPDP` here) is the code stored in `EINVOICING_PDP`. Pick something
+  unlikely to collide, it is global to the Dolibarr installation;
+- an entry whose key is already taken by a provider of the module is **ignored** (a warning is
+  written in the log). A module never redefines a native provider;
+- the provider only shows up while your module is enabled. If the user disables it while it was the
+  selected provider, the setup page says so and offers the other providers;
+- the hook runs on every instantiation of `PDPProviderManager`, including in the cron job. Keep it to
+  building the array: no query, no API call.
+
+## 2. Write the provider class
+
+`/mymodule/class/providers/MyPDPProvider.class.php`:
+
+```php
+dol_include_once('einvoicing/class/providers/AbstractPDPProvider.class.php');
+dol_include_once('einvoicing/class/protocols/ProtocolManager.class.php');
+dol_include_once('einvoicing/class/call.class.php');   // needed by logCall()
+
+class MyPDPProvider extends AbstractPDPProvider
+{
+    public $name = 'MyPDP';
+
+    public function __construct($db)
+    {
+        parent::__construct($db);
+
+        $this->config = array(
+            'provider_url'   => 'https://mypdp.example.com',
+            'prod_auth_url'  => 'https://api.mypdp.example.com/v1/',
+            'prod_api_url'   => 'https://api.mypdp.example.com/v1/',
+            'test_auth_url'  => 'https://sandbox.mypdp.example.com/v1/',
+            'test_api_url'   => 'https://sandbox.mypdp.example.com/v1/',
+            'dol_prefix'     => 'EINVOICING_MYPDP',
+            'has_validator'  => 0,
+            'live'           => getDolGlobalInt('EINVOICING_LIVE', 0),
+        );
+
+        $this->tokenData = $this->fetchOAuthTokenDB();
+
+        $ProtocolManager = new ProtocolManager($this->db);
+        $this->exchangeProtocol = $ProtocolManager->getProtocol(getDolGlobalString('EINVOICING_PROTOCOL'));
+    }
+
+    // ... the methods below
+}
+```
+
+The class **must** extend `AbstractPDPProvider`: a class that does not is refused by
+`PDPProviderManager::getProvider()`, with a line in the log, rather than failing later on a missing
+method.
+
+### `dol_prefix`, the only naming convention to respect
+
+`$this->config['dol_prefix']` is the prefix of everything belonging to your provider:
+
+- its constants: `EINVOICING_MYPDP_API_KEY`, `EINVOICING_MYPDP_USERNAME`, `EINVOICING_MYPDP_ROUTING_ID`...
+- the actions of the setup page: `setEINVOICING_MYPDP_TOKEN`, `callEINVOICING_MYPDP_HEALTHCHECK`,
+  `deleteEINVOICING_MYPDP_TOKEN`, `makeEINVOICING_MYPDP_sampleinvoice`;
+- the OAuth token rows stored by `saveOAuthTokenDB()` / read by `fetchOAuthTokenDB()`.
+
+Suffix the credentials with `_PROD` for the production ones (`EINVOICING_MYPDP_API_KEY_PROD`), as the
+native providers do: `EINVOICING_LIVE` then switches the whole set at once, and the sandbox keys are
+never sent to the production platform.
+
+### Methods to implement
+
+Abstract, so the class does not load without them:
+
+| Method | Returns | Called by |
+| --- | --- | --- |
+| `validateConfiguration($mode = 1)` | `bool` — `$mode` 0: credentials are set, 1: a token is set | before the API calls |
+| `getAccessToken()` | `string|null` — new token, saved with `saveOAuthTokenDB()` | setup page, and on an expired token |
+| `refreshAccessToken()` | `string|null` | when `isTokenExpired()` is true |
+| `checkHealth()` | `array{status_code:int,message:string}` | "Test connection" of the setup page |
+| `callApi($resource, $method, $options, $extraHeaders, $callType)` | `array{status_code:int,response:mixed,call_id:?string}` | every other method of your class |
+| `sendInvoice($object)` | flow id given by the platform, `false` on failure | validation/transmission of a customer invoice |
+| `sendStatusMessage($object, $statusCode, $reasonCode, $paymentData)` | `array{res:int,message:string}` | lifecycle of the e-invoice (received, rejected, cashed...) |
+| `sendSampleInvoice($onlymake = 0)` | array of messages, `0` on failure | setup page |
+| `validateEInvoiceFile($idinvoice, $filePath)` | `array{res:int,message:string}` | only when `has_validator` is 1 |
+| `syncFlows($syncFromDate = 0, $limit = 0)` | `array{res:int,messages:string[],...}` | cron job and "Synchronize" button |
+| `syncFlow($flowId, $call_id = null)` | `array{res:int,message:string,action:?string}` | one flow of the synchronization |
+
+Not abstract but required in practice:
+
+- `initFormSetup(&$formSetup, $prefix, $prefixenv, $providersConfig, $TFieldProtocols, $TFieldProfiles)`
+  builds the configuration block of your provider in the setup page (credentials, token, actions).
+  Without it the page shows nothing to configure. `$prefix` is your `dol_prefix` followed by `_`, and
+  `$prefixenv` is `prod` or `test`;
+- `deleteAccessToken()` if you display the "remove the connection" link.
+
+### What the base class already does for you
+
+- `getApiUrl($mode)` returns the production or sandbox URL of your config depending on
+  `EINVOICING_LIVE` — `$mode` being `auth`, `api`, `ap_api` or `afnor_directory`;
+- `saveOAuthTokenDB()` / `fetchOAuthTokenDB()` / `deleteOAuthTokenDB()` / `isTokenExpired()` store and
+  read the tokens of your provider;
+- `logCall()` records an API call in `llx_einvoicing_call`, on an independent database connection so
+  the trace survives a rollback, and redacts the secrets. Call it from your `callApi()` and the whole
+  module gets a complete call log;
+- `checkRecipientDirectory($idprof1)` pre-checks that a recipient is reachable, through the AFNOR
+  directory service (XP Z12-013) when your config declares `prod_afnor_directory_url` /
+  `test_afnor_directory_url`;
+- `fetchFlowData()`, `fetchFlowXml()`, `resolveFlowProfile()`, `addEvent()`, `generateUuidV4()`,
+  `getLastSyncDate()`.
+
+The XML itself is **not** the business of the provider: it is built by the exchange protocol chosen by
+the user (CII, Factur-X, UBL), loaded in the constructor above. A provider transports a file, it does
+not produce it.
+
+## 3. Check the integration
+
+1. enable your module, then go to `Setup > Modules > E-invoicing`: your provider is in the list;
+2. select it: the block built by your `initFormSetup()` appears;
+3. enter the credentials, generate the token, run the health check;
+4. enable the developer tools of the module (`EINVOICING_ALLOW_DEVTOOLS`) to get the "generate a
+   sample invoice" action, which exercises the generation without sending anything;
+5. then a real invoice: validate it, transmit it, and follow the "API calls" list of the module,
+   which shows every call your `callApi()` logged.

--- a/einvoicing/test/phpunit/AllTests.php
+++ b/einvoicing/test/phpunit/AllTests.php
@@ -110,6 +110,8 @@ class AllTests
 		$suite->addTestSuite('CIIProtocolTest');
 		require_once dirname(__FILE__).'/EInvoicingSamplesTest.php';
 		$suite->addTestSuite('EInvoicingSamplesTest');
+		require_once dirname(__FILE__).'/PDPProviderManagerTest.php';
+		$suite->addTestSuite('PDPProviderManagerTest');
 		require_once dirname(__FILE__).'/RecipientDirectoryTest.php';
 		$suite->addTestSuite('RecipientDirectoryTest');
 		require_once dirname(__FILE__).'/SupplierInvoiceHelperTest.php';

--- a/einvoicing/test/phpunit/PDPProviderManagerTest.php
+++ b/einvoicing/test/phpunit/PDPProviderManagerTest.php
@@ -1,0 +1,221 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/
+ */
+
+/**
+ *      \file       test/phpunit/PDPProviderManagerTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for PDPProviderManager::getProvider(): loading a provider whose class
+ *                  lives in another module (the 'classpath' key that lets an external module bring its
+ *                  own provider), the refusal of a class that does not extend AbstractPDPProvider, and
+ *                  the paths that must keep returning null.
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+// See RecipientDirectoryTest for why DOLIBARR_HTDOCS is honoured here.
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+dol_include_once('einvoicing/class/providers/AbstractPDPProvider.class.php');
+dol_include_once('einvoicing/class/providers/PDPProviderManager.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+if (empty($user->id)) {
+	print "Load permissions for admin user nb 1\n";
+	$user->fetch(1);
+	// User::loadRights() only exists from Dolibarr 19 on, older versions name it getrights()
+	if (method_exists($user, 'loadRights')) {
+		$user->loadRights();
+	} else {
+		$user->getrights();
+	}
+}
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class PDPProviderManagerTest extends CommonClassTest
+{
+	/**
+	 * Declare a provider in the list of a manager, the way the hook of an external module does.
+	 *
+	 * The list is private, and its filling by the hook needs a third-party module installed, so the
+	 * entry is written directly: what is under test is getProvider(), which only sees the entry.
+	 *
+	 * @param	PDPProviderManager				$manager	Manager to complete
+	 * @param	string							$code		Code of the provider
+	 * @param	array<string,int|string|array>	$entry		Entry of the provider
+	 * @return	void
+	 */
+	private function declareProvider($manager, $code, $entry)
+	{
+		$property = new ReflectionProperty('PDPProviderManager', 'providersList');
+		$property->setAccessible(true);
+
+		$list = $property->getValue($manager);
+		$list[$code] = $entry;
+		$property->setValue($manager, $list);
+	}
+
+	/**
+	 * A provider of the module itself declares no 'classpath': it must keep being loaded from
+	 * einvoicing/class/providers/.
+	 *
+	 * The entry is declared here rather than taken from the list of the instance under test, whose
+	 * native entries can all be disabled by the setup (EINVOICING_SUPERPDP_VIAPARTNER_ONLY).
+	 *
+	 * @return void
+	 */
+	public function testNativeProviderIsLoadedWithoutClasspath()
+	{
+		global $db;
+
+		$manager = new PDPProviderManager($db);
+		$this->declareProvider($manager, 'NOCLASSPATHPDP', array(
+			'class' => 'TestPDPProvider',
+			'is_enabled' => 1,
+		));
+
+		$provider = $manager->getProvider('NOCLASSPATHPDP');
+
+		$this->assertInstanceOf('TestPDPProvider', $provider);
+		// The code of the entry is handed back to the provider: several entries may share a class.
+		$this->assertSame('NOCLASSPATHPDP', $provider->providerName);
+	}
+
+	/**
+	 * A provider declared with a 'classpath' is loaded from that directory, which is what lets an
+	 * external module ship its provider class in its own module directory.
+	 *
+	 * @return void
+	 */
+	public function testProviderIsLoadedFromItsDeclaredClasspath()
+	{
+		global $db;
+
+		$manager = new PDPProviderManager($db);
+		$this->declareProvider($manager, 'EXTERNALDIRPDP', array(
+			'class' => 'ExternalDirPDPProvider',
+			'classpath' => '/einvoicing/test/phpunit/fixtures/',
+			'position' => 500,
+			'provider_countries' => array('all'),
+			'provider_name' => 'External dir PDP',
+			'description' => 'Provider whose class file is outside einvoicing/class/providers/',
+			'is_enabled' => 1,
+			'prod_account_admin_url' => null,
+			'test_account_admin_url' => null,
+		));
+
+		$provider = $manager->getProvider('EXTERNALDIRPDP');
+
+		$this->assertInstanceOf('ExternalDirPDPProvider', $provider);
+		$this->assertInstanceOf('AbstractPDPProvider', $provider);
+		$this->assertSame('EXTERNALDIRPDP', $provider->providerName);
+	}
+
+	/**
+	 * A trailing slash on the classpath is optional: both spellings must find the class file.
+	 *
+	 * @return void
+	 */
+	public function testClasspathWithoutTrailingSlashIsAccepted()
+	{
+		global $db;
+
+		$manager = new PDPProviderManager($db);
+		$this->declareProvider($manager, 'EXTERNALDIRPDP2', array(
+			'class' => 'ExternalDirPDPProvider',
+			'classpath' => '/einvoicing/test/phpunit/fixtures',
+			'is_enabled' => 1,
+		));
+
+		$this->assertInstanceOf('ExternalDirPDPProvider', $manager->getProvider('EXTERNALDIRPDP2'));
+	}
+
+	/**
+	 * The rest of the module calls the methods of AbstractPDPProvider on whatever getProvider() hands
+	 * back. A class that does not extend it is refused here, instead of failing later on a missing
+	 * method, far from the declaration that is at fault.
+	 *
+	 * @return void
+	 */
+	public function testClassNotExtendingAbstractProviderIsRefused()
+	{
+		global $db;
+
+		$manager = new PDPProviderManager($db);
+		// An existing class, loadable from an existing file, but not a provider.
+		$this->declareProvider($manager, 'NOTAPROVIDER', array(
+			'class' => 'EInvoicing',
+			'classpath' => '/einvoicing/class/',
+			'is_enabled' => 1,
+		));
+
+		$this->assertNull($manager->getProvider('NOTAPROVIDER'));
+	}
+
+	/**
+	 * A class file that does not exist must be reported as an unusable provider, not fatal.
+	 *
+	 * @return void
+	 */
+	public function testMissingClassFileReturnsNull()
+	{
+		global $db;
+
+		$manager = new PDPProviderManager($db);
+		$this->declareProvider($manager, 'GHOSTPDP', array(
+			'class' => 'GhostPDPProvider',
+			'classpath' => '/einvoicing/class/providers/',
+			'is_enabled' => 1,
+		));
+
+		$this->assertNull($manager->getProvider('GHOSTPDP'));
+	}
+
+	/**
+	 * A disabled provider, and a provider that was never declared, are not instantiable.
+	 *
+	 * @return void
+	 */
+	public function testDisabledOrUnknownProviderReturnsNull()
+	{
+		global $db;
+
+		$manager = new PDPProviderManager($db);
+		$this->declareProvider($manager, 'DISABLEDPDP', array(
+			'class' => 'TestPDPProvider',
+			'is_enabled' => 0,
+		));
+
+		$this->assertNull($manager->getProvider('DISABLEDPDP'));
+		$this->assertNull($manager->getProvider('THISPDPDOESNOTEXIST'));
+	}
+}

--- a/einvoicing/test/phpunit/fixtures/ExternalDirPDPProvider.class.php
+++ b/einvoicing/test/phpunit/fixtures/ExternalDirPDPProvider.class.php
@@ -1,0 +1,39 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/
+ */
+
+/**
+ *      \file       test/phpunit/fixtures/ExternalDirPDPProvider.class.php
+ *      \ingroup    test
+ *      \brief      Provider class living outside einvoicing/class/providers/, standing for the class
+ *                  an external module ships in its own directory. Only used by
+ *                  PDPProviderManagerTest to check the 'classpath' of a declared provider is really
+ *                  the directory the class is loaded from.
+ */
+
+dol_include_once('einvoicing/class/providers/TestPDPProvider.class.php');
+
+/**
+ * A provider brought by "another module". It inherits everything from the sample provider: what is
+ * tested here is where the class file is loaded from, not what the provider does.
+ */
+class ExternalDirPDPProvider extends TestPDPProvider
+{
+	/**
+	 * @var string		Name
+	 */
+	public $name = 'ExternalDirPDP';
+}


### PR DESCRIPTION
Closes #448. Implements the design validated by @atm-maxime in the issue.

## What prevented it

Two things, both in `PDPProviderManager`:

1. `$this->providersList` is a literal array in the constructor;
2. `getProvider()` includes the class from a hardcoded `/einvoicing/class/providers/`, so a class living in `/mymodule/class/providers/` could never be loaded.

Everything else was already provider-agnostic: `admin/setup.php` delegates the whole configuration screen to `$provider->initFormSetup()`, and `getConf()['dol_prefix']` drives the constants, the `set…TOKEN` / `call…HEALTHCHECK` actions, the OAuth token storage and the call logging.

## Registration through a hook

A module declares the context in its descriptor:

```php
$this->module_parts = array('hooks' => array('einvoicingproviders'));
```

and returns its entries from `addPDPProviders()` in `class/actions_mymodule.class.php`:

```php
$this->results = array(
    'MYPDP' => array(
        'class'     => 'MyPDPProvider',              // extends AbstractPDPProvider
        'classpath' => '/mymodule/class/providers/', // relative to the Dolibarr root
        'position'  => 50,
        'provider_name' => 'My PDP',
        // ... the other keys of a native entry, all optional
    ),
);
```

A hook rather than a scan of the module directories: `PDPProviderManager` is instantiated on many pages and on every cron pass, a `dol_dir_list()` across the module directories on each `new` is a real cost, a scan cannot tell whether the owning module is enabled, and it gives no control point over `position` / `is_enabled`.

Rules enforced:

- only `class` and `classpath` are mandatory, the other keys fall back to a working default;
- an entry whose code is already taken by a native provider is **ignored** (warning in the log): a module never redefines a native one;
- a class that does not extend `AbstractPDPProvider` is refused when it is loaded, rather than failing later on a missing method;
- the merge happens before the `EINVOICING_SUPERPDP_VIAPARTNER_ONLY` filter, so that flag keeps meaning "one single tunnel offered".

The hook manager used is a dedicated instance, not the global `$hookmanager`: this class is also instantiated from inside hook methods (`actions_einvoicing.class.php`), and adding a context to the global manager there would change the hooks the caller runs afterwards.

## Reference implementation

The `TESTPDP` entry pointed to a `TestPDPProvider` class that does not exist in the repository. It becomes the documented skeleton: every method of the contract, nothing over the network, so a new integration can be clicked through before a line of HTTP is written. It is offered only when the developer tools are enabled (`EINVOICING_ALLOW_DEVTOOLS`).

`einvoicing/doc/ADD-A-PDP-PROVIDER.md` documents the contract: the abstract methods and what they must return, `initFormSetup()`, the `dol_prefix` convention, and what `AbstractPDPProvider` already provides.

## Split out

The crash of `admin/setup.php` when the selected provider cannot be instantiated - the case of a module
that gets disabled after its provider was selected - was moved to its own pull request, #535: it is a
hole that exists on main today, independently of this feature, and one subject per pull request. This
branch no longer touches `admin/setup.php`.

## Tested

On the sandbox (devbrasserie), Dolibarr 18.0.10 / 20.0.5 / 23.0.3 / 24.0.0-beta sharing the deployed tree:

- **PHPUnit, file by file, on the 4 cores**: green, including the new `PDPProviderManagerTest` (6 tests). `EInvoicingSamplesTest` keeps its 3 known failures on 18/20/24 (fixture pinned to a core-23 rounding), untouched by this patch.
- **A real throwaway external module** installed on the 23 instance: its provider shows up in the list at its position, is loaded from its own directory and instantiated with its own `dol_prefix`; an entry trying to redefine `SUPERPDP` is ignored; an entry without `class`/`classpath` is ignored; disabling the module makes the setup page report it instead of dying (with #535 applied, which is where that guard now lives).
- **The sample provider end to end**: token generated and stored, health check, API call logged in the call list, sample invoice really generated, error paths returning what they claim.
- **Export**: `sendSampleInvoice(1)` on CII EN16931/EXTENDED on the 4 cores, and FACTURX EN16931/EXTENDED/MINIMUM/BASIC.
- **E2E on a brand new invoice**, sandbox platform, both databases: emission (invoice created, validated, generated, transmitted, flow `i_191150`), reception on the other instance as a supplier invoice with the right vendor and amount, lifecycle 205 sent back, and the status read on the emitting side **from another process** (200, 201, then 205).

Open question left from the issue: the hook name `einvoicingproviders` / method `addPDPProviders` - happy to rename before merge.