### PR TITLE
fix(einvoicing): the vendor of an unimportable invoice is reported as "Array"

### DIFF
--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -821,18 +821,22 @@ trait CommonProtocol
 			$createUrl .= '&backtopage=' . urlencode(dol_buildpath('/einvoicing/document_list.php', 1));
 
 			$errorDetails = [];
+			// The caller renders $actiondata as "key: value" pairs, the flat shape the PRODUCT_NOT_FOUND
+			// case returns. Building it as a list of one-entry arrays made every value reach the message
+			// as the string "Array", and dropped the first pair altogether, its key being the falsy
+			// index 0 - so the vendor name never made it there.
 			$actiondata = [];
 			if (!empty($sellername)) {
 				$errorDetails[] = 'Supplier: ' . $sellername;
-				$actiondata[] = array('name' => $sellername);
+				$actiondata['name'] = $sellername;
 			}
 			if (!empty($selleremail)) {
 				$errorDetails[] = 'Email: ' . $selleremail;
-				$actiondata[] = array('email' => $selleremail);
+				$actiondata['email'] = $selleremail;
 			}
 			if (!empty($sellervat)) {
 				$errorDetails[] = 'Vat number: ' . $sellervat;
-				$actiondata[] = array('vatnumber' => $sellervat);
+				$actiondata['vatnumber'] = $sellervat;
 			}
 			if (!empty($sellerInfo['sellerGlobalIds']) && is_array($sellerInfo['sellerGlobalIds'])) {
 				foreach ($sellerInfo['sellerGlobalIds'] as $idScheme => $globalId) {
@@ -840,7 +844,7 @@ trait CommonProtocol
 						$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode);
 						if (!empty($idprofField)) {
 							$errorDetails[] = $idprofField.': ' . $globalId;
-							$actiondata[] = array($idprofField => $globalId);
+							$actiondata[$idprofField] = $globalId;
 						}
 					}
 				}


### PR DESCRIPTION
When a received supplier invoice names a vendor that is not in the database and auto-creation of third parties is disabled, the synchronization stops and tells the user which vendor to create. That message currently comes out as:

> The third party of the vendor of the imported invoice (**1: Array, 2: Array, 3: Array, 4: Array**) could not be found in your database and auto-creation of third party is disabled. So you must create it manually.

plus one `Array to string conversion` warning per value on PHP 8.

## Cause

The consumer renders `actiondata` as a flat map of `key: value` pairs (`SuperPDPProvider::syncFlows()`, and the same block in `EsalinkPDPProvider`):

```php
foreach ($res['actiondata'] ?? [] as $datakey => $dataval) {
    if ($datakey && $dataval) { $infostring .= …$datakey.': '.$dataval; }
}
```

`PRODUCT_NOT_FOUND` returns exactly that shape. `THIRDPARTY_NOT_FOUND` instead built a list of one-entry arrays:

```php
$actiondata[] = array('name' => $sellername);
$actiondata[] = array('email' => $selleremail);
…
```

so the keys are `0,1,2,3` and the values are arrays. Two consequences, not one:

- each value is concatenated as an array, hence `Array`;
- the **first pair is dropped entirely**, its key being the falsy index `0` — and that first pair is the vendor name, the single most useful field of the message.

## Fix

Assign the pairs instead of appending wrappers — four lines, the surrounding structure untouched:

```php
-  $actiondata[] = array('name' => $sellername);
+  $actiondata['name'] = $sellername;
```

No consumer changes: all four call sites already expect this shape.

`$createParams`, built a few lines above from the very same values, happens to hold exactly this array today, so it is tempting to just assign it. I did not, on purpose: the two serve different roles — `$createParams` is the payload that prefills the "create supplier" form, `$actiondata` is what the message shows — and `PRODUCT_NOT_FOUND` keeps them deliberately distinct, its `$createParams` carrying `type`, `tva_tx`, `status`, `barcode`… that have no place in a message. Reusing it here would couple the two and let any future prefill key leak into the user-facing text.

## Before / after

Same instance, same flow (`i_193090`), same received invoice, only the code changes.

Before:

<img width="1543" alt="before, the vendor is reported as Array" src="https://github.com/user-attachments/assets/af8565e4-eb90-4e0a-bd1f-9a3abbb7a5c4" />

After:

<img width="1543" alt="after, the vendor identifiers are readable" src="https://github.com/user-attachments/assets/ddff9ccc-207a-47fb-a4ed-8708d1356c6f" />

The values are the vendor's real identifiers, and the PHP warnings are gone.

## Tests

On the SuperPDP sandbox, with invoices really transmitted through the platform:

- the message above, captured on a genuinely received invoice whose vendor is absent from the database, with auto-creation of third parties disabled — before and after, on the same flow, which is left unstored on this error and so can be replayed as is;
- non-regression on the normal path, both directions: an invoice emitted from one instance and imported by another (`TRI-FA-2608-0033`, `TRI-FA-2608-0034`), and one emitted the other way and imported back (`BQ-FA-2608-0035`), all attached to the right vendor;
- `php -l` and the CI phan configuration (5.5.2, `--quick`, with the repository baseline, merged with `main`) run locally: clean.

Found while investigating #539 / #540, but independent of both.
