### PR TITLE
Fix: einvoicing import keeps line description and supplier ref on product-linked lines

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2026       Laurent Destailleur         <eldy@users.sourceforge.net>
  * Copyright (C) 2026       Mohamed DAOUD               <mdaoud@dolicloud.com>
  * Copyright (C) 2026		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		Jose Martinez				<jose.martinez@pichinov.com>
  *
  *
  * This program is free software: you can redistribute it and/or modify
@@ -1253,6 +1254,10 @@ class CIIProtocol extends AbstractProtocol
 
 			// Add line to invoice
 			$line = new SupplierInvoiceLine($db);
+			// Supplier's product reference (BT-155 SellerAssignedID) -> shown as "Ref. fournisseur" on the line.
+			if (!empty($parsedLine['prodsellerid']) && $parsedLine['prodsellerid'] !== '0000') {
+				$line->ref_supplier = trim($parsedLine['prodsellerid']);
+			}
 			if (!empty($productId)) {
 				$line->fk_product = $productId;
 				if ($productMatchType == 'defaultrouting') {
@@ -1260,6 +1265,10 @@ class CIIProtocol extends AbstractProtocol
 					// vendor: without the wording of the XML, every line of the invoice would show the same
 					// label. Keep the description of the vendor on top of the product link.
 					$line->desc = trim($parsedLine['prodname'] ?? '') . (!empty($parsedLine['proddesc']) ? "\n" . trim($parsedLine['proddesc']) : '');
+				} elseif (!empty($parsedLine['proddesc'])) {
+					// Keep the XML line-level description even when a real product is linked:
+					// it is often project-specific and not carried by the product's own label/description.
+					$line->desc = trim($parsedLine['proddesc']);
 				}
 			} elseif (!$is_deposit_line) {
 				// Free line: no product linked, description set from XML data


### PR DESCRIPTION
# Fix: einvoicing supplier-invoice import keeps line description and supplier ref on product-linked lines

## Problem
When an incoming e-invoice (CII / Factur-X) is imported into a supplier invoice, a line that resolves to a **real product** (matched by supplier ref / GTIN / internal ref, or newly created — anything other than the *default-routing* catch-all product) loses two pieces of information that **are present in the received XML**:

- **Line description** — `SpecifiedTradeProduct/ram:Description` (BT-154). It is often **project-specific** (e.g. the scope of a service line) and is intentionally *not* stored on the product record, so it cannot be recovered from the product afterwards.
- **Supplier product reference** — `SpecifiedTradeProduct/ram:SellerAssignedID` (BT-155), which Dolibarr shows as **"Ref. fournisseur"** on the invoice line (`facture_fourn_det.ref` / `SupplierInvoiceLine::$ref_supplier`).

Result: the created supplier invoice line shows only the linked product's own label (and an empty description if the product has none) and no supplier reference — even though the XML carried both.

## Root cause
In `CIIProtocol::createSupplierInvoiceLinesFromSource()`:
- `$line->desc` was only set for **free lines** (no product) and for the **default-routing** catch-all product; for a normally matched/created product it was left unset, so the line fell back to the product's own (often empty) description.
- `$line->ref_supplier` was never set. The supplier price entry (`product_fournisseur_price.ref_fourn`) is created separately, but the per-line supplier reference was not.

## Fix
- Set `$line->ref_supplier` from `prodsellerid` for every line (skipping the `0000` placeholder).
- On a product-linked line, keep the XML line description (`proddesc`) instead of discarding it.

The module's own line insert (`createSupplierInvoiceLinesIntoDatabase`) already persists both `ref_supplier` and `desc`, so no other change is needed.

## Notes
- Applies to the CII protocol and therefore to Factur-X (which embeds the same CII XML).
- Backward-compatible: it only fills fields that were previously left empty; no behaviour change for lines that already had a description/ref.

