### PR TITLE
New: EINVOICING_PREFER_ORIGINAL — import issuer's Original (Factur-X) before Converted

### DIFF
--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2025       Laurent Destailleur         <eldy@users.sourceforge.net>
  * Copyright (C) 2025       Mohamed DAOUD               <mdaoud@dolicloud.com>
  * Copyright (C) 2026		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		Jose Martinez				<jose.martinez@pichinov.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -2446,7 +2447,12 @@ class SuperPDPProvider extends AbstractPDPProvider
 			'client_not_configured' => false
 		);
 
-		foreach (array('Converted', 'Original', 'ReadableView') as $docType) {
+		// EINVOICING_PREFER_ORIGINAL: fetch the issuer's Original document (its Factur-X, which carries
+		// the human-readable PDF) before the Converted one, so the created supplier invoice keeps the PDF.
+		$docTypeOrder = getDolGlobalString('EINVOICING_PREFER_ORIGINAL')
+			? array('Original', 'Converted', 'ReadableView')
+			: array('Converted', 'Original', 'ReadableView');
+		foreach ($docTypeOrder as $docType) {
 			$flowResponse = $this->fetchFlowData($flowId, $docType, 'get_flow_for_supplier_invoice');
 
 			if ($flowResponse['status_code'] != 200) {


### PR DESCRIPTION
# New: `EINVOICING_PREFER_ORIGINAL` — import the issuer's Original document (its Factur-X) instead of the Converted one

## Problem
On import, `SuperPDPProvider::fetchImportableFlowDocument()` fetches the flow documents in the order `Converted → Original → ReadableView` and imports the first readable one.

When the recipient's access-point account is configured to **convert** incoming invoices to CII, the `Converted` document is a CII XML — so even when the issuer sent a **Factur-X** (carrying the human-readable PDF), the created supplier invoice ends up with only the XML attached. `FacturXProtocol` already attaches the PDF as `<ref_supplier>_einvoice.pdf`, but the CII `Converted` document is imported first and that path is never reached.

## Fix
Add an opt-in constant **`EINVOICING_PREFER_ORIGINAL`**. When set, the fetch order becomes `Original → Converted → ReadableView`, so the issuer's **Original** document (its Factur-X, with the readable PDF) is imported when available. The existing "skip a document whose syntax is not supported and try the next" logic is unchanged, so a UBL-only `Original` still falls back to the `Converted` document.

Default behaviour is unchanged (`Converted` first).

## Tested (live SuperPDP flow)
Issuer sending Factur-X, recipient account converting to CII. With the constant set, the log shows:

```
fetchImportableFlowDocument No usable 'Converted' document for flowId ... reading the 'Original' one instead
FacturXProtocol::createSupplierInvoiceFromSource ...
```

and the created supplier invoice now carries `<ref>_einvoice.pdf` (the issuer's Factur-X, byte-for-byte the emitted file) instead of only the CII XML.

## Notes
- Backward-compatible, opt-in via a single constant.
- Lets a recipient keep the emitter's Factur-X PDF on the created supplier invoice without changing the access-point account's conversion syntax.

---
