### PR TITLE
FIX #549 : a replaced supplier invoice stayed open for payment

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -2,6 +2,13 @@
 
 ## 1.0.4
 
+FIX: Validating a replacement supplier invoice now closes the invoice it replaces, with the close
+code the core reserves for that, instead of leaving it validated and open for payment with nothing
+saying it had been superseded. Dolibarr does it on the customer side and not on the supplier one, so
+a replaced supplier e-invoice could still be paid a second time. Only the invoices exchanged through
+the platform are concerned; one that is already paid, or still a draft, is left untouched (issue
+#549).
+
 FIX: A down payment invoice now declares in BT-8 that its VAT falls due on collection, whatever the
 VAT mode of the instance, which is already why its cash-in is reported to the platform with the status
 212. Dolibarr builds every down payment line as a goods line, so the document used to say nothing at

--- a/einvoicing/class/helpers/SupplierInvoiceHelper.class.php
+++ b/einvoicing/class/helpers/SupplierInvoiceHelper.class.php
@@ -495,6 +495,72 @@ class SupplierInvoiceHelper
 	}
 
 	/**
+	 * Close the supplier invoice that a newly validated replacement invoice replaces.
+	 *
+	 * Dolibarr does this on the customer side - Facture::validate() cancels the replaced invoice with
+	 * the close code "replaced" - but FactureFournisseur::validate() does not, so a replaced supplier
+	 * invoice stayed validated, with nothing saying it had been superseded and nothing stopping it
+	 * from being paid a second time (issue #549).
+	 *
+	 * Scope. Only the invoices this module is responsible for are touched, i.e. those exchanged
+	 * through the platform: either the replacement or the invoice it replaces has to be an e-invoice.
+	 * A replacement recorded by hand between two ordinary supplier invoices is left to the core.
+	 *
+	 * Three states are deliberately left alone:
+	 * - a paid replaced invoice, because abandoning it would contradict the payment already recorded;
+	 * - a draft one, which cannot be paid nor transferred to accountancy anyway, and which validating
+	 *   just to cancel would give a reference it never earned;
+	 * - one already closed by this same rule, so the method is idempotent.
+	 *
+	 * @param	FactureFournisseur	$replacement	Replacement invoice that has just been validated
+	 * @param	User				$user			User validating it
+	 * @return	int									1 if the replaced invoice was closed, 0 if there was nothing to do, -1 on error
+	 */
+	public static function closeReplacedSupplierInvoice(FactureFournisseur $replacement, User $user)
+	{
+		global $db;
+
+		if ((int) $replacement->type !== FactureFournisseur::TYPE_REPLACEMENT || empty($replacement->fk_facture_source)) {
+			return 0;
+		}
+
+		$sourceId = (int) $replacement->fk_facture_source;
+
+		if (!self::isEInvoice((int) $replacement->id) && !self::isEInvoice($sourceId)) {
+			return 0;
+		}
+
+		$source = new FactureFournisseur($db);
+		if ($source->fetch($sourceId) <= 0) {
+			dol_syslog(__METHOD__ . ' Cannot load the supplier invoice id ' . $sourceId . ' replaced by id ' . $replacement->id, LOG_ERR, 0, '_einvoicing');
+			return -1;
+		}
+
+		if ($source->status == FactureFournisseur::STATUS_ABANDONED && $source->close_code == FactureFournisseur::CLOSECODE_REPLACED) {
+			return 0;
+		}
+
+		if (!empty($source->paid) || $source->status == FactureFournisseur::STATUS_CLOSED) {
+			dol_syslog(__METHOD__ . ' Supplier invoice id ' . $sourceId . ' is replaced by id ' . $replacement->id . ' but is already paid: left as it is', LOG_WARNING, 0, '_einvoicing');
+			return 0;
+		}
+
+		if ($source->status == FactureFournisseur::STATUS_DRAFT) {
+			dol_syslog(__METHOD__ . ' Supplier invoice id ' . $sourceId . ' is replaced by id ' . $replacement->id . ' but is still a draft: left as it is', LOG_INFO, 0, '_einvoicing');
+			return 0;
+		}
+
+		if ($source->setCanceled($user, FactureFournisseur::CLOSECODE_REPLACED, '') < 0) {
+			dol_syslog(__METHOD__ . ' Failed to close the supplier invoice id ' . $sourceId . ' replaced by id ' . $replacement->id . ' : ' . implode(', ', (array) $source->errors), LOG_ERR, 0, '_einvoicing');
+			return -1;
+		}
+
+		dol_syslog(__METHOD__ . ' Supplier invoice id ' . $sourceId . ' closed as replaced by id ' . $replacement->id, LOG_DEBUG, 0, '_einvoicing');
+
+		return 1;
+	}
+
+	/**
 	 * Callback to invoke once an outbound lifecycle status message has been validated (confirmed
 	 * or rejected by the e-invoicing platform). This is a no-op unless the message is a
 	 * confirmed ('Ok') refusal (EInvoicing::STATUS_REFUSED) of a supplier invoice, in which case

--- a/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
+++ b/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
@@ -290,6 +290,15 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 					return -1;
 				}
 			}
+
+			// A validated replacement invoice supersedes the one it replaces, which must not stay open
+			// for payment. The core does exactly that on the customer side and nothing on the supplier
+			// side, so a replaced supplier invoice used to keep every action of an ordinary one
+			// (issue #549). Never escalated to $this->errors: a failure here must not undo a validation
+			// the operator asked for, and the log carries the reason.
+			if (SupplierInvoiceHelper::closeReplacedSupplierInvoice($object, $user) > 0) {
+				setEventMessage($langs->trans("ModuleEInvoicingName") . ' : ' . $langs->trans('EInvoiceReplacedSupplierInvoiceClosed', $object->ref), 'mesgs');
+			}
 		}
 
 		// fr:211 (Paiement transmis) is what we, as the buyer, tell the vendor once we have paid one of

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -359,6 +359,7 @@ SupplierInvoiceComparisonVatRateNotFound=VAT rate of %s%% not found in the Dolib
 SupplierInvoiceComparisonSuggestVatCalculationMode=recalculate invoice using Mode %s to get VAT amounts corresponding to e-invoice
 EinvoicingCantDeleteADocumentLinkedToAnExistingSupplierInvoice=Document n° %s can't be deleted because it is linked to the Dolibarr supplier invoice n° %s
 EinvoicingCantDeleteASupplierInvoice=A supplier EInvoice can't be deleted. Please approve or reject this invoice
+EInvoiceReplacedSupplierInvoiceClosed=The supplier invoice replaced by %s has been closed as replaced, so it can no longer be paid.
 EinvoicingDuplicateDocumentForSupplierInvoice=Several e-invoicing documents were found for the supplier invoice %s. This should never happen and needs to be fixed in database before this invoice can be validated or deleted.
 EinvoicingCantDeleteATransmittedInvoice=You try to delete an invoice that is locked once the invoice has been transmitted to the Access Point
 EInvoiceSupplierInvoiceLinkedToOrder=The supplier invoice was automatically linked to purchase order %s (matching order reference BT-13).

--- a/einvoicing/test/phpunit/SupplierInvoiceHelperTest.php
+++ b/einvoicing/test/phpunit/SupplierInvoiceHelperTest.php
@@ -347,6 +347,186 @@ class SupplierInvoiceHelperTest extends CommonClassTest
 	}
 
 	/**
+	 * Build a replacement supplier invoice pointing at a source invoice.
+	 *
+	 * The type and the source are set on the object rather than written back: they are what the
+	 * validation trigger hands over, and what the helper reads to take its decision.
+	 *
+	 * @param	int	$sourceId	Id of the invoice it replaces
+	 * @return	FactureFournisseur
+	 */
+	private function createReplacementFor($sourceId)
+	{
+		$replacement = $this->createSpecimenSupplierInvoice();
+		$replacement->type = FactureFournisseur::TYPE_REPLACEMENT;
+		$replacement->fk_facture_source = $sourceId;
+
+		return $replacement;
+	}
+
+	/**
+	 * The invoice a replacement e-invoice replaces is closed with the close code the core reserves
+	 * for it, so the card stops offering to pay it (issue #549).
+	 *
+	 * @return void
+	 */
+	public function testReplacedEInvoiceIsClosed()
+	{
+		global $conf, $user, $langs, $db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		$source = $this->createSpecimenSupplierInvoice();
+		$this->addEInvoicingDocument($source->id);
+		$this->assertGreaterThan(0, $source->validate($user), $source->errorsToString());
+
+		$replacement = $this->createReplacementFor($source->id);
+
+		$this->assertEquals(1, SupplierInvoiceHelper::closeReplacedSupplierInvoice($replacement, $user));
+
+		$source->fetch($source->id);
+		$this->assertEquals(FactureFournisseur::STATUS_ABANDONED, $source->status);
+		$this->assertEquals(FactureFournisseur::CLOSECODE_REPLACED, $source->close_code);
+	}
+
+	/**
+	 * A replacement recorded between two ordinary supplier invoices is none of this module's
+	 * business and is left exactly as the core leaves it.
+	 *
+	 * @return void
+	 */
+	public function testReplacedPlainSupplierInvoiceIsLeftAlone()
+	{
+		global $conf, $user, $langs, $db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		$source = $this->createSpecimenSupplierInvoice();
+		$this->assertGreaterThan(0, $source->validate($user), $source->errorsToString());
+
+		$replacement = $this->createReplacementFor($source->id);
+
+		$this->assertEquals(0, SupplierInvoiceHelper::closeReplacedSupplierInvoice($replacement, $user));
+
+		$source->fetch($source->id);
+		$this->assertEquals(FactureFournisseur::STATUS_VALIDATED, $source->status);
+	}
+
+	/**
+	 * An invoice that has been paid is never closed: abandoning it would contradict the payment
+	 * already recorded against it.
+	 *
+	 * @return void
+	 */
+	public function testReplacedPaidInvoiceIsLeftAlone()
+	{
+		global $conf, $user, $langs, $db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		$source = $this->createSpecimenSupplierInvoice();
+		$this->addEInvoicingDocument($source->id);
+		$this->assertGreaterThan(0, $source->validate($user), $source->errorsToString());
+		$this->assertGreaterThan(0, $source->setPaid($user), $source->errorsToString());
+
+		$replacement = $this->createReplacementFor($source->id);
+
+		$this->assertEquals(0, SupplierInvoiceHelper::closeReplacedSupplierInvoice($replacement, $user));
+
+		$source->fetch($source->id);
+		$this->assertNotEquals(FactureFournisseur::STATUS_ABANDONED, $source->status);
+	}
+
+	/**
+	 * A draft cannot be paid nor transferred to accountancy, so it is left as it is rather than
+	 * being validated only to be cancelled.
+	 *
+	 * @return void
+	 */
+	public function testReplacedDraftInvoiceIsLeftAlone()
+	{
+		global $conf, $user, $langs, $db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		$source = $this->createSpecimenSupplierInvoice();
+		$this->addEInvoicingDocument($source->id);
+
+		$replacement = $this->createReplacementFor($source->id);
+
+		$this->assertEquals(0, SupplierInvoiceHelper::closeReplacedSupplierInvoice($replacement, $user));
+
+		$source->fetch($source->id);
+		$this->assertEquals(FactureFournisseur::STATUS_DRAFT, $source->status);
+	}
+
+	/**
+	 * An invoice that is not a replacement, or one with no source recorded, has nothing to close.
+	 *
+	 * @return void
+	 */
+	public function testNonReplacementInvoiceClosesNothing()
+	{
+		global $conf, $user, $langs, $db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		$source = $this->createSpecimenSupplierInvoice();
+		$this->addEInvoicingDocument($source->id);
+		$this->assertGreaterThan(0, $source->validate($user), $source->errorsToString());
+
+		// Standard type, even though it does carry a source.
+		$standard = $this->createSpecimenSupplierInvoice();
+		$standard->fk_facture_source = $source->id;
+		$this->assertEquals(0, SupplierInvoiceHelper::closeReplacedSupplierInvoice($standard, $user));
+
+		// Replacement type, but no source recorded.
+		$orphan = $this->createSpecimenSupplierInvoice();
+		$orphan->type = FactureFournisseur::TYPE_REPLACEMENT;
+		$this->assertEquals(0, SupplierInvoiceHelper::closeReplacedSupplierInvoice($orphan, $user));
+
+		$source->fetch($source->id);
+		$this->assertEquals(FactureFournisseur::STATUS_VALIDATED, $source->status);
+	}
+
+	/**
+	 * Closing the same replaced invoice a second time changes nothing.
+	 *
+	 * @return void
+	 */
+	public function testCloseReplacedIsIdempotent()
+	{
+		global $conf, $user, $langs, $db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		$source = $this->createSpecimenSupplierInvoice();
+		$this->addEInvoicingDocument($source->id);
+		$this->assertGreaterThan(0, $source->validate($user), $source->errorsToString());
+
+		$replacement = $this->createReplacementFor($source->id);
+
+		$this->assertEquals(1, SupplierInvoiceHelper::closeReplacedSupplierInvoice($replacement, $user));
+		$this->assertEquals(0, SupplierInvoiceHelper::closeReplacedSupplierInvoice($replacement, $user));
+
+		$source->fetch($source->id);
+		$this->assertEquals(FactureFournisseur::STATUS_ABANDONED, $source->status);
+		$this->assertEquals(FactureFournisseur::CLOSECODE_REPLACED, $source->close_code);
+	}
+
+	/**
 	 * A 'Pending' validation status is not a confirmation: it must never trigger the abandon.
 	 *
 	 * @return void


### PR DESCRIPTION
Fixes #549. Thanks @camlafit — reproduced, and the payment part is the one that bites.

## What was wrong

Validating a replacement supplier invoice left the invoice it replaces exactly as it was: still validated, no close code, and every action of an ordinary invoice. Reproduced on Dolibarr 23.0.3 on `main`, on a real pair built through the real objects:

```
replaced invoice : status=1 close_code=NULL
pay              : ACCEPTED
delete           : refused (A supplier EInvoice can't be deleted...)
```

So of your three points:

* **paying it** — the real problem. The card shows the "Make payment" button because it only tests `status == STATUS_VALIDATED && paid == 0`, and nothing had changed that status. The amount can be paid twice, once on the replaced invoice and once on the replacement that claims it as well.
* **deleting it** — already refused for an invoice received through the platform, by the `BILL_SUPPLIER_DELETE` guard, with the message quoted above. The button stays visible, the operation does not go through. (On an ordinary supplier invoice deletion does go through and leaves `fk_facture_source` pointing at a row that no longer exists, but that is core territory, see below.)
* **approving it** — a supplier invoice has no approval step beyond validation, and once closed it is not re-openable either: the card already refuses `ReOpen` when `close_code == 'replaced'`.

## Where the gap really is

Dolibarr does the right thing on the customer side: `Facture::validate()` cancels the replaced invoice with `CLOSECODE_REPLACED`. `FactureFournisseur::validate()` does nothing of the sort, so the supplier side was left with a link and no consequence.

And the core supplier card *already reads that value*: `fourn/facture/card.php` disables `ReOpen` and `MakeBankTransferOrder` on `close_code != 'replaced'`. The close code was simply never set. This PR sets it — nothing new is invented, the value the core is already looking for is finally there.

## Scope

Only the invoices this module is responsible for: either the replacement or the invoice it replaces has to be an e-invoice. A replacement recorded by hand between two ordinary supplier invoices keeps exactly the behaviour it has today, because that is a core question, not a module one — the same one that also lets such an invoice be deleted out from under its replacement.

Three states are left alone on purpose:

* an already paid invoice, because abandoning it would contradict the payment recorded against it;
* a draft, which cannot be paid nor transferred to accountancy, and which validating only to cancel would give a reference it never earned;
* one already closed by this rule, so a second call changes nothing.

Say the word if you would rather have it apply to every supplier invoice — or, better, have it in `FactureFournisseur::validate()` where the customer side has it, in which case this becomes a core patch and the module keeps nothing.

## Tests

Run for real on Dolibarr **18.0.10 / 20.0.4 / 23.0.3 / 24.0.0-beta**, PHP 8.4.

**Bench, five scenarios × four cores**, each building a real source/replacement pair through the real objects so the real triggers fire:

| scenario | replaced invoice, before | replaced invoice, after |
|---|---|---|
| replacement of an e-invoice | `status=1 close_code=NULL`, payable | `status=3 close_code='replaced'` |
| ordinary pair, no e-invoice | `status=1 close_code=NULL` | unchanged |
| replaced invoice already paid | `status=2` | unchanged |
| replaced invoice still a draft | `status=0` | unchanged |
| helper called twice | — | second call returns 0, nothing changes |

Identical on the four cores.

**What the card offers**, evaluated on the closed invoice with the core's own conditions:

```
invoice 221 status=3 close_code='replaced' replaced_by='222'
  DoPayment button      : hidden
  ReOpen button         : hidden/refused
  BankTransferOrder     : hidden/refused
```

**End to end through the platform**, which is the scenario of the issue:

1. Dolibarr 18 issues an invoice, sends it, Dolibarr 23 imports it as a supplier invoice and validates it;
2. Dolibarr 18 issues the **replacement** of that invoice and sends it;
3. Dolibarr 23 imports it: `type=1`, `fk_facture_source=221` — the link is recorded;
4. validating that replacement closes the source: `status=3 close_code='replaced'`.

**Unit tests**: six cases added to `SupplierInvoiceHelperTest` (closed, ordinary pair untouched, paid untouched, draft untouched, non-replacement closes nothing, idempotence). The whole suite — 9 files, one PHP process each — is green on the four cores, before and after.
