### PR TITLE
FIX: EINVOICING_PROFILE is ignored in Factur-X generation — profile a…

### DIFF
--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -310,13 +310,13 @@ class FacturXProtocol extends CIIProtocol
 			$profile = getDolGlobalString('EINVOICING_PROFILE');
 			switch ($profile) {
 				case 'EN16931':
-					$used_profile = ZugferdProfiles::PROFILE_EXTENDED;
-					$facturxpdf = ZugferdDocumentBuilder::createNew($used_profile);
-					// no break
+					$used_profile = ZugferdProfiles::PROFILE_EN16931;
+					break;
 				default:
 					$used_profile = ZugferdProfiles::PROFILE_EXTENDED;
-					$facturxpdf = ZugferdDocumentBuilder::createNew($used_profile);
+					break;
 			}
+			$facturxpdf = ZugferdDocumentBuilder::createNew($used_profile);
 			dol_syslog(get_class($this) . '::executeHooks create new XML document based on ' . $used_profile);
 
 			// Get the type of invoice in FacturX nomenclature


### PR DESCRIPTION
…lways forced to EXTENDED

## Problem

When the exchange protocol is `FACTURX`, the generated PDF always embeds a Factur-X XML with the **EXTENDED** profile (guideline `urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended`, XMP `fx:ConformanceLevel = EXTENDED`), even when the hidden constant `EINVOICING_PROFILE` is set to `EN16931`.

## Root cause

In `class/protocols/FacturXProtocol.class.php` (around line 311), the profile switch has two defects:

1. the `case 'EN16931':` branch assigns `ZugferdProfiles::PROFILE_EXTENDED` instead of `ZugferdProfiles::PROFILE_EN16931`;
2. the branch has no `break` (there is even a `// no break` marker), so execution falls through into `default:`, which re-assigns EXTENDED and calls `ZugferdDocumentBuilder::createNew()` a **second time**.

Net effect: whatever the configured value, `$used_profile` is always EXTENDED, and when `EINVOICING_PROFILE=EN16931` the document builder is instantiated twice. The syslog line just above ("create new XML document based on PROFILE_EN16931 (CIUS-FR)") makes debugging harder because it does not reflect what is actually produced.

## Why it matters

- EN 16931 is the profile of the European standard — the level every Access Point / Plateforme Agréée and every receiver must support. EXTENDED is a superset intended for complex use cases; claiming EXTENDED for ordinary invoice data only reduces interoperability (stricter/different schematron on the receiving side, extended fields the receiver is not required to process), with no benefit since the generator does not write any EXTENDED-only field.
- Inconsistency between protocols: the CII protocol already produces EN 16931 (`urn:cen.eu:en16931:2017`), so the same invoice currently gets a different conformance level depending on the transport format.

## Fix

Assign the correct constant in each branch, add the missing `break`s, and move the `createNew()` call after the switch so the builder is created exactly once. The default behaviour (EXTENDED when `EINVOICING_PROFILE` is not set) is preserved.

## How to test

1. Set `EINVOICING_PROTOCOL=FACTURX` and `EINVOICING_PROFILE=EN16931` in `llx_const`.
2. Generate an invoice PDF and extract the embedded `factur-x.xml` from `<ref>_facturx.pdf`.
3. Before the fix, the guideline reads `urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended`; after the fix it reads `urn:cen.eu:en16931:2017`, and the XMP `fx:ConformanceLevel` switches from `EXTENDED` to `EN 16931`.
4. Without `EINVOICING_PROFILE` set, the output remains EXTENDED (default unchanged).

The defect is version-independent (the switch is executed the same way on every Dolibarr version supported by the module, including 24). Verified on a real invoice: with the fix, the embedded XML validates with the EN 16931 guideline and a single builder instantiation.