### PR TITLE
FIX: a failed e-invoice generation kills the request on Dolibarr 17-20, and is a red error on 23

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -2,6 +2,14 @@
 
 ## 1.0.4
 
+FIX: On Dolibarr 23, a failed e-invoice generation was reported as an error where the core was able to
+carry it as a warning, so validating an invoice showed a red message for something that does not stop
+the validation. The module kept everything as an error below 24, but the chain a hook needs to report
+a warning - HookManager collecting the warnings of the hook instance, the document generator copying
+them, and commonGenerateDocument() copying them onto the object - is whole in 23 and absent in 22. The
+bound is 23 now. Nothing changes on 22 and below, where the warning would be reported nowhere, nor on
+24 and above.
+
 FIX: Generating two Factur-X sample invoices in the same request no longer ends on a PHP fatal error.
 The generator loaded its helper file with require rather than require_once, so the second call
 redeclared its functions - and a fatal error is not something the calling code can catch and report.

--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -214,9 +214,14 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 								return -1;
 							} else {
 								if ($result < 0) {
-									if ((float) DOL_VERSION < 24.0) {
+									// A hook can only report a warning where the core carries one back. That chain -
+									// HookManager collecting $actionclassinstance->warnings, the document generator
+									// copying $hookmanager->warnings, and commonGenerateDocument() copying $obj->warnings
+									// onto the object - appears whole in Dolibarr 23 and is absent in 22. Below it the
+									// warning would be reported nowhere, so the failure is raised as an error instead.
+									if ((float) DOL_VERSION < 23) {
 										$this->errors = array_merge($this->errors, $protocol->errors);
-										$this->warnings = array();	// We remove warning array to keep only the error array, because only errors array is managed with version < 24.0 of Dolibarr.
+										$this->warnings = array();
 									} else {
 										$this->warnings = array_merge($this->errors, $protocol->errors);	// We want to return the error as a warning.
 									}

--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -39,6 +39,22 @@ dol_include_once('/einvoicing/class/providers/PDPProviderManager.class.php');
 class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-line PhanRedefinedExtendedClass
 {
 	/**
+	 * @var string[] Errors the hook reports back to whoever executed it.
+	 *
+	 * Declared here rather than relied upon from the parent: CommonHookActions only declares ->errors
+	 * from Dolibarr 21 and ->warnings from 23, and the compat class this module ships for the versions
+	 * before 19 declares neither. Writing to an undeclared property is a deprecation on PHP 8.2, and
+	 * reading one back into array_merge() is a fatal TypeError - which is what a failed generation did
+	 * on 17 to 20.
+	 */
+	public $errors = array();
+
+	/**
+	 * @var string[] Warnings the hook reports back, on the versions whose core carries them
+	 */
+	public $warnings = array();
+
+	/**
 	 * systemMessage
 	 *
 	 * @param array<string,mixed> 	$parameters		Array of parameters


### PR DESCRIPTION
Fourth finding of the audit of every `DOL_VERSION` branch of the module against the core sources of 17 to 24 (see #566 and #568). It started as a threshold that was one version late and turned out to sit on top of a fatal error on half the supported versions.

## 1. A failed generation kills the request on Dolibarr 17 to 20

When `generateInvoice()` fails and `EINVOICING_EINVOICE_CANCEL_IF_EINVOICE_FAILS` is off, the hook reports the failure through `$this->errors` / `$this->warnings`. It declares neither, and the parent does not always have them:

| Dolibarr | `CommonHookActions::$errors` | `::$warnings` |
|---|---|---|
| 17 / 18 (the compat class this module ships) | **absent** | absent |
| 19 / 20 | **absent** | absent |
| 21 / 22 | present | absent |
| 23 / 24 | present | present |

So on **17, 18, 19 and 20** the hook reached `array_merge($this->errors, ...)` with an undeclared property:

```
PHP Warning:  Undefined property: ActionsEInvoicing::$errors
PHP Fatal error: Uncaught TypeError: array_merge(): Argument #1 must be of type array, null given
    at einvoicing/class/actions_einvoicing.class.php:218
```

The request dies instead of reporting anything — on half the versions the module claims to support. On 21 and 22 it worked, but `$this->warnings` was created as a dynamic property, deprecated since PHP 8.2.

Both are declared on the class now, which owes nothing to what the parent happens to have.

## 2. The warning threshold is 23, not 24

With that out of the way, the branch underneath is one version late:

```php
if ((float) DOL_VERSION < 24.0) {
    $this->errors = array_merge($this->errors, $protocol->errors);
    $this->warnings = array();  // only errors array is managed with version < 24.0 of Dolibarr
```

The chain a hook needs for a warning to reach the screen is whole in **23**:

* `HookManager::executeHooks()` collects `$actionclassinstance->warnings` into `$hookmanager->warnings` — in 23 and 24, absent in 22;
* the invoice document generators (`pdf_sponge`, `pdf_crabe`) copy `$hookmanager->warnings` onto themselves — in 23 and 24, absent in 22;
* `commonGenerateDocument()` copies `$obj->warnings` onto the object — in 23 and 24, absent in 22.

So on 23 the module was throwing away a warning the core would have displayed, and raising a red error for something that does not stop the validation. The bound is 23 now. Below it the error is kept, because there the warning would be reported nowhere.

## Tests

Measured on the bench, **one instance per supported version, 17 through 24**. The probe builds an invoice whose Factur-X carrier cannot be read — the branch under test — calls the hook the way the PDF generation does, and prints both arrays of the hook instance:

| Dolibarr | before | after |
|---|---|---|
| 17.0.4 | *(blocked earlier, see #568)* | error reported |
| 18.0.10 | **fatal TypeError** | error reported |
| 19.0.4 | **fatal TypeError** | error reported |
| 20.0.4 | **fatal TypeError** | error reported |
| 21.0.4 | error reported | error reported |
| 22.0.5 | error reported | error reported |
| 23.0.3 | **error reported** | **warning reported** |
| 24.0.0-beta | warning reported | warning reported |

17 is the one line that needs #568 as well: without it the generation dies earlier, on `dolChmod()`. With both branches applied it reports the error like 18 does — measured, not assumed.

Unit suite green on every instance from 18 to 24, 9 test files each, one PHP process per file. `phpcs` clean.
