### PR TITLE
FIX #576 : the billing period of the lines is dropped when a received e-invoice is imported

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -24,6 +24,14 @@ starting after it ends - one line open from March next to another closed in Janu
 period at all rather than a pair BR-29 refuses, which would have the whole document rejected for a field
 nobody filled in (issue #572).
 
+FIX: Importing a received e-invoice now keeps the billing period of its lines (BT-134 / BT-135), where a
+service line billed over a period used to arrive with no period at all. The two dates were read from the
+document and then went nowhere: the line built for the supplier invoice never carried them, although the
+call that saves it has always passed its date_start and date_end on to the core. A period with only one
+of the two dates keeps that one, as the norm allows (BR-CO-20). A document declaring a period that ends
+before it starts - which BR-30 refuses, and which the core refuses too - is imported without that period
+rather than failing the whole invoice over it (issue #576).
+
 FIX: The module works on Dolibarr 17 again, the version its own descriptor declares as the minimum it
 supports. Two things stood in the way and neither of them failed quietly. Installing it died on a PHP
 TypeError: init() passed an empty array() where ExtraFields::update() expects a parameter string, and

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -34,6 +34,10 @@ require_once DOL_DOCUMENT_ROOT . '/core/class/translate.class.php';
 require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/class/discount.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
+// dol_stringtotime() reads the dates of a received document, on the import path. master.inc.php does not
+// load this library - only main.inc.php does, and only for a web request - so a caller outside a request
+// (the cron that synchronizes, a script) was reaching it by chance until now.
+require_once DOL_DOCUMENT_ROOT . '/core/lib/date.lib.php';
 // dolChmod() only exists from Dolibarr 18, and both writers call it on the XML they just produced.
 if ((float) DOL_VERSION < 18) {
 	dol_include_once('/einvoicing/compat/files.lib.php');
@@ -1307,6 +1311,18 @@ class CIIProtocol extends AbstractProtocol
 			$line->total_tva = $parsedLine['calculatedAmount'] ?? 0;
 			$line->total_ttc = $parsedLine['lineTotalAmount'] + ($parsedLine['calculatedAmount'] ?? 0);
 
+			// Billing period of the line (BT-134 / BT-135). The two dates were read from the document and
+			// then went nowhere: createSupplierInvoiceLinesIntoDatabase() has always handed
+			// $line->date_start / ->date_end to updateline(), but nothing ever set them, so a service line
+			// billed over a period arrived without one (issue #576). See resolveLinePeriod().
+			$linePeriod = $this->resolveLinePeriod($parsedLine);
+			if ($linePeriod['start'] !== null) {
+				$line->date_start = $linePeriod['start'];
+			}
+			if ($linePeriod['end'] !== null) {
+				$line->date_end = $linePeriod['end'];
+			}
+
 			$supplierInvoice->lines[] = $line;
 		}
 
@@ -1471,6 +1487,46 @@ class CIIProtocol extends AbstractProtocol
 			return null;
 		$v = str_replace(',', '.', trim($v));
 		return is_numeric($v) ? (float) $v : null;
+	}
+
+	/**
+	 * Billing period of a received line (BG-26 / BT-134 / BT-135), as the timestamps a Dolibarr line holds.
+	 *
+	 * parseInvoiceLines() hands the two dates as 'Y-m-d' strings, normDate() having already reduced whatever the
+	 * document carried to that shape, and a supplier invoice line stores a timestamp: updateline() passes
+	 * date_start / date_end to idate() on every supported core. dol_stringtotime() is the conversion the
+	 * import already makes for the invoice date itself, so the line periods are read the same way rather
+	 * than through a second convention (issue #576).
+	 *
+	 * One side alone is kept: BR-CO-20 accepts a period with a start date or an end date, "or both", and
+	 * facture_fourn_det holds one without the other.
+	 *
+	 * A period that ends before it starts is dropped, keeping the line. Such a document breaks BR-30 and
+	 * should not exist, but it comes from outside, and updateline() answers -1 on that pair
+	 * (ErrorStartDateGreaterEnd) - which would fail the whole import over a period, where dropping it
+	 * imports the invoice as it always did.
+	 *
+	 * @param	array<string,mixed>				$parsedLine		One line as parseInvoiceLines() returns it
+	 * @return	array{start: ?int, end: ?int}					Timestamps to store, null for a side with nothing
+	 */
+	private function resolveLinePeriod(array $parsedLine)
+	{
+		$start = !empty($parsedLine['linePeriodStart']) ? dol_stringtotime((string) $parsedLine['linePeriodStart']) : null;
+		$end = !empty($parsedLine['linePeriodEnd']) ? dol_stringtotime((string) $parsedLine['linePeriodEnd']) : null;
+
+		// dol_stringtotime() answers false or '' on something it cannot read, and that must not reach idate().
+		$start = is_int($start) && $start > 0 ? $start : null;
+		$end = is_int($end) && $end > 0 ? $end : null;
+
+		if ($start !== null && $end !== null && $start > $end) {
+			dol_syslog(get_class($this) . '::resolveLinePeriod line ' . ($parsedLine['lineid'] ?? '?')
+				. ' declares a period from ' . dol_print_date($start, 'day') . ' to ' . dol_print_date($end, 'day')
+				. ', which BR-30 refuses; the line is imported without its period', LOG_WARNING);
+
+			return array('start' => null, 'end' => null);
+		}
+
+		return array('start' => $start, 'end' => $end);
 	}
 
 

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -34,9 +34,6 @@ require_once DOL_DOCUMENT_ROOT . '/core/class/translate.class.php';
 require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/class/discount.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
-// dol_stringtotime() reads the dates of a received document, on the import path. master.inc.php does not
-// load this library - only main.inc.php does, and only for a web request - so a caller outside a request
-// (the cron that synchronizes, a script) was reaching it by chance until now.
 require_once DOL_DOCUMENT_ROOT . '/core/lib/date.lib.php';
 // dolChmod() only exists from Dolibarr 18, and both writers call it on the XML they just produced.
 if ((float) DOL_VERSION < 18) {

--- a/einvoicing/test/phpunit/CIIProtocolTest.php
+++ b/einvoicing/test/phpunit/CIIProtocolTest.php
@@ -19,13 +19,16 @@
 /**
  *      \file       test/phpunit/CIIProtocolTest.php
  *      \ingroup    test
- *      \brief      PHPUnit test for the line billing period export (issue #435):
- *                  CIIProtocol::buildLineItem() must map the line date_start/date_end
- *                  (already parsed upstream into linePeriodStart/linePeriodEnd) to the
- *                  BillingSpecifiedPeriod block (EN 16931 BG-26 / BT-134 / BT-135), placed
- *                  between ApplicableTradeTax and SpecifiedTradeAllowanceCharge/
- *                  SpecifiedTradeSettlementLineMonetarySummation as required by the CII
- *                  D22B schema sequence.
+ *      \brief      PHPUnit test for the line billing period (EN 16931 BG-26 / BT-134 / BT-135), in
+ *                  both directions.
+ *                  Export (issue #435): CIIProtocol::buildLineItem() must map the line
+ *                  date_start/date_end (already parsed upstream into linePeriodStart/linePeriodEnd)
+ *                  to the BillingSpecifiedPeriod block, placed between ApplicableTradeTax and
+ *                  SpecifiedTradeAllowanceCharge/SpecifiedTradeSettlementLineMonetarySummation as
+ *                  required by the CII D22B schema sequence.
+ *                  Import (issue #576): CIIProtocol::resolveLinePeriod() must turn what the parser
+ *                  read back into the timestamps a supplier invoice line stores, keeping one side
+ *                  alone and refusing a period that ends before it starts.
  *      \remarks    To run this script as CLI: phpunit filename.php
  */
 
@@ -265,5 +268,168 @@ class CIIProtocolTest extends CommonClassTest
 			['ram:ApplicableTradeTax', 'ram:BillingSpecifiedPeriod', 'ram:SpecifiedTradeAllowanceCharge', 'ram:SpecifiedTradeSettlementLineMonetarySummation'],
 			$this->childElementNames($sett)
 		);
+	}
+
+	/**
+	 * Call the private CIIProtocol::resolveLinePeriod() through reflection, the same convention as
+	 * callBuildLineItem() above: it reads nothing but its argument and touches no database.
+	 *
+	 * @param	CIIProtocol		$protocol	Protocol instance
+	 * @param	array			$parsedLine	One line, as parseInvoiceLines() returns it
+	 * @return	array{start: ?int, end: ?int}
+	 */
+	private function callResolveLinePeriod(CIIProtocol $protocol, array $parsedLine): array
+	{
+		$method = new ReflectionMethod(CIIProtocol::class, 'resolveLinePeriod');
+		$method->setAccessible(true);
+
+		return $method->invoke($protocol, $parsedLine);
+	}
+
+	/**
+	 * A received line with both dates gives the two timestamps the supplier invoice line stores. The
+	 * assertion is on the date, not on the exact second: what matters is the day the document declared.
+	 *
+	 * @return void
+	 */
+	public function testAReceivedPeriodBecomesTheLineDates()
+	{
+		global $db;
+
+		$period = $this->callResolveLinePeriod(new CIIProtocol($db), [
+			'lineid' => '1',
+			'linePeriodStart' => '2026-06-01',
+			'linePeriodEnd' => '2026-06-30',
+		]);
+
+		$this->assertIsInt($period['start']);
+		$this->assertIsInt($period['end']);
+		$this->assertSame('2026-06-01', dol_print_date($period['start'], '%Y-%m-%d', 'gmt'));
+		$this->assertSame('2026-06-30', dol_print_date($period['end'], '%Y-%m-%d', 'gmt'));
+	}
+
+	/**
+	 * One side alone is a period BR-CO-20 accepts, and facture_fourn_det holds one date without the
+	 * other, so the side that is there is kept rather than the whole period dropped.
+	 *
+	 * @return void
+	 */
+	public function testOneSideAloneIsImported()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$startOnly = $this->callResolveLinePeriod($protocol, ['linePeriodStart' => '2026-06-01', 'linePeriodEnd' => null]);
+		$this->assertSame('2026-06-01', dol_print_date($startOnly['start'], '%Y-%m-%d', 'gmt'));
+		$this->assertNull($startOnly['end']);
+
+		$endOnly = $this->callResolveLinePeriod($protocol, ['linePeriodStart' => null, 'linePeriodEnd' => '2026-06-30']);
+		$this->assertNull($endOnly['start']);
+		$this->assertSame('2026-06-30', dol_print_date($endOnly['end'], '%Y-%m-%d', 'gmt'));
+	}
+
+	/**
+	 * A line with no period declares none: no date is invented from the invoice date, and the keys may
+	 * be absent altogether since the parser only sets what the document carried.
+	 *
+	 * @return void
+	 */
+	public function testALineWithoutAPeriodGetsNoDates()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$this->assertSame(['start' => null, 'end' => null], $this->callResolveLinePeriod($protocol, []));
+		$this->assertSame(['start' => null, 'end' => null], $this->callResolveLinePeriod($protocol, ['linePeriodStart' => null, 'linePeriodEnd' => null]));
+		$this->assertSame(['start' => null, 'end' => null], $this->callResolveLinePeriod($protocol, ['linePeriodStart' => '', 'linePeriodEnd' => '']));
+	}
+
+	/**
+	 * A period that ends before it starts breaks BR-30 and must not reach updateline(), which answers
+	 * -1 on that pair (ErrorStartDateGreaterEnd) and would fail the import of the whole invoice. The
+	 * line is imported without its period instead.
+	 *
+	 * @return void
+	 */
+	public function testAnInvertedPeriodIsDroppedRatherThanFailingTheImport()
+	{
+		global $db;
+
+		$period = $this->callResolveLinePeriod(new CIIProtocol($db), [
+			'lineid' => '2',
+			'linePeriodStart' => '2026-03-01',
+			'linePeriodEnd' => '2026-01-31',
+		]);
+
+		$this->assertSame(['start' => null, 'end' => null], $period);
+	}
+
+	/**
+	 * Something unreadable where a date was expected must not reach idate() either: dol_stringtotime()
+	 * answers a value that is not a usable timestamp, and the line is imported without the period.
+	 *
+	 * @return void
+	 */
+	public function testAnUnreadableDateIsIgnored()
+	{
+		global $db;
+
+		$period = $this->callResolveLinePeriod(new CIIProtocol($db), [
+			'linePeriodStart' => 'not a date',
+			'linePeriodEnd' => 'NA',
+		]);
+
+		$this->assertSame(['start' => null, 'end' => null], $period);
+	}
+
+	/**
+	 * The shape resolveLinePeriod() expects is not an assumption: this reads a document back through
+	 * parseInvoiceLines() and checks the parser hands the two dates as 'Y-m-d' strings, then that the pair
+	 * resolves to the days the document declared.
+	 *
+	 * @return void
+	 */
+	public function testWhatTheParserHandsOverIsWhatTheImportReads()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$xml = '<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+  <rsm:SupplyChainTradeTransaction>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument><ram:LineID>1</ram:LineID></ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct><ram:Name>Prestation</ram:Name></ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:NetPriceProductTradePrice><ram:ChargeAmount>100.00</ram:ChargeAmount></ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery><ram:BilledQuantity unitCode="C62">1</ram:BilledQuantity></ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>20.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:BillingSpecifiedPeriod>
+          <ram:StartDateTime><udt:DateTimeString format="102">20260601</udt:DateTimeString></ram:StartDateTime>
+          <ram:EndDateTime><udt:DateTimeString format="102">20260630</udt:DateTimeString></ram:EndDateTime>
+        </ram:BillingSpecifiedPeriod>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation><ram:LineTotalAmount>100.00</ram:LineTotalAmount></ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>';
+
+		$lines = $protocol->parseInvoiceLines($xml);
+		$this->assertCount(1, $lines);
+		$this->assertSame('2026-06-01', $lines[0]['linePeriodStart'], 'the parser normalises BT-134 to Y-m-d');
+		$this->assertSame('2026-06-30', $lines[0]['linePeriodEnd'], 'the parser normalises BT-135 to Y-m-d');
+
+		$period = $this->callResolveLinePeriod($protocol, $lines[0]);
+		$this->assertSame('2026-06-01', dol_print_date($period['start'], '%Y-%m-%d', 'gmt'));
+		$this->assertSame('2026-06-30', dol_print_date($period['end'], '%Y-%m-%d', 'gmt'));
 	}
 }


### PR DESCRIPTION
Closes #576. Independent of #575 (which writes the *header* period on the way out); this one is the
reading side, and the two branches do not touch the same code.

## What was wrong

The billing period of a received line was read and then went nowhere. Everything around it was already in
place:

* `getMappingLines()` maps BT-134 / BT-135 (`CIIProtocol.class.php:308-309`);
* `parseInvoiceLines()` normalises both to `Y-m-d`;
* `createSupplierInvoiceLinesIntoDatabase()` has always passed `$line->date_start` / `->date_end` to
  `updateline()`.

The one missing step was in between: the `SupplierInvoiceLine` built from the document never got the two
values, so the arguments above were always an unset property and the column was written `NULL`. A service
line billed "1 June → 30 June" arrived with no period, silently.

Measured on 23.0.3, same document imported before and after this branch:

| | line 1 (`20260601`–`20260630`) | line 2 (`20260515`–`20260731`) |
|---|---|---|
| `main` | `date_start=NULL date_end=NULL` | `date_start=NULL date_end=NULL` |
| this branch | `2026-06-01` → `2026-06-30` | `2026-05-15` → `2026-07-31` |

## What this does

`resolveLinePeriod()` turns what the parser read into the timestamps a line stores, and the import assigns
them. Three decisions, none of them arbitrary:

**The conversion is the one the import already makes.** `dol_stringtotime()` is what
`doCreateSupplierInvoiceFromSource()` uses for the invoice date itself, from the same parser and the same
`Y-m-d` shape, and `updateline()` hands `date_start` to `idate()` on every supported core — checked in
17.0.4, 18.0.10, 20.0.4, 23.0.3 and 24.0.0-beta, where `SupplierInvoiceLine` declares both properties and
persists them through `idate()`. So a timestamp is what has to be stored, and no second convention is
introduced.

**One side alone is kept.** BR-CO-20 accepts a period with a start date or an end date, "or both" (this is
#573 on the writing side), and `facture_fourn_det` holds one date without the other. Verified live: a
document carrying only BT-134 imports as `date_start='2026-06-01' date_end=NULL`.

**A period that ends before it starts is dropped, and the invoice still imports.** Such a document breaks
BR-30, but it comes from outside, and the core refuses that pair — measured, not assumed:

```
dd18 (Dolibarr 18.0.10) updateline(start 2026-03-01, end 2026-01-31) -> -1 : The start date is greater than the end date
dd23 (Dolibarr 23.0.3)  updateline(...) -> -1 : La date de début est supérieure à la date de fin
dd24 (24.0.0-beta)      updateline(...) -> -1 : La date de début est supérieure à la date de fin
```

`createSupplierInvoiceLinesIntoDatabase()` returns `false` on that `-1`, which fails the import of the
*whole invoice* — over a period. So the pair is dropped and the line imported without it, which is exactly
what happened before this branch existed. Verified live on a document whose first line has its two dates
swapped and nothing else changed: the invoice imports, that line comes in with no period, and the second
line keeps its own (`2026-05-15` → `2026-07-31`).

## One latent fatal fixed on the way

`CIIProtocol` calls `dol_stringtotime()` (already, for the invoice date) but nothing loaded
`core/lib/date.lib.php`: `master.inc.php` does not, only `main.inc.php` does and only for a web request.
So a caller outside a request — `scripts/cron/cron_run_jobs.php` loads `master.inc.php` alone, and the
module's synchronization is a cron job — was reaching that function by chance, through whichever core
helper had lazily included the library first. The class requires it now, next to the `files.lib.php` it
already required. This is also what made the new tests fail before it was added, which is how it surfaced.

## Tests

`CIIProtocolTest` was already the file for BT-134/BT-135 on the writing side (#435), so the reading side
joins it: 6 new tests (11 total, 35 assertions), through the same `ReflectionMethod` convention the file
already uses for a private method. They cover both dates, one side alone on each side, no period at all
(including absent keys), the inverted pair, an unreadable date that must not reach `idate()`, and one
round trip that reads a document back through `parseInvoiceLines()` to check the `Y-m-d` shape this relies
on rather than assuming it.

| | 17.0.4 | 18.0.10 | 19.0.4 | 20.0.4 | 21.0.4 | 22.0.5 | 23.0.3 | 24.0.0-beta |
|---|---|---|---|---|---|---|---|---|
| `CIIProtocolTest` | OK | OK | OK | OK | OK | OK | OK | OK |

Plus, on 23.0.3 and 18.0.10: the other 8 test files of the module (all green), the sample matrix (CII
standard / down payment / credit note, all OK — the Factur-X samples fail below 24 on the FPDF/TCPDF
collision of #554, unchanged here and identical on `main`), and the four imports above, each read back
from a second process so a transaction left open would show.
### End-to-end on the sandbox, with this branch deployed

Real exchange through the SuperPDP sandbox — the period is not read out of a local file but out of a
document that actually travelled. One **new** invoice, two service lines with different periods:

```
emitter  dolidev 23.0.3  ->  TRI-FA-2608-0130, flow i_214895
  line 285  2026-06-01 .. 2026-06-30
  line 286  2026-05-15 .. 2026-07-31
Access Point   : acknowledgement Ok
receiver dd23 23.0.3  ->  supplier invoice 1032 (SI2608-0049), ref_supplier TRI-FA-2608-0130
  line 4423  date_start='2026-06-01 00:00:00'  date_end='2026-06-30 00:00:00'
  line 4424  date_start='2026-05-15 00:00:00'  date_end='2026-07-31 00:00:00'
statuses back on the emitter : 200 (ie_733326), 201 (ie_733327)
receiver side : the incoming CDAR ie_733328 delivered with the invoice is decoded as 202 and attached to it
no transaction left open on either side
```

The same run on `main` receives the same document with `date_start=NULL date_end=NULL` on both lines,
which is the bug. Read back from a separate process in both cases, so an uncommitted write would show.
