### PR TITLE
FIX : generating two sample invoices in one request kills the request

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## 1.0.4
 
+FIX: Generating two Factur-X sample invoices in the same request no longer ends on a PHP fatal error.
+The generator loaded its helper file with require rather than require_once, so the second call
+redeclared its functions - and a fatal error is not something the calling code can catch and report.
+
 FIX: A down payment invoice now declares in BT-8 that its VAT falls due on collection, whatever the
 VAT mode of the instance, which is already why its cash-in is reported to the platform with the status
 212. Dolibarr builds every down payment line as a goods line, so the document used to say nothing at

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -888,7 +888,10 @@ class FacturXProtocol extends CIIProtocol
 		$outputlangs = $langs;		// TODO Use the target language
 		$outputlangs->load("einvoicing@einvoicing");
 
-		require __DIR__ . "/ExampleHelpers.php";
+		// require_once, not require: this file declares plain functions, so loading it a second time
+		// in the same PHP request is a fatal redeclare - which is what happens as soon as two samples
+		// are generated in one request, and a fatal error is not something the caller can catch.
+		require_once __DIR__ . "/ExampleHelpers.php";
 
 		$existingPdfFilename = __DIR__ . "/../../doc/00_ZugferdDocumentPdfBuilder_PrintLayout.pdf";
 		$newPdfFilename = $conf->einvoicing->dir_temp . "/INVTEST-".dol_print_date(dol_now(), '%y%m%d-%H%M%S').".pdf";


### PR DESCRIPTION
Noticed while working on #554, sent separately since it has nothing to do with it.

`FacturXProtocol::generateSampleInvoiceOld()` loads its helper file with `require`, not `require_once`:

```php
require __DIR__ . "/ExampleHelpers.php";
```

That file declares plain functions (`validationEnabled()`, and the KOSiT validator helpers next to it), so a second sample generated in the same PHP request redeclares them:

```
PHP Fatal error: Cannot redeclare function validationEnabled()
  (previously declared in einvoicing/class/protocols/ExampleHelpers.php:11)
  in einvoicing/class/protocols/ExampleHelpers.php on line 11
```

A fatal error is not something the calling code can catch and turn into a message, so the request stops there and the page comes back empty with nothing in the interface explaining why. One keyword fixes it.

## Tests

Reproduced and fixed for real on Dolibarr **18.0.10 / 20.0.4 / 23.0.3 / 24.0.0-beta** (PHP 8.4), by generating two Factur-X samples in one PHP process:

* before: first call succeeds, second one is the fatal above — on 18 and 23 alike;
* after: `call 1 : ok` / `call 2 : ok` on the four cores.

Non-regression on the same tree: the 9 unit test files, one process each, green on the four cores; a single sample generation still produces the same file, structurally complete (embedded XML, `/AF`, PDF/A-3 output intent, Factur-X XMP).
