### PR TITLE
fix(einvoicing): a replacement invoice carries no reference to the invoice it replaces

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -900,8 +900,10 @@ class CIIProtocol extends AbstractProtocol
 		// documentdate is already formatted into 'Y-m-d' by the parser ZugFerd and CII
 		$supplierInvoice->date = !empty($parsedHeader['documentdate']) ? dol_stringtotime($parsedHeader['documentdate']) : null;
 
-		// For credit notes, link to the source invoice via fk_facture_source (BT-25)
-		if ($supplierInvoice->type == FactureFournisseur::TYPE_CREDIT_NOTE && !empty($parsedHeader['invoiceRefDocs']) && is_array($parsedHeader['invoiceRefDocs'])) {
+		// For credit notes and replacement invoices, link to the source invoice via fk_facture_source
+		// (BT-25). A replacement invoice (BT-3 = 384) corrects the invoice it references just as a credit
+		// note cancels it, and Dolibarr stores that source in the same field for both.
+		if (in_array($supplierInvoice->type, array(FactureFournisseur::TYPE_CREDIT_NOTE, FactureFournisseur::TYPE_REPLACEMENT)) && !empty($parsedHeader['invoiceRefDocs']) && is_array($parsedHeader['invoiceRefDocs'])) {
 			$firstRefDoc = reset($parsedHeader['invoiceRefDocs']);
 			$refSourceSupplier = !empty($firstRefDoc['IssuerAssignedID']) ? (string) $firstRefDoc['IssuerAssignedID'] : '';
 			if ($refSourceSupplier !== '') {
@@ -911,9 +913,9 @@ class CIIProtocol extends AbstractProtocol
 					$objSource = $db->fetch_object($resqlSource);
 					if ($objSource) {
 						$supplierInvoice->fk_facture_source = (int) $objSource->rowid;
-						dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Credit note linked to source invoice id=' . $supplierInvoice->fk_facture_source, LOG_DEBUG);
+						dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Linked to source invoice id=' . $supplierInvoice->fk_facture_source, LOG_DEBUG);
 					} else {
-						dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Source invoice ref_supplier="' . $refSourceSupplier . '" not found for credit note ' . ($parsedHeader['documentno'] ?? ''), LOG_WARNING);
+						dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Source invoice ref_supplier="' . $refSourceSupplier . '" not found for ' . ($parsedHeader['documentno'] ?? ''), LOG_WARNING);
 					}
 				}
 			}

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -1449,8 +1449,10 @@ class FacturXProtocol extends CIIProtocol
 		// documentdate is already formatted into 'Y-m-d' by the parser ZugFerd and CII
 		$supplierInvoice->date = !empty($parsedHeader['documentdate']) ? dol_stringtotime($parsedHeader['documentdate']) : null;
 
-		// For credit notes, link to the source invoice via fk_facture_source (BT-25)
-		if ($supplierInvoice->type == FactureFournisseur::TYPE_CREDIT_NOTE && !empty($parsedHeader['invoiceRefDocs']) && is_array($parsedHeader['invoiceRefDocs'])) {
+		// For credit notes and replacement invoices, link to the source invoice via fk_facture_source
+		// (BT-25). A replacement invoice (BT-3 = 384) corrects the invoice it references just as a credit
+		// note cancels it, and Dolibarr stores that source in the same field for both.
+		if (in_array($supplierInvoice->type, array(FactureFournisseur::TYPE_CREDIT_NOTE, FactureFournisseur::TYPE_REPLACEMENT)) && !empty($parsedHeader['invoiceRefDocs']) && is_array($parsedHeader['invoiceRefDocs'])) {
 			$firstRefDoc = reset($parsedHeader['invoiceRefDocs']);
 			$refSourceSupplier = !empty($firstRefDoc['IssuerAssignedID']) ? (string) $firstRefDoc['IssuerAssignedID'] : '';
 			if ($refSourceSupplier !== '') {
@@ -1460,9 +1462,9 @@ class FacturXProtocol extends CIIProtocol
 					$objSource = $db->fetch_object($resqlSource);
 					if ($objSource) {
 						$supplierInvoice->fk_facture_source = (int) $objSource->rowid;
-						dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Credit note linked to source invoice id=' . $supplierInvoice->fk_facture_source, LOG_DEBUG);
+						dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Linked to source invoice id=' . $supplierInvoice->fk_facture_source, LOG_DEBUG);
 					} else {
-						dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Source invoice ref_supplier="' . $refSourceSupplier . '" not found for credit note ' . ($parsedHeader['documentno'] ?? ''), LOG_WARNING);
+						dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Source invoice ref_supplier="' . $refSourceSupplier . '" not found for ' . ($parsedHeader['documentno'] ?? ''), LOG_WARNING);
 					}
 				}
 			}

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -267,17 +267,26 @@ if (! ($object->project instanceof Project)) {
 
 $invoiceRefDocs = [];
 
-// Source invoice (credit note)
-if ($object->type == $object::TYPE_CREDIT_NOTE && !empty($object->fk_facture_source)) {
+// Source invoice (credit note, replacement invoice)
+// A replacement invoice (BT-3 = 384) references the invoice it corrects in the same BG-3 slot as a
+// credit note does, and BR-FR-CO-04 makes that reference mandatory for it, with a "fatal" flag: one
+// sent without it is refused by the access point, and a receiver has nothing to attach it to.
+$refDocTypeCode = '';
+if ($object->type == $object::TYPE_CREDIT_NOTE) {
+	$refDocTypeCode = '381';			// 381 = Credit note
+} elseif ($object->type == $object::TYPE_REPLACEMENT) {
+	$refDocTypeCode = '384';			// 384 = Corrected invoice
+}
+if ($refDocTypeCode !== '' && !empty($object->fk_facture_source)) {
 	$sourceFact = new Facture($this->db);
 	if ($sourceFact->fetch($object->fk_facture_source) > 0) {
 		$sourceFactDate = new DateTime(dol_print_date($sourceFact->date, 'dayrfc'));
 		$invoiceRefDocs[] = [
 			'ref' => $sourceFact->ref,
 			'date' => $sourceFactDate,
-			'type' => '381' 				// 381 = Credit note
+			'type' => $refDocTypeCode
 		];
-		dol_syslog(get_class($this) . '::generateXML Set source invoice reference ' . $sourceFact->ref . ' for credit note ' . $object->ref);
+		dol_syslog(get_class($this) . '::generateXML Set source invoice reference ' . $sourceFact->ref . ' for ' . $object->ref);
 	} else {
 		if ($object->id == 0) { // Specimen case.
 			$specimenRefDoc = $object->fk_facture_source ?? 'FA0000-SPECIMEN';
@@ -285,11 +294,11 @@ if ($object->type == $object::TYPE_CREDIT_NOTE && !empty($object->fk_facture_sou
 			$invoiceRefDocs[] = [
 				'ref' => $specimenRefDoc,
 				'date' => $sourceFactDate,
-				'type' => '381' 				// 381 = Credit note
+				'type' => $refDocTypeCode
 			];
-			dol_syslog(get_class($this) . '::generateXML Set source invoice reference ' . $specimenRefDoc . ' for credit note specimen ' . $object->ref);
+			dol_syslog(get_class($this) . '::generateXML Set source invoice reference ' . $specimenRefDoc . ' for specimen ' . $object->ref);
 		} else {
-			dol_syslog(get_class($this) . '::generateXML Cannot fetch source invoice id=' . $object->fk_facture_source . ' for credit note ' . $object->ref, LOG_WARNING);
+			dol_syslog(get_class($this) . '::generateXML Cannot fetch source invoice id=' . $object->fk_facture_source . ' for ' . $object->ref, LOG_WARNING);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #536, where a corrected invoice received from a vendor gets the right type but is never attached to the invoice it replaces.

Reproduced on current `main`. `BT-3 = 384` is mapped to `TYPE_REPLACEMENT` correctly — hence the right status the reporter sees — but everything around the preceding invoice reference (BT-25) was written for credit notes only, on both sides.

## On generation

`einvoicing/lib/buildinvoicelines.inc.php`:

```php
if ($object->type == $object::TYPE_CREDIT_NOTE && !empty($object->fk_facture_source)) {
    $invoiceRefDocs[] = […];
}
```

A replacement invoice therefore leaves Dolibarr with an empty BG-3, although the invoice it replaces sits right there in `fk_facture_source`. Measured on a replacement invoice generated from `main`:

```
BT-3                       = 384
InvoiceReferencedDocument  = 0 occurrence
```

That is not merely incomplete, it is invalid. `BR-FR-Flux2-Schematron-CII.sch`, pattern `BR-FR-CO-04`, `flag="fatal"`:

> Si le type de facture (BT-3) est une facture rectificative (384, 471, 472, 473), alors **une et une seule** référence à une facture antérieure (BT-25) avec sa date (BT-26) doit être présente.

So the access point refuses every replacement invoice this module sends. On the sandbox, the one generated from `main` came back `acknowledgement.status = Error` with a CDAR `213` (rejected).

## On import

`CIIProtocol::doCreateSupplierInvoiceFromSource()` and its Factur-X counterpart:

```php
if ($supplierInvoice->type == FactureFournisseur::TYPE_CREDIT_NOTE && !empty($parsedHeader['invoiceRefDocs'])) {
    … $supplierInvoice->fk_facture_source = …
}
```

so even a correctly formed replacement invoice, from an issuer that does emit BT-25, arrives orphaned. This is the half that hits the reporter, whose vendor is not necessarily running this module.

## Fix

Both paths now treat the two document types the same way, which is what Dolibarr does too — `fk_facture_source` holds the source of a credit note and of a replacement invoice alike. The type code written in the reference follows the existing convention (`381` for a credit note, `384` for a replacement); it is only emitted on EXTENDED profiles, and I left that convention untouched.

## Tests

End to end on the SuperPDP sandbox, two instances, invoices really transmitted:

| | source invoice | replacement invoice |
| --- | --- | --- |
| emitted | `TRI-FA-2608-0038` | `TRI-FA-2608-0039`, BT-3 384, **one** BT-25 → `TRI-FA-2608-0038` with its date |
| platform | accepted | accepted — where the same invoice built from `main` was **rejected** (ack `Error`, CDAR 213) |
| imported | supplier invoice type 0, no source | supplier invoice **type 1**, `fk_facture_source` = the source invoice |

The before/after on the platform acknowledgement is the same instance, the same kind of invoice, minutes apart: `Error` without the patch, `Ok` with it.

A second receiving instance, still on `main`, imported the very same flow as type 1 with `fk_facture_source` left empty — the control for the import half.

The whole scenario of the issue was then played end to end, through the platform, on a second pair of invoices:

| step | actor | result |
| --- | --- | --- |
| invoice issued | seller | `TRI-FA-2608-0040` sent, accepted, imported by the buyer |
| **refused** | buyer | status `210` with reason `MONTANTTOTAL_ERR`, received on the seller's invoice |
| **replacement issued** | seller | `TRI-FA-2608-0041`, BT-3 384 with its BT-25 → `TRI-FA-2608-0040`, **accepted** |
| imported | buyer | type 1, `fk_facture_source` = the refused invoice — while a second receiving instance still on `main` imported the same flow with `fk_facture_source` empty |
| **205** approved | buyer | received on the seller's invoice |
| **211** payment transmitted | buyer | received on the seller's invoice |
| **212** cashed | seller, after payment | received on the buyer's supplier invoice |

The same scenario was then played in the other direction — the two instances swapping the seller and buyer roles — with the same outcome at every step: replacement accepted, imported with `fk_facture_source` pointing at the refused invoice, and `205` / `211` / `212` exchanged both ways.

so a replacement invoice behaves like any other document over the whole chain, not only at import time. (`212` is refused for a buyer and `205`/`211` for a seller, which is the module's existing split and matches who reports what in the lifecycle; `210` requires a reason code, per `BR-FR-CDV-15`.)

`php -l` and the CI phan configuration (5.5.2, `--quick`, repository baseline, merged with `main`) run locally: clean.
