### PR TITLE
FIX: a line period with only one date is dropped by the Factur-X path, kept by the CII one

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -25,6 +25,13 @@ resolve - a deployment that does not sit where the module expects, which is what
 can produce - only wrote a line in the log and returned false, so the polyfill was silently absent and
 the next call to it was a fatal "Call to undefined function isValidSiren" (issue #565).
 
+FIX: A line billed over a period that has only a start date, or only an end date, now carries that
+period in the Factur-X document as it already did in the CII one. The Factur-X path asked for both
+dates before writing anything, so a service line left open on one side lost its BT-134/BT-135
+entirely - and the same invoice produced two different documents depending on the protocol selected.
+One date alone is a period the norm accepts: BR-CO-20 asks for the start date or the end date, "or
+both".
+
 FIX: Generating two Factur-X sample invoices in the same request no longer ends on a PHP fatal error.
 The generator loaded its helper file with require rather than require_once, so the second call
 redeclared its functions - and a fatal error is not something the calling code can catch and report.

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -471,8 +471,10 @@ class FacturXProtocol extends CIIProtocol
 					$facturxpdf->setDocumentInvoiceReferencedDocument($lineData['depositInvoiceRef'], ZugferdInvoiceType::PREPAYMENTINVOICE, $lineData['depositInvoiceDate']);
 				}
 
-				// Set billing period for the line
-				if ($lineData['linePeriodStart'] !== null && $lineData['linePeriodEnd'] !== null) {
+				// Set billing period for the line (BG-26 / BT-134 / BT-135). One date alone is a valid
+				// period: BR-CO-20 asks for the start date or the end date, "or both". The builder
+				// leaves out the side it is given as null, so the same condition as the CII path applies.
+				if ($lineData['linePeriodStart'] !== null || $lineData['linePeriodEnd'] !== null) {
 					$facturxpdf->setDocumentPositionBillingPeriod($lineData['linePeriodStart'], $lineData['linePeriodEnd']);
 				}
 


### PR DESCRIPTION
## What

A line billed over a period that is open on one side - only a start date, or only an end date - keeps its BT-134/BT-135 in the CII document and loses them entirely in the Factur-X one.

The two paths do not test the same thing:

```php
// CIIProtocol.class.php:2348
if ($line['linePeriodStart'] !== null || $line['linePeriodEnd'] !== null) {

// FacturXProtocol.class.php:475 (before this PR)
if ($lineData['linePeriodStart'] !== null && $lineData['linePeriodEnd'] !== null) {
```

So the same invoice produces two different documents depending on `EINVOICING_PROTOCOL`, and the Factur-X one silently drops a period the seller did enter on the line.

## Why the CII behaviour is the right one

One date alone is a period the norm accepts. `BR-CO-20`, `flag="fatal"` in both `EN16931-CII-validation-preprocessed.sch` and `EXTENDED-CTC-FR-CII.sch` (FNFE `France_RFE`):

> [BR-CO-20]-If Invoice line period (BG-26) is used, the Invoice line period start date (BT-134) **or** the Invoice line period end date (BT-135) shall be filled, or both.

with `test="(ram:StartDateTime) or (ram:EndDateTime)"`. The French rules add nothing on top: `BR-FR-Flux2-Schematron-CII.sch` only checks the date *format* of BT-134/BT-135 (`BR-FR-03`, year between 2000 and 2099).

## Why the change is safe

`setDocumentPositionBillingPeriod()` already handles the null side on its own: `ZugferdObjectHelper::getSpecifiedPeriodType()` returns `null` when everything it gets is null, and `tryCall()` skips a date given as null. Checked against the bundled builder, `PROFILE_EXTENDED`:

| line dates | `BillingSpecifiedPeriod` emitted | StartDateTime | EndDateTime |
| --- | --- | --- | --- |
| both | 1 | 20260101 | 20260131 |
| start only | 1 | 20260101 | - |
| end only | 1 | - | 20260131 |
| neither | 0 | - | - |

So the guard is kept (mirroring CII) rather than removed, and a line without dates still emits nothing.

The CII side already has the coverage for the three cases - `CIIProtocolTest::testOnlyStartDateProducesStartOnly`, `testOnlyEndDateProducesEndOnly`, `testNoDateProducesNoPeriodBlock`. The Factur-X emission sits inline in the `generateInvoice()` line loop and has no unit seam, so it is not covered by a new test here; opening one would mean extracting the loop body, which felt out of proportion for the change.

## Where it comes from

Spotted while reading #572 (BT-73/BT-74 not written). It is **not** a fix for that issue - #572 is about the *header* period BG-14/BT-73/BT-74, which is still never written and is waiting on a design decision discussed there. This PR only aligns the two protocols on the *line* period they already both write.

phan clean (`--quick`, merge with main), `php -l` clean.
