### PR TITLE
FIX : three phpcs exclude-patterns silently exclude the whole checkout

### DIFF
--- a/dev/setup/codesniffer/ruleset.xml
+++ b/dev/setup/codesniffer/ruleset.xml
@@ -7,17 +7,20 @@
 
 	<!-- info: '*' is replaced with '.*', so better use '+' in some cases -->
 	<!-- info: 'relative' paths are relative to the examined file, so not ok. -->
+	<!-- WARNING: a pattern is a regex matched CASE-INSENSITIVELY against the ABSOLUTE path of every
+	     file (PHP_CodeSniffer\Filters\Filter::shouldIgnorePath), not against its path in the
+	     repository. A pattern naming a common directory therefore excludes the whole checkout of
+	     anyone who happens to keep it under a directory of that name, silently: phpcs reports
+	     nothing and exits 0, which is indistinguishable from a clean run. Keep them specific
+	     enough that they cannot match anything but what they are meant to. -->
 	<exclude-pattern>/dev/build/(html|aps)/</exclude-pattern>
 	<exclude-pattern>/dev/tools/test/namespacemig/</exclude-pattern>
 	<exclude-pattern>/dev/tools/phan/stubs/</exclude-pattern>
 	<!-- <exclude-pattern>dev/initdata/dbf/includes</exclude-pattern> -->
-	<exclude-pattern>/documents/</exclude-pattern>
 	<exclude-pattern>/htdocs/core/class/lessc\.class\.php</exclude-pattern>
-	<exclude-pattern>/htdocs/(custom|includes)/</exclude-pattern>
 	<exclude-pattern>/htdocs/install/doctemplates/websites</exclude-pattern>
 	<exclude-pattern>/htdocs/([^/]+/)?conf\.php</exclude-pattern>
 	<exclude-pattern>*/nltechno*</exclude-pattern>
-	<exclude-pattern>/source/</exclude-pattern>
 	<exclude-pattern>/\.git/</exclude-pattern>
 	<exclude-pattern>/\.cache/</exclude-pattern>
 


### PR DESCRIPTION
Found the hard way: `phpcs` on my machine reported nothing on files the CI then failed on. It was not checking anything at all, and had not been for a long time.

## The mechanism

A phpcs `exclude-pattern` is a regex matched **case-insensitively** against the **absolute** path of every file — `PHP_CodeSniffer\Filters\Filter::shouldIgnorePath()`:

```php
$testPath = $path;              // absolute, unless type="relative"
$pattern  = '`'.$pattern.'`i';  // note the i
if (preg_match($pattern, $testPath) === 1) { return true; }
```

So `<exclude-pattern>/documents/</exclude-pattern>` does not mean "the `documents/` directory of the repository". It means "any path containing a `documents` segment, whatever the case". My clone lives in `~/Documents/dolibarr-community-modules`, so **every file of the repository was excluded**. phpcs then prints no report and exits 0, which is exactly what a clean run looks like:

```
$ phpcs -v --standard=dev/setup/codesniffer/ruleset.xml einvoicing/class/utils/Some.php
Creating file list... DONE (0 files in queue)
$ echo $?
0
```

`~/Documents` is the default document directory of most desktops, so this is not a corner case. The same file, moved one directory sideways:

| path of the file | files analysed |
|---|---|
| `…/Docsother/P.php` | 1 → 3 errors |
| `…/MesDocuments/P.php` | 1 → 3 errors |
| `…/Documents/P.php` | **0** |
| `…/source/P.php` | **0** |
| `…/htdocs/custom/einvoicing/P.php` | **0** |

The last line is worth noting on its own: a module of this repository is *meant* to live in `htdocs/custom/<module>`, and linting it there checks nothing.

## What this changes

The three patterns that can swallow a whole checkout — `/documents/`, `/source/`, `/htdocs/(custom|includes)/` — have no target in **this** repository: there is no `documents/`, no `source/` and no `htdocs/` here. They came along with the ruleset copied from the core. Removing them costs nothing and gives the developers back a lint that looks at their code.

The other patterns are specific enough to keep (`/dev/tools/phan/stubs/`, `/htdocs/core/class/lessc.class.php`, …), and a comment above them now states the absolute, case-insensitive matching so the next one is written with it in mind.

The comment already there — *"'relative' paths are relative to the examined file, so not ok"* — is the reason `type="relative"` is not used instead, and it is right for a per-file invocation, which is what a developer does. Removing the dead patterns solves it without that trade-off.

## Test

Same command as the CI workflow, run from a checkout **outside** any trapped path so the comparison is meaningful:

```
phpcs -v --standard=dev/setup/codesniffer/ruleset.xml --extensions=php \
      --ignore='*/tx/*,*/vendor/*,dev/tools/phan/*' .
```

| ruleset | files analysed |
|---|---|
| `main` | 82 |
| this PR | 82 |

Same file list, so the CI result is unchanged by construction. And on the trapped paths, `0 files in queue` becomes `1` for the three cases of the table above.
