### PR TITLE
[einvoicing] FIX: a directory answer with no line status is settled with what the platform does report

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -127,6 +127,17 @@ for - and an instance running a Dolibarr that does not know that option diverged
 honouring a setting its core ignores. Nothing reported it: the document stayed internally consistent
 and the platform accepted it (issue #505).
 
+FIX: The recipient reachability pre-check no longer answers "undetermined" on SuperPDP when the
+platform can tell. Some lines of its standardized directory answer come back without their status,
+and that status cannot be requested, so the check stayed non-conclusive; its own directory endpoint,
+already used when the standardized lookup is unavailable, does report it for the very same lines, and
+it now settles those answers. Only those: a status the standardized answer did give is never
+overridden, and an endpoint that fails or knows nothing of the recipient settles nothing. The two
+recipients seen with that gap - both declared and not open yet - are now reported as not reachable
+instead of undetermined, and the option that requires a reachable recipient blocks them at its first
+value. Where the verdict was read is displayed next to it, since the directory consulted by hand
+shows no status for that line.
+
 
 ## 1.0.3
 

--- a/einvoicing/ajax/checkdirectory.php
+++ b/einvoicing/ajax/checkdirectory.php
@@ -122,6 +122,12 @@ function einvoicing_directory_html($r, $siren)
 			if (!empty($r['platform'])) {
 				$details[] = $langs->trans("EInvoicingDirectoryPlatformType").': '.dol_escape_htmltag($r['platform']);
 			}
+			// Where the status was read, when it did not come from the standardized directory answer:
+			// the annuaire consulted by hand then shows no status for that line, and the difference
+			// must be explainable without reading the code.
+			if (!empty($r['message'])) {
+				$details[] = dol_escape_htmltag($langs->trans($r['message']));
+			}
 			if (!empty($details)) {
 				$txt .= ' <span class="opacitymedium small">('.implode(' - ', $details).')</span>';
 			}
@@ -139,8 +145,15 @@ function einvoicing_directory_html($r, $siren)
 			} else {
 				$txt = $langs->trans("EInvoicingDirectoryInactive", $siren);
 			}
+			$details = array();
 			if (!empty($r['linestatus'])) {
-				$txt .= ' <span class="opacitymedium small">('.$langs->trans("EInvoicingDirectoryLineStatus").': '.dol_escape_htmltag($r['linestatus']).')</span>';
+				$details[] = $langs->trans("EInvoicingDirectoryLineStatus").': '.dol_escape_htmltag($r['linestatus']);
+			}
+			if (!empty($r['message'])) {
+				$details[] = dol_escape_htmltag($langs->trans($r['message']));
+			}
+			if (!empty($details)) {
+				$txt .= ' <span class="opacitymedium small">('.implode(' - ', $details).')</span>';
 			}
 			return img_picto('', 'warning', 'class="paddingright"').$txt;
 		case 'undetermined':

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -1250,17 +1250,77 @@ class SuperPDPProvider extends AbstractPDPProvider
 	public function checkRecipientDirectory($idprof1)
 	{
 		// Standardized AFNOR directory check first (works for any conformant Approved Platform).
-		// 'undetermined' also ends the check: the annuaire did answer with lines for that SIREN, only
-		// without their status. Falling back to the legacy endpoint there could contradict it with a
-		// worse answer ('absent' when the standardized annuaire holds a line), and only the AFNOR
-		// annuaire carries the effective date that decides reachability.
 		$result = parent::checkRecipientDirectory($idprof1);
-		if (in_array($result['status'], array('routable', 'inactive', 'absent', 'undetermined'), true)) {
+		if (in_array($result['status'], array('routable', 'inactive', 'absent'), true)) {
+			// The standardized answer carried the line status: it decides, and nothing else may
+			// override it. This is what keeps the specific endpoint from re-introducing a wrong
+			// positive on a line the annuaire reports as not open.
 			return $result;
+		}
+		if ($result['status'] === 'undetermined') {
+			// Lines exist for that SIREN but the platform did not report their status, and it cannot be
+			// asked for it. Its own directory endpoint does carry that information: use it to settle the
+			// answer instead of leaving the user with a shrug.
+			return $this->settleUndeterminedDirectory($idprof1, $result);
 		}
 
 		// Standardized lookup unavailable or errored: fall back to the SuperPDP specific endpoint.
 		return $this->checkRecipientDirectoryLegacy($idprof1);
+	}
+
+	/**
+	 * Settle a standardized directory answer that came back without line statuses, using the SuperPDP
+	 * specific french_directory endpoint as a tie-breaker.
+	 *
+	 * The status is missing from some standardized answers of this platform (observed on the lines
+	 * addressed by the bare SIREN and not open yet), and it cannot be requested: 'directoryLineStatus'
+	 * is not one of the values the search accepts in 'fields', and reading the line on its own omits it
+	 * as well. The platform's own endpoint answers about the very same lines, at the same moment, and
+	 * does carry the flag: on every line where both answers report it, the boolean matches the
+	 * standardized status (true for 'Enabled', false for 'Upcoming'). So it is used here to conclude,
+	 * and only here:
+	 * - it settles a non-conclusive answer, it never overrides a status the standardized answer gave ;
+	 * - it stays silent (the answer remains non-conclusive) when it knows nothing of that SIREN or
+	 *   fails, since the standardized annuaire does hold lines for it.
+	 *
+	 * The boolean does not tell a line waiting for its effective date from a closed one, so a negative
+	 * verdict says the recipient cannot receive without claiming which of the two it is.
+	 *
+	 * @param 	string 	$idprof1 	Recipient SIREN (idprof1)
+	 * @param 	array{status:string,reachable:int,entries:int,active:int,unknown:int,identifier:string,linestatus:string,platform:string,effectivedate:int,message:string,httpcode:int} 	$result 	Non-conclusive result of the standardized check
+	 * @return 	array{status:string,reachable:int,entries:int,active:int,unknown:int,identifier:string,linestatus:string,platform:string,effectivedate:int,message:string,httpcode:int}
+	 */
+	private function settleUndeterminedDirectory($idprof1, $result)
+	{
+		$legacy = $this->checkRecipientDirectoryLegacy($idprof1);
+
+		if ($legacy['entries'] == 0 || $legacy['status'] === 'error') {
+			// Nothing to settle with: the specific endpoint failed, or knows no entry for a SIREN the
+			// standardized annuaire holds lines for. Keep the non-conclusive answer rather than
+			// contradicting the standardized one.
+			return $result;
+		}
+
+		// 'active' counts entries flagged as able to receive with an effective date already reached,
+		// 'unknown' those flagged the same way with no date in the payload: both are entries this
+		// platform reports as receiving, which is exactly the status the standardized answer dropped.
+		if ($legacy['active'] > 0 || $legacy['unknown'] > 0) {
+			$result['status'] = 'routable';
+			$result['reachable'] = 1;
+			if (!empty($legacy['identifier'])) {
+				$result['identifier'] = $legacy['identifier'];
+			}
+		} else {
+			$result['status'] = 'inactive';
+			$result['reachable'] = 0;
+			$result['linestatus'] = $legacy['linestatus'];
+			$result['effectivedate'] = $legacy['effectivedate'];
+		}
+		// Provenance: this verdict does not come from the standardized answer displayed by the annuaire
+		// consultation, so a user comparing the two must be able to tell where it comes from.
+		$result['message'] = 'EInvoicingDirectoryStatusFromPlatform';
+
+		return $result;
 	}
 
 	/**

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -483,6 +483,7 @@ EInvoicingDirectoryInactive=Not reachable: recipient (SIREN %s) is in the direct
 EInvoicingDirectoryUpcoming=Not reachable yet: recipient (SIREN %s) has a reception address in the directory that only takes effect on %s
 EInvoicingDirectoryUpcomingNoDate=Not reachable yet: recipient (SIREN %s) has a reception address declared in the directory that has not taken effect yet
 EInvoicingDirectoryUndetermined=Undetermined: recipient (SIREN %s) has a reception address in the directory, but the platform did not report its line status, so it cannot be told from an address that only takes effect later. Reachability is unconfirmed: transmission may still come back as a routing error
+EInvoicingDirectoryStatusFromPlatform=status read from the platform own directory, which the standardized answer did not report
 EInvoicingDirectoryLineStatus=Line status
 EInvoicingDirectoryPlatformType=Platform
 EInvoicingDirectoryUnsupported=Directory lookup is not available for the current platform

--- a/einvoicing/test/phpunit/RecipientDirectoryTest.php
+++ b/einvoicing/test/phpunit/RecipientDirectoryTest.php
@@ -254,6 +254,30 @@ class FakeLegacySuperPDPProvider extends SuperPDPProvider
 
 
 /**
+ * Provider double for the SuperPDP tie-breaker: the AFNOR directory base is configured, so
+ * checkRecipientDirectory() runs the standardized lookup first and only then, when that answer holds
+ * no line status, the specific french_directory endpoint. Both answers come from the same canned
+ * queue, in that order.
+ */
+class FakeDirectorySuperPDPProvider extends FakeLegacySuperPDPProvider
+{
+	/**
+	 * Constructor
+	 *
+	 * @param DoliDB $db Database handler
+	 */
+	public function __construct($db)
+	{
+		parent::__construct($db);
+
+		// Both keys set: getApiUrl('afnor_directory') then answers whatever EINVOICING_LIVE is.
+		$this->config['test_afnor_directory_url'] = 'https://example.invalid/afnor-directory/';
+		$this->config['prod_afnor_directory_url'] = 'https://example.invalid/afnor-directory/';
+	}
+}
+
+
+/**
  * Class for PHPUnit tests
  *
  * @backupGlobals disabled
@@ -615,5 +639,159 @@ class RecipientDirectoryTest extends CommonClassTest
 
 		$this->assertSame('absent', $result['status']);
 		$this->assertSame(0, $result['reachable']);
+	}
+
+	/**
+	 * Build a SuperPDP double that answers the standardized search with the given lines, then the
+	 * specific french_directory lookup with the given entries.
+	 *
+	 * @param	array<int,array<string,mixed>>	$lines		Directory lines returned by the standardized search
+	 * @param	?array<int,array<string,mixed>>	$entries	Entries returned by french_directory/entries, null for a failing call
+	 * @return	FakeDirectorySuperPDPProvider
+	 */
+	private function superPdpReturningLinesThenEntries($lines, $entries)
+	{
+		global $db;
+
+		$provider = new FakeDirectorySuperPDPProvider($db);
+		$provider->cannedResponses = array(
+			array('status_code' => 200, 'response' => array('results' => $lines, 'totalNumberOfResults' => count($lines))),
+			$entries === null ? array('status_code' => 500, 'response' => '') : array('status_code' => 200, 'response' => array('data' => $entries)),
+		);
+
+		return $provider;
+	}
+
+	/**
+	 * The standardized answer of this platform drops the line status on some lines, and the status
+	 * cannot be requested. Its own directory endpoint does report it: a line it does not flag as
+	 * receiving makes the recipient not reachable, instead of leaving a shrug on the invoice card.
+	 *
+	 * @return void
+	 */
+	public function testLineWithoutStatusIsSettledInactiveByTheSpecificDirectory()
+	{
+		$provider = $this->superPdpReturningLinesThenEntries(
+			array(array('addressingIdentifier' => '824369342', 'platformType' => 'WK', 'siren' => '824369342')),
+			array(array('identifier' => '824369342', 'is_active' => false))
+		);
+
+		$result = $provider->checkRecipientDirectory('824369342');
+
+		$this->assertSame('inactive', $result['status']);
+		$this->assertSame(0, $result['reachable']);
+		// The verdict comes from the specific endpoint, not from the standardized answer: said so on
+		// screen, or the annuaire consulted by hand (no status at all) looks like it contradicts it.
+		$this->assertSame('EInvoicingDirectoryStatusFromPlatform', $result['message']);
+		$this->assertSame(
+			array('afnor-directory/v1/directory-line/search', 'french_directory/entries?number=824369342'),
+			$provider->calledResources
+		);
+	}
+
+	/**
+	 * Same lookup, on a recipient the specific endpoint does flag as receiving: the standardized answer
+	 * was simply incomplete, the recipient is reachable and the address it reports is handed back.
+	 *
+	 * @return void
+	 */
+	public function testLineWithoutStatusIsSettledRoutableByTheSpecificDirectory()
+	{
+		$provider = $this->superPdpReturningLinesThenEntries(
+			array(array('addressingIdentifier' => '892304189', 'platformType' => 'WK', 'siren' => '892304189')),
+			array(array('identifier' => '892304189', 'is_active' => true))
+		);
+
+		$result = $provider->checkRecipientDirectory('892304189');
+
+		$this->assertSame('routable', $result['status']);
+		$this->assertSame(1, $result['reachable']);
+		$this->assertSame('892304189', $result['identifier']);
+		$this->assertSame('EInvoicingDirectoryStatusFromPlatform', $result['message']);
+	}
+
+	/**
+	 * The tie-breaker only settles an answer that reported no status: a status the standardized
+	 * directory did give is never overridden, which is what kept the original wrong positive from
+	 * coming back through the other end.
+	 *
+	 * @return void
+	 */
+	public function testExplicitStandardizedStatusIsNotOverriddenBySpecificDirectory()
+	{
+		$provider = $this->superPdpReturningLinesThenEntries(
+			array(array('addressingIdentifier' => '824369342_82436934200020', 'directoryLineStatus' => 'Upcoming', 'platformType' => 'WK', 'siren' => '824369342')),
+			array(array('identifier' => '824369342_82436934200020', 'is_active' => true))
+		);
+
+		$result = $provider->checkRecipientDirectory('824369342');
+
+		$this->assertSame('inactive', $result['status']);
+		$this->assertSame('Upcoming', $result['linestatus']);
+		$this->assertSame('', $result['message']);
+		// The specific endpoint is not even called: the standardized answer already concluded.
+		$this->assertSame(array('afnor-directory/v1/directory-line/search'), $provider->calledResources);
+	}
+
+	/**
+	 * A failing tie-breaker settles nothing: the answer stays non-conclusive (the caller keeps failing
+	 * open) rather than turning a platform outage into a verdict.
+	 *
+	 * @return void
+	 */
+	public function testUndeterminedStaysWhenTheSpecificDirectoryFails()
+	{
+		$provider = $this->superPdpReturningLinesThenEntries(
+			array(array('addressingIdentifier' => '824369342', 'siren' => '824369342')),
+			null
+		);
+
+		$result = $provider->checkRecipientDirectory('824369342');
+
+		$this->assertSame('undetermined', $result['status']);
+		$this->assertSame(-1, $result['reachable']);
+		$this->assertSame('EInvoicingDirectoryNoLineStatus', $result['message']);
+	}
+
+	/**
+	 * Same when the specific endpoint knows no entry for that SIREN while the standardized annuaire
+	 * holds lines for it: the two answers disagree on the recipient even existing, so the tie-breaker
+	 * has nothing to settle and must not conclude 'absent'.
+	 *
+	 * @return void
+	 */
+	public function testUndeterminedStaysWhenTheSpecificDirectoryKnowsNothing()
+	{
+		$provider = $this->superPdpReturningLinesThenEntries(
+			array(array('addressingIdentifier' => '824369342', 'siren' => '824369342')),
+			array()
+		);
+
+		$result = $provider->checkRecipientDirectory('824369342');
+
+		$this->assertSame('undetermined', $result['status']);
+		$this->assertSame(-1, $result['reachable']);
+		$this->assertSame(1, $result['entries']);
+	}
+
+	/**
+	 * When the tie-breaker does date the entry and that date is still ahead, the recipient cannot
+	 * receive yet and the date is reported with the verdict.
+	 *
+	 * @return void
+	 */
+	public function testSettledInactiveCarriesTheEffectiveDateWhenTheSpecificDirectoryHasOne()
+	{
+		$provider = $this->superPdpReturningLinesThenEntries(
+			array(array('addressingIdentifier' => '824369342', 'siren' => '824369342')),
+			array(array('identifier' => '824369342', 'is_active' => true, 'start_date' => '07-08-2216'))
+		);
+
+		$result = $provider->checkRecipientDirectory('824369342');
+
+		$this->assertSame('inactive', $result['status']);
+		$this->assertSame(0, $result['reachable']);
+		$this->assertSame('Upcoming', $result['linestatus']);
+		$this->assertGreaterThan(dol_now(), $result['effectivedate']);
 	}
 }


### PR DESCRIPTION
Follows #511, which stopped the reachability card from showing a recipient as reachable on a directory line whose status the platform did not report. That answer is now honest, but it is a shrug: `undetermined`, fail-open, and the invoice goes out anyway unless the option added in #513 is set to its strict value.

It does not have to stay a shrug on SuperPDP.

## What was measured

The status is missing from part of the standardized answer (`afnor-directory/v1/directory-line/search`) and it cannot be requested: `fields` only accepts `addressingIdentifier|siren|siret|addressingSuffix` (anything else is a HTTP 400), and `GET directory-line/code:<id>` omits it as well on the platform that omits it in the search.

The platform own endpoint, `french_directory/entries` — already used by this provider as a fallback when the standardized lookup is unavailable — answers about the very same lines, at the same moment, and does carry the information:

| line | standardized `directoryLineStatus` | `is_active` | same SIREN on another platform |
|---|---|---|---|
| `892304189` | `Enabled` | `true` | `Enabled` |
| `552081317` | `Enabled` | `true` | — |
| `552081317_ACHAT_TESTPILOTE`, `…_DCO_ENEDIS_TEST`, `…_DCO_SONG1` | `Enabled` | `true` | — |
| `552081317_ACHATPUB_403201767` | `Upcoming` | `false` | — |
| `824369342_82436934200020` | `Upcoming` | `false` | `Upcoming` |
| **`824369342`** | **absent** | **`false`** | `Upcoming` |
| **`908506140`** | **absent** | **`false`** | `Upcoming` |

Line by line, the boolean matches the status wherever both report it. So the missing status is a hole in the serialization of one answer, not missing data: the module was picking the worse of two signals it already had. The two lines where the status is missing are also exactly the ones that are declared and not open yet, so the shrug is not landing on harmless noise.

## What this changes

`SuperPDPProvider::checkRecipientDirectory()` consults the specific endpoint when — and only when — the standardized answer reported no status:

- a status the standardized answer did give is never overridden, so a line the directory reports as not open cannot become reachable through the other end (this is what kept #511 from being undone);
- an endpoint that fails, or that knows no entry for a SIREN the standardized directory holds lines for, settles nothing: the answer stays non-conclusive and the caller keeps failing open;
- `is_active` does not tell a line waiting for its effective date from a closed one, so a negative verdict says the recipient cannot receive without claiming which of the two it is;
- nothing changes for a recipient whose status the standardized answer does report: same single call, same verdict.

Where the verdict was read is displayed next to it, since the directory consulted by hand shows no status for that line and would otherwise look like it contradicts the card.

## Before / after, on the real directory

Two live recipients, through both a direct SuperPDP account and one going through a partner:

| | before | after |
|---|---|---|
| card, SIREN `908506140` | *Undetermined … reachability is unconfirmed* (neutral) | **Not reachable** — no active routing line (status read from the platform own directory) |
| card, SIREN `824369342` | idem | **Not reachable** |
| card, SIREN `892304189` / `552081317` | Reachable — Enabled / WK | unchanged, one call |
| `EINVOICING_REQUIRE_ROUTABLE_RECIPIENT=1`, recipient `908506140` | `ok=1`, transmitted | `ok=0`, blocked with a reason |
| same, value 2 | `ok=0`, "unconfirmed" | `ok=0`, "no active routing line" |

Both would have been transmitted and come back as a routing error (fr:213).

## Tests

Six cases added to `RecipientDirectoryTest.php`: no status + inactive entry ⇒ `inactive`; no status + active entry ⇒ `routable`; explicit standardized status + contradicting entry ⇒ standardized status wins, and the specific endpoint is not even called; failing endpoint ⇒ stays `undetermined`; endpoint knowing nothing of the SIREN ⇒ stays `undetermined`; dated entry still ahead ⇒ `inactive` with its date.

Full module suite green on Dolibarr 18.0.10, 20.0.5, 23.0.3 (×2) and 24.0.0-beta: 77 tests, 476 assertions. phpcs and phan clean.