### PR TITLE
fix: use Original docType instead of Converted for SuperPDP supplier invoice retrieval

### DIFF
--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -1861,7 +1861,7 @@ class SuperPDPProvider extends AbstractPDPProvider
 
 				// Retrieve Original file
 				$receivedFile = null;
-				$flowResponse = $this->fetchFlowData($flowId, 'Converted', 'get_flow_for_supplier_invoice');
+				$flowResponse = $this->fetchFlowData($flowId, 'Original', 'get_flow_for_supplier_invoice');
 
 				if ($flowResponse['status_code'] != 200) {
 					return array('res' => -1, 'message' => "ERROR_FLOW_GETORIG Failed to retrieve 'Original' document for SupplierInvoice flow (flowId: " . $flowId . ")" . (empty($flowResponse['errorMessage']) ? '' : ' - ' . $flowResponse['errorMessage']));


### PR DESCRIPTION
## Summary

When synchronising incoming supplier invoices with SuperPDP, the sync fails on the first new flow with:

```
ERROR_FLOW_GETORIG Failed to retrieve 'Original' document for SupplierInvoice flow — Configuration of the oauth2 client is required
```

## Root cause

The `docType=Converted` endpoint is **optional** in the XP Z12-013 spec (*"the document optionally converted by the system"*) and seems to require additional OAuth2 configuration.

The code was requesting `Converted` while the surrounding comment, the error code (`ERROR_FLOW_GETORIG`) and the variable name all indicate the intent was to fetch `Original`. 

## Changes

- `SuperPDPProvider.class.php` — change `fetchFlowData($flowId, 'Converted', ...)` to `fetchFlowData($flowId, 'Original', ...)` in the `SupplierInvoice` case of `syncFlow()`
