### PR TITLE
FIX: the module can neither be installed nor generate a document on Dolibarr 17

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -2,6 +2,15 @@
 
 ## 1.0.4
 
+FIX: The module works on Dolibarr 17 again, the version its own descriptor declares as the minimum it
+supports. Two things stood in the way and neither of them failed quietly. Installing it died on a PHP
+TypeError: init() passed an empty array() where ExtraFields::update() expects a parameter string, and
+the branch that tolerates an empty array was only added to the core in 18, so activateModule() never
+completed. Generating a document died on "Call to undefined function dolChmod()", that helper having
+arrived in the core in 18 as well, while both writers call it on the XML they have just produced. The
+first is passed as '' now, which stores the same thing everywhere, and the second is supplied by a
+compat file alongside the two the module already ships for that version.
+
 FIX: Generating two Factur-X sample invoices in the same request no longer ends on a PHP fatal error.
 The generator loaded its helper file with require rather than require_once, so the second call
 redeclared its functions - and a fatal error is not something the calling code can catch and report.

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -34,6 +34,10 @@ require_once DOL_DOCUMENT_ROOT . '/core/class/translate.class.php';
 require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/class/discount.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
+// dolChmod() only exists from Dolibarr 18, and both writers call it on the XML they just produced.
+if ((float) DOL_VERSION < 18) {
+	dol_include_once('/einvoicing/compat/files.lib.php');
+}
 
 dol_include_once('einvoicing/class/protocols/AbstractProtocol.class.php');
 dol_include_once('einvoicing/class/protocols/CommonProtocol.class.php');

--- a/einvoicing/compat/files.lib.php
+++ b/einvoicing/compat/files.lib.php
@@ -1,0 +1,50 @@
+<?php
+/* Copyright (C) 2006-2011	Laurent Destailleur		<eldy@users.sourceforge.net>
+ * Copyright (C) 2026		Pierre Grasswill		<da.grumpf@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *  \file		einvoicing/compat/files.lib.php
+ *  \ingroup	einvoicing
+ *  \brief		Core file helpers this module uses and that Dolibarr 17 does not ship yet
+ */
+
+// @phan-file-suppress PhanRedefineFunction
+
+if (!function_exists('dolChmod')) {
+	/**
+	 *	Change mod of a file
+	 *
+	 *  Copy of the function added to htdocs/core/lib/functions.lib.php in Dolibarr 18, kept identical
+	 *  so a file written on 17 gets exactly the permissions it would get anywhere else.
+	 *
+	 *  @param	string		$filepath		Full file path
+	 *  @param	string		$newmask		Force new mask. For example '0644'
+	 *	@return void
+	 *  @since	Dolibarr V18
+	 */
+	function dolChmod($filepath, $newmask = '')
+	{
+		global $conf;
+
+		if (!empty($newmask)) {
+			@chmod($filepath, octdec($newmask));
+		} elseif (getDolGlobalString('MAIN_UMASK')) {
+			@chmod($filepath, octdec(getDolGlobalString('MAIN_UMASK')));
+		}
+	}
+}

--- a/einvoicing/core/modules/modEInvoicing.class.php
+++ b/einvoicing/core/modules/modEInvoicing.class.php
@@ -674,7 +674,11 @@ class modEInvoicing extends DolibarrModules
 			0, //$unique
 			0, //$required
 			95032, //$pos
-			array(), //$param
+			// '' and not array(): the empty array is only tolerated from Dolibarr 18, which added an
+			// "elseif (is_array($param))" branch to ExtraFields::update_label(). On 17 an empty array
+			// falls through to strlen($param) and kills the whole module installation on PHP 8. Both
+			// forms store exactly the same thing - an empty parameter string - on every version.
+			'', //$param
 			1, //$alwayseditable
 			'', //$perms
 			'1', //$list

--- a/einvoicing/core/modules/modEInvoicing.class.php
+++ b/einvoicing/core/modules/modEInvoicing.class.php
@@ -665,8 +665,14 @@ class modEInvoicing extends DolibarrModules
 		);
 
 		// Update extrafield par rapport au module openDSI, il faut pouvoir éditer le champ ChorusId
+		// The $param below is '' and not array(): the empty array is only tolerated from Dolibarr 18,
+		// which added an "elseif (is_array($param))" branch to ExtraFields::update_label(). On 17 an
+		// empty array falls through to strlen($param) and kills the whole module installation on PHP 8.
+		// Both forms store exactly the same thing - an empty parameter string - on every version, and
+		// the parameter was itself declared as '' up to 19 before becoming array() in 20, which is the
+		// signature the phan stub carries and the reason for the suppression.
 		$result = $extrafields->update(
-			'd4d_chorus_id', //$attrname
+			'd4d_chorus_id', //$attrname	// @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
 			$langs->trans('ChorusId'), //$label
 			'varchar', //$type
 			'36', //$length
@@ -674,10 +680,6 @@ class modEInvoicing extends DolibarrModules
 			0, //$unique
 			0, //$required
 			95032, //$pos
-			// '' and not array(): the empty array is only tolerated from Dolibarr 18, which added an
-			// "elseif (is_array($param))" branch to ExtraFields::update_label(). On 17 an empty array
-			// falls through to strlen($param) and kills the whole module installation on PHP 8. Both
-			// forms store exactly the same thing - an empty parameter string - on every version.
 			'', //$param
 			1, //$alwayseditable
 			'', //$perms


### PR DESCRIPTION
Third finding of an audit of every `DOL_VERSION` branch of the module against the core sources of 17 to 24 (see also #566). This one is not a threshold that is off by a version: **the module does not work at all on Dolibarr 17**, which `modEInvoicing` declares as the version it supports:

```php
$this->need_dolibarr_version = array(17, -3);
```

Two independent failures, neither of them quiet.

## 1. It cannot be installed

```
PHP Fatal error: Uncaught TypeError: strlen(): Argument #1 ($string) must be of type string,
array given in htdocs/core/class/extrafields.class.php:728
#0 extrafields.class.php(620): ExtraFields->update_label()
#1 einvoicing/core/modules/modEInvoicing.class.php(668): ExtraFields->update()
#2 htdocs/core/lib/admin.lib.php(1151): modEInvoicing->init()
```

`init()` passes an empty `array()` as the `$param` of `ExtraFields::update()` for `d4d_chorus_id`. `update_label()` sorts that argument out like this — Dolibarr 18:

```php
if (is_array($param) && count($param) > 0) {   $params = serialize($param);
} elseif (is_array($param)) {                  $params = '';          // <- added in 18
} elseif (strlen($param) > 0) {                $params = trim($param);
```

The middle branch is what tolerates an **empty** array, and 17 does not have it: `count()` is 0, so an empty array falls straight through to `strlen($param)` and PHP 8 raises a TypeError. It escapes `init()`, `activateModule()` dies, and the module can never be enabled.

Passing `''` stores exactly the same thing — an empty parameter string — on every version. The other calls in that file pass a non-empty array, which `count($param) > 0` sends to `serialize()` on 17 as well, so they were never concerned.

## 2. It cannot generate a document

```
Error: Call to undefined function dolChmod()
  einvoicing/class/protocols/CIIProtocol.class.php:521
```

`dolChmod()` arrived in `core/lib/functions.lib.php` in Dolibarr 18. Both writers call it on the XML they have just produced, so on 17 nothing could be generated at all.

It is polyfilled the way this module already polyfills `profid.lib.php` (< 20) and `commonhookactions.class.php` (< 19): a compat file loaded only below the version that ships it, holding a copy of the core function so a file written on 17 gets the same permissions it would get anywhere else.

## Tests

The bench now carries **one instance per version, 17 through 24** — 17.0.4, 18.0.10, 19.0.4, 20.0.4, 21.0.4, 22.0.5, 23.0.3 and 24.0.0-beta — so this is measured on every supported core rather than on a sample of them.

**Reproduction, then proof** — the module disabled on the 17.0.4 instance, then enabled twice:

| code | result |
|---|---|
| `main` | `Uncaught TypeError: strlen()` … module not enabled |
| this branch | `MAIN_MODULE_EINVOICING='1'` |

**Unit suite, 9 test files per instance, one PHP process each:**

| | 17.0.4 | 18.0.10 | 19.0.4 | 20.0.4 | 21.0.4 | 22.0.5 | 23.0.3 | 24.0.0-beta |
|---|---|---|---|---|---|---|---|---|
| before | install fails | 9/9 | 9/9 | 9/9 | 9/9 | 9/9 | 9/9 | 9/9 |
| after | **9/9** | 9/9 | 9/9 | 9/9 | 9/9 | 9/9 | 9/9 | 9/9 |

`EInvoicingSamplesTest` is the one that matters for the second failure: it generates the sample documents through `CIIProtocol::generateXML()` and compares them to the reference fixtures. It was dying on `dolChmod()` at generation time on 17 and passes there now, with the same fixtures as the other seven versions.

Nothing changes on 18 and above: the polyfill is behind `function_exists()` and only loaded below 18, and `''` and `array()` are stored identically from 18 on.

`phpcs` clean.
