### PR TITLE
feat(einvoicing): add BT-25/BT-26 reference to preceding situation invoice

### DIFF
--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -303,6 +303,28 @@ if ($refDocTypeCode !== '' && !empty($object->fk_facture_source)) {
 	}
 }
 
+// Situation invoice: BT-25/BT-26 — reference to the immediately preceding situation invoice.
+// XP Z12-012 requires each situation invoice (counter > 1) to carry the reference of the previous
+// one in the same cycle so the receiver can reconstruct the chain and verify the cumulated amounts.
+// The first situation (counter = 1) has no predecessor and no BG-3 block.
+if ($object->type == $object::TYPE_SITUATION && !empty($object->situation_counter) && $object->situation_counter > 1 && !empty($object->situation_cycle_ref)) {
+	$object->fetchPreviousNextSituationInvoice();
+	if (!empty($object->tab_previous_situation_invoice)) {
+		// tab_previous_situation_invoice is ordered ASC by situation_counter: last element is the immediate predecessor
+		$prevSituation = end($object->tab_previous_situation_invoice);
+		reset($object->tab_previous_situation_invoice);
+		if ($prevSituation && !empty($prevSituation->ref)) {
+			$prevSituationDate = new DateTime(dol_print_date($prevSituation->date, 'dayrfc'));
+			$invoiceRefDocs[] = [
+				'ref'  => $prevSituation->ref,
+				'date' => $prevSituationDate,
+				'type' => '380'		// Situation invoices are transmitted as standard invoices (380)
+			];
+			dol_syslog(get_class($this) . '::generateXML Set preceding situation invoice reference ' . $prevSituation->ref . ' for situation invoice ' . $object->ref);
+		}
+	}
+}
+
 // Collect lines into $linesData array
 $linesData         	= [];
 $taxBreakdown		= [];


### PR DESCRIPTION
## Summary

Situation invoices (Dolibarr `TYPE_SITUATION = 5`) in a construction/services contract are transmitted as standard invoices (type code `380`) per AFNOR XP Z12-012. However, each invoice in the chain must carry a reference to the immediately preceding situation invoice (BT-25/BT-26 — `InvoiceReferencedDocument`) so that the receiver can reconstruct the chain and verify cumulated amounts.

This PR implements that requirement in `buildinvoicelines.inc.php`.

## Changes

**`lib/buildinvoicelines.inc.php`**

- Added a BG-3 block (BT-25 / BT-26) for situation invoices with `situation_counter > 1`.
- Uses `fetchPreviousNextSituationInvoice()` to load the full invoice chain ordered ASC by `situation_counter`; the last element is the immediate predecessor.
- The first situation invoice (`situation_counter = 1`) has no predecessor and no BG-3 block is emitted.
- The referenced invoice type code is `380` (situation invoices are always standard invoices).

## Standard reference

Per **AFNOR PR XP Z12-012** AND **AFNOR PR XP Z12-014**(June 30, 2026), situation invoices are transmitted as type `380`. The standard does not define any dedicated line-level "progress rate" or "cumulated amount" fields.
