### PR TITLE
FIX: on a Dolibarr 23 pre-release the access token is stored in one place and read from another

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -2,6 +2,13 @@
 
 ## 1.0.4
 
+FIX: On a Dolibarr 23 pre-release, the access token obtained from the Access point was stored in one
+place and looked for in another, so every call re-authenticated and the stored row was never cleaned.
+The three sites that pick between the llx_oauth_token columns added in 23 and the constants used
+before did not use the same bound: the writer compared against '23.0.0-alpha' and the reader and the
+delete against '23.0.0', and version_compare() orders a pre-release below its release. All three
+compare against '23.0.0' now. Released versions were never affected.
+
 FIX: Generating two Factur-X sample invoices in the same request no longer ends on a PHP fatal error.
 The generator loaded its helper file with require rather than require_once, so the second call
 redeclared its functions - and a fatal error is not something the calling code can catch and report.

--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -472,8 +472,12 @@ abstract class AbstractPDPProvider
 		// Build service name depending on environment
 		$serviceName = $this->config['dol_prefix'] . '_' . ($this->config['live'] ? 'PROD' : 'TEST');
 
-		// For backward compatibility with Dolibarr versions < 23.0.0
-		if (version_compare(DOL_VERSION, '23.0.0-alpha', '<')) {
+		// For backward compatibility with Dolibarr versions < 23.0.0.
+		// The bound is '23.0.0' and not '23.0.0-alpha': version_compare() orders a pre-release below
+		// its release, so the two readers below - which compare against '23.0.0' - take the constants
+		// branch on a 23.0.0-alpha or -beta while this writer would take the table one, and the token
+		// just written would never be found again.
+		if (version_compare(DOL_VERSION, '23.0.0', '<')) {
 			dolibarr_set_const($db, $serviceName.'_TOKEN', $accessToken, 'chaine', 0, '', $conf->entity);
 
 			if ($refreshToken !== null) {


### PR DESCRIPTION
Second finding of the same audit as #566: every `DOL_VERSION` branch of the module read against the core sources of 17 to 24.

## What is wrong

Three sites pick between the `llx_oauth_token` columns that arrive in Dolibarr 23 and the constants used before. They do not use the same bound:

| method | bound |
|---|---|
| `storeAccessToken()` | `'23.0.0-alpha'` |
| `loadAccessToken()` | `'23.0.0'` |
| `deleteAccessToken()` | `'23.0.0'` |

`version_compare()` orders a pre-release below its release:

```
version_compare('23.0.0-alpha', '23.0.0-alpha', '<') = false   -> writer takes the table branch
version_compare('23.0.0-alpha', '23.0.0',       '<') = true    -> reader takes the constants branch
version_compare('23.0.0-beta',  '23.0.0',       '<') = true    -> same
```

So on a **23.0.0-alpha or 23.0.0-beta**, the token is written into `llx_oauth_token` and then looked for in the constants of the previous scheme. It is never found, the provider re-authenticates on every call, and the row it wrote is never deleted either since `deleteAccessToken()` also clears the constants.

The columns themselves are not the issue — checked in `install/mysql/tables/llx_oauth_token.sql`, `tokenstring_refresh` and `expire_at` do appear in 23 and are absent in 17 through 22 — so `< 23.0.0` is the right bound. It is only the pre-release form that made the three disagree.

## What this does

All three compare against `'23.0.0'`.

## Scope

Released versions never took the two branches apart, so nothing changes for them, and there is nothing to observe on the bench instances (17 through 22 use the constants on both sides, 23 and 24 use the table on both sides). What can be shown is the ordering that causes it, which is the three `version_compare()` results quoted above.

`phpcs` clean.
