### PR TITLE
[build] Fix: the einvoicing package ships without its compat/ directory

### DIFF
--- a/dev/build/makepack-modules.php
+++ b/dev/build/makepack-modules.php
@@ -353,6 +353,7 @@ function buildModulePackages($action, $modulename)
 		'ajax',
 		'backport',
 		'class',
+		'compat',
 		'css',
 		'core',
 		'img',
@@ -370,6 +371,7 @@ function buildModulePackages($action, $modulename)
 		'*.yaml',
 		'COPYING',
 		'COPYRIGHT',
+		'VERSION',
 		'modulebuilder.txt',
 	];
 
@@ -559,6 +561,9 @@ function detectModule()
 	// search, and store all matching occurrences in $matches
 	if (preg_match_all($pattern, $contents, $matches)) {
 		$version = reset($matches['version']);
+	} elseif (file_exists('VERSION')) {
+		// The descriptor may read its version from the VERSION file of the module instead of hardcoding it
+		$version = trim((string) file_get_contents('VERSION'));
 	}
 
 	if (version_compare($version, '0.0.1', '>=') != 1) {


### PR DESCRIPTION
Fixes #537.

## The bug

Enabling einvoicing 1.0.3 on Dolibarr 18 fatals with `Class "CommonHookActions" not found`.

`CommonHookActions` only exists in core from Dolibarr **19.0** on, so the module carries its own copy
in `einvoicing/compat/` and loads it below that version — the fix that closed #153:

```php
if ((float) DOL_VERSION < 19) {
	dol_include_once('/einvoicing/compat/commonhookactions.class.php');
} else {
	require_once DOL_DOCUMENT_ROOT . '/core/class/commonhookactions.class.php';
}
```

That code is fine. **The `compat/` directory never reaches the user**: `buildModulePackages()` copies an
explicit allow-list of directories into the zip and `compat` is not in it. The same directory also holds
`profid.lib.php`, loaded below Dolibarr 20 for `isValidSiren()` / `isValidSiret()`, so 17, 18 and 19 were
all broken — the module declares `need_dolibarr_version = 17`.

The zip published on dolistore and `dev/build/bin/module_einvoicing-1.0.3.zip` are identical (same 2414
entries, same content), so both are affected.

## Second problem, found while testing

`VERSION` is not in the allow-list either. It became necessary when `modEInvoicing` stopped hardcoding its
version and started reading the file, and its absence also broke `detectModule()`, whose regular
expression looks for the literal `$this->version = '...'` assignment:

```
extract data from core/modules/modEInvoicing.class.php
[fail] Error auto extract version fail
[fail] This repository does not contain a valid module sources, skipped.
```

So the einvoicing package could not be rebuilt from `main` at all. `detectModule()` now falls back to the
`VERSION` file when the descriptor no longer holds a literal.

## Verified

Virgin Dolibarr **18.0.10**, no other module. With the published zip:

```
DOL_VERSION = 18.0.10
core/class/commonhookactions.class.php present in core: NO
custom/einvoicing/compat/ present: NO
activateModule errors: (none)
--- now loading hooks like any page does ---
PHP Fatal error:  Uncaught Error: Class "CommonHookActions" not found in
  custom/einvoicing/class/actions_einvoicing.class.php:39
```

With the zip rebuilt by this branch, same instance, nothing else changed:

```
--- initHooks(invoicecard) ---
HOOKS LOADED OK, classes: ["50:einvoicing"]
module version = [1.0.3]
```

The rebuilt package holds 2415 entries: the 2414 published ones plus `einvoicing/VERSION`,
`einvoicing/compat/commonhookactions.class.php` and `einvoicing/compat/profid.lib.php`.

## Note

The published package still has to be regenerated for the fix to reach users — this branch only repairs
the builder. One thing to be aware of when doing it: `makezip` writes the archive to
`einvoicing/module_einvoicing-1.0.3.zip`, while the committed one lives in `dev/build/bin/`, so it has to
be moved. I left that as is rather than guess the intended layout.
