### PR TITLE
[einvoicing] FIX: the setup page dies when the selected Access point is not available anymore

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -2,6 +2,15 @@
 
 ## 1.0.4
 
+FIX: The setup page no longer dies on a fatal error when the selected Access point cannot be
+instantiated - the case of a provider disabled after being selected, "SuperPDP via partner only" being
+the way it happens today, since that option disables every other entry including the one already
+recorded in EINVOICING_PDP. The page read the configuration of a provider it did not have, so it
+answered nothing at all and the setup could no longer be reached to select another one. It now says
+which Access point is unavailable and offers the ones that remain. The actions of the provider block
+(token, health check, sample invoice) are skipped in that state instead of being matched on an empty
+prefix.
+
 FIX: A synchronization no longer raises a PHP warning for every flow whose source invoice is not in
 this database. Such a flow is the ordinary case on a platform account shared with another system -
 the customer invoice behind it simply lives somewhere else - and syncFlow() notes it in a message

--- a/einvoicing/admin/setup.php
+++ b/einvoicing/admin/setup.php
@@ -149,11 +149,18 @@ if (getDolGlobalString('EINVOICING_PDP')) {
 	// Generate a $provider (this call the constructor that load the token with fetchOAuthTokenDB() and save it in the memory var $provider->tokenData)
 	// Note: Token may have been expired
 	$provider = $PDPManager->getProvider(getDolGlobalString('EINVOICING_PDP'));
-	// Now we load the conf
 
-	$providerconfig  = $provider->getConf();
+	if ($provider instanceof AbstractPDPProvider) {
+		// Now we load the conf
+		$providerconfig  = $provider->getConf();
 
-	$prefix = $providerconfig['dol_prefix'].'_';
+		$prefix = $providerconfig['dol_prefix'].'_';
+	} else {
+		// The selected provider is not available anymore: the module that brought it has been disabled,
+		// or its entry has been removed. Without this the page ends on a fatal error and the setup can
+		// no longer be reached to select another provider.
+		setEventMessages($langs->trans("SelectedAccessPointNotAvailable", getDolGlobalString('EINVOICING_PDP')), null, 'warnings');
+	}
 }
 
 // Return of the OAuth 2.1 Authorization Code flow (?code&state). Handled here, BEFORE the form is
@@ -236,7 +243,7 @@ if ($action == 'update' && GETPOSTISSET('EINVOICING_PDP') && GETPOST('EINVOICING
 }
 
 // Action to get/generate a token
-if (preg_match('/set'.$prefix.'TOKEN/i', $action, $reg)) {
+if ($prefix && preg_match('/set'.$prefix.'TOKEN/i', $action, $reg)) {
 	$token = $provider->getAccessToken();	// Get access token from provider and save it into database
 
 	if ($token) {
@@ -249,7 +256,7 @@ if (preg_match('/set'.$prefix.'TOKEN/i', $action, $reg)) {
 }
 
 // Action healthcheck
-if (preg_match('/call'.$prefix.'HEALTHCHECK/i', $action, $reg)) {
+if ($prefix && preg_match('/call'.$prefix.'HEALTHCHECK/i', $action, $reg)) {
 	$statusPDP = $provider->checkHealth();
 	if ($statusPDP['status_code'] == 200) {
 		setEventMessages($statusPDP['message'], null, 'mesgs');
@@ -259,7 +266,7 @@ if (preg_match('/call'.$prefix.'HEALTHCHECK/i', $action, $reg)) {
 }
 
 // Generate a sample invoice and try to send it
-if (preg_match('/make'.$prefix.'sampleinvoice/i', $action, $reg)) {
+if ($prefix && preg_match('/make'.$prefix.'sampleinvoice/i', $action, $reg)) {
 	$result = $provider->sendSampleInvoice(1);
 	if ($result) {
 		setEventMessages('', $result, 'mesgs');
@@ -267,7 +274,7 @@ if (preg_match('/make'.$prefix.'sampleinvoice/i', $action, $reg)) {
 		setEventMessages($provider->error, $provider->errors, 'errors');
 	}
 }
-if (preg_match('/makesend'.$prefix.'sampleinvoice/i', $action, $reg)) {
+if ($prefix && preg_match('/makesend'.$prefix.'sampleinvoice/i', $action, $reg)) {
 	$result = $provider->sendSampleInvoice(0);
 	if ($result) {
 		setEventMessages('', $result, 'mesgs');
@@ -276,7 +283,7 @@ if (preg_match('/makesend'.$prefix.'sampleinvoice/i', $action, $reg)) {
 	}
 }
 
-if (preg_match('/delete'.$prefix.'TOKEN/i', $action, $reg)) {
+if ($prefix && preg_match('/delete'.$prefix.'TOKEN/i', $action, $reg)) {
 	// Delete token
 	$result = $provider->deleteAccessToken();
 
@@ -289,7 +296,7 @@ if (preg_match('/delete'.$prefix.'TOKEN/i', $action, $reg)) {
 	}
 }
 
-if (getDolGlobalString('EINVOICING_PDP')) {
+if (getDolGlobalString('EINVOICING_PDP') && $provider instanceof AbstractPDPProvider) {
 	// Link to get the Credentials
 	$prefixenv = getDolGlobalString('EINVOICING_LIVE') ? 'prod' : 'test';
 

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -57,6 +57,7 @@ CheckPdpConfiguration=Please verify the Access Point provider configuration.
 FailedToRetrieveAccessToken=Failed to obtain access token from the Access Point provider.
 APApiReachable=Connection successful: The Access point %s is reachable.
 APApiNotReachable=Connection failed: The Access point %s is not reachable.
+SelectedAccessPointNotAvailable=The selected Access point (%s) is not available anymore. The module that provides it may have been disabled. Select another Access point.
 EINVOICING_PROTOCOL=Select the exchange protocol (for generating and sending invoices)
 EINVOICING_PROTOCOL_HELP=Available protocols are listed here.
 generateSampleInvoice=Generate a sample invoice


### PR DESCRIPTION
`admin/setup.php` uses the selected provider right after asking the manager for it, without looking at
what it got back (lines 148-157 of main):

```php
$provider = $PDPManager->getProvider(getDolGlobalString('EINVOICING_PDP'));
// Now we load the conf

$providerconfig  = $provider->getConf();
```

`getProvider()` returns `null` for a provider that is not enabled, and that happens today:
`EINVOICING_SUPERPDP_VIAPARTNER_ONLY` disables every entry but the via-partner one - including the one
already recorded in `EINVOICING_PDP`. The page then dies on `Call to a member function getConf() on null`,
and since it is the only place where the Access point can be changed, the setup can no longer be reached
to select another one.

The provider is now tested before being used: the page tells which Access point is unavailable and keeps
offering the others. The actions of the provider block are skipped in that state too - with an empty
`$prefix` their patterns degrade to `/setTOKEN/i`, `/callHEALTHCHECK/i`, `/makesampleinvoice/i`... which
would call the same null provider.

One new translation key, `SelectedAccessPointNotAvailable`, in `en_US` only.

## Tested

On a sandbox instance (Dolibarr 23.0.3, PHP 8.4) put in exactly that state - `EINVOICING_SUPERPDP_VIAPARTNER_ONLY = 1`
and `EINVOICING_PDP = SUPERPDP`, i.e. a selected provider the grey-label option disables - running the
statements of the page verbatim:

```
== BEFORE (code of main)
EINVOICING_PDP=SUPERPDP VIAPARTNER_ONLY=1
PHP Fatal error: Uncaught Error: Call to a member function getConf() on null

== AFTER (this patch)
EINVOICING_PDP=SUPERPDP VIAPARTNER_ONLY=1
WARNING shown to the admin: The selected Access point (SUPERPDP) is not available anymore. The module
that provides it may have been disabled. Select another Access point.
page continues, prefix=""
```

The same statements were then run with a provider that *is* available, on that instance and on the
three other ones (18.0.10, 20.0.5, 24.0.0-beta), together with the `initFormSetup()` call that follows
them: the block behaves as before, the configuration form is built with the same items. The module test
suite was run file by file on the four cores as well - on a tree that also carried #534, since both
were validated in the same run.

Split out of #534, which met the same crash from the other end (a provider brought by a module that
gets disabled) - the two are independent, this one fixes a hole that exists on main today.