### PR TITLE
FIX #565 : the compat polyfills are looked up through dol_buildpath(), and a lookup that fails is silent

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -2,6 +2,12 @@
 
 ## 1.0.4
 
+FIX: The compatibility files the module ships for the older cores are loaded from a path relative to
+the file that needs them, instead of being looked up through dol_buildpath(). A lookup that does not
+resolve - a deployment that does not sit where the module expects, which is what a container install
+can produce - only wrote a line in the log and returned false, so the polyfill was silently absent and
+the next call to it was a fatal "Call to undefined function isValidSiren" (issue #565).
+
 FIX: Generating two Factur-X sample invoices in the same request no longer ends on a PHP fatal error.
 The generator loaded its helper file with require rather than require_once, so the second call
 redeclared its functions - and a fatal error is not something the calling code can catch and report.

--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -25,7 +25,9 @@
  */
 
 if ((float) DOL_VERSION < 19) {
-	dol_include_once('/einvoicing/compat/commonhookactions.class.php');
+	// Relative to this file rather than through dol_buildpath(), for the reason given in
+	// einvoicing.class.php: a resolution that fails is silent, and the class would just be missing.
+	require_once __DIR__ . '/../compat/commonhookactions.class.php';
 } else {
 	require_once DOL_DOCUMENT_ROOT . '/core/class/commonhookactions.class.php';
 }

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -25,7 +25,11 @@
  */
 
 if ((float) DOL_VERSION < 20) {
-	dol_include_once('/einvoicing/compat/profid.lib.php');
+	// require_once on a path relative to this file, not dol_include_once: the latter resolves the
+	// module through dol_buildpath() and, when that resolution fails, only writes a line in the log
+	// and returns false. The polyfill was then simply absent and the first isValidSiren() below was
+	// a fatal "Call to undefined function" (issue #565). The compat directory sits next to this one.
+	require_once __DIR__ . '/../compat/profid.lib.php';
 } else {
 	require_once DOL_DOCUMENT_ROOT . '/core/lib/profid.lib.php';
 }


### PR DESCRIPTION
Fixes #565. Thanks @baptistereb — the polyfill you had to write by hand does exist in the module, it was just never loaded on your install.

## What is wrong

`isValidSiren()` and its siblings arrived in the core in Dolibarr 20 (`core/lib/profid.lib.php`), so the module ships its own copy for the versions before that and picks between the two:

```php
if ((float) DOL_VERSION < 20) {
    dol_include_once('/einvoicing/compat/profid.lib.php');
} else {
    require_once DOL_DOCUMENT_ROOT . '/core/lib/profid.lib.php';
}
```

`dol_include_once()` resolves the path through `dol_buildpath()`, and when that resolution fails it does this and nothing else:

```php
if (!file_exists($fullpath)) {
    dol_syslog('functions::dol_include_once Tried to load unexisting file: '.$relpath, LOG_WARNING);
    return false;
}
```

A line in `dolibarr.log`, `false` returned, no error raised. The polyfill is then simply absent, and the first call a few hundred lines below — `validatethirdpartyConfiguration()` checking a SIREN — is fatal. Which is exactly what you saw, and why mocking the function made it go away.

Whether `dol_buildpath()` resolves depends on where the instance is deployed and on `$dolibarr_main_document_root_alt`, which is why this bites in a container and not on a plain install.

## What this does

Both compat files sit next to the files that include them, so they are required from a path relative to those, which cannot fail quietly:

```php
require_once __DIR__ . '/../compat/profid.lib.php';
```

That is already how `einvoicing.class.php` is required a few lines below in the same file. The same change is made for `compat/commonhookactions.class.php`, included the same way for the versions before 19.

Nothing else changes: on 20 and above the core file is used exactly as before.

## Tests

Measured on the bench, **one instance per supported version, 17 through 24**.

The failure is reproduced rather than described: the probe empties `$conf->file->dol_document_root` of everything but the main root, which is what a deployment the module cannot be found from looks like, then loads `einvoicing.class.php` and calls the function.

| Dolibarr | `dol_buildpath` resolves | `dol_include_once` returns | before | after |
|---|---|---|---|---|
| 17.0.4 | no | `false` | **`Call to undefined function isValidSiren()`** | polyfill loaded |
| 18.0.10 | no | `false` | **`Call to undefined function isValidSiren()`** | polyfill loaded |
| 19.0.4 | no | `false` | **`Call to undefined function isValidSiren()`** | polyfill loaded |

and the polyfill then answers: `isValidSiren('000000001')` is `false` (wrong check digit), `isValidSiret('00000000100012')` is `false` — it computes rather than returning true like the temporary mock had to.

Unit suite: 9/9 on 18 to 24. On 17 it is 8/9, and the one failure is `EInvoicingSamplesTest` dying on `dolChmod()`, which is the subject of #568 and unrelated to this branch — with both branches applied it is 9/9 there too.

`phpcs` clean.

## One thing I tried and dropped

I first added a `function_exists()` / `class_exists()` early return at the top of each compat file, so that loading one twice could not end on a redeclare. It does not work: PHP hoists unconditional top-level function and class declarations at compile time, before the `return` ever runs, so the redeclare fatal happens anyway. Guarding each declaration individually would work but buys nothing here — with `require_once` from a fixed path the module loads each file exactly once — so I left the files alone.
