### PR TITLE
FIX: synchronization stops for good on a vendor whose thirdparty code is missing

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -213,6 +213,16 @@ instead of undetermined, and the option that requires a reachable recipient bloc
 value. Where the verdict was read is displayed next to it, since the directory consulted by hand
 shows no status for that line.
 
+FIX: Synchronizing incoming documents no longer stops on a vendor whose thirdparty code is missing.
+On an instance where the code is mandatory - MAIN_COMPANY_CODE_ALWAYS_REQUIRED, or a numbering module
+that refuses an empty code - a thirdparty saved without one, as an import or a provisioning script
+leaves it, is refused by the core on every update: Societe::verify() answers ErrorSupplierCodeRequired
+and the synchronization aborts there, leaving the remaining flows untouched. The module now asks for a
+generated code, the way the thirdparty card does when it saves that same thirdparty, and only where
+the numbering module allows the code to be set. The customer code is treated the same, because the core
+checks both on any update and reports only the last of the two, which made the customer half invisible
+behind the vendor error. Marking a thirdparty as a vendor also stores its new code now, which passing
+the code alone never did: update() writes the code columns only when it is allowed to modify them.
 
 ## 1.0.3
 

--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -713,14 +713,29 @@ trait CommonProtocol
 					$thirdparty->tva_assuj = 1;
 				}
 			}
-			// Si le tiers n'est pas encore fournisseur, on le marque comme tel
-			// (ex. prospect/client qui reçoit sa 1ère facture fournisseur).
+			// Flag the thirdparty as a vendor if it is not one yet
+			// (ex: a prospect or customer receiving its first supplier invoice).
 			if (!$thirdparty->fournisseur) {
 				$thirdparty->fournisseur = 1;
-				$thirdparty->code_fournisseur = 'auto';
 			}
 
-			$result = $thirdparty->update(0, $user);
+			// A thirdparty code may be mandatory (MAIN_COMPANY_CODE_ALWAYS_REQUIRED, or a numbering
+			// module refusing an empty code): verify() then refuses every update of a thirdparty saved
+			// without one, and the whole synchronization stops on it. Ask for a generated code when the
+			// numbering module allows it. The allowmod flags are required twice over: update() checks
+			// them before writing the code columns, and it is also how the thirdparty card saves a code.
+			$allowmodcodeclient = 0;
+			$allowmodcodefournisseur = 0;
+			if (empty($thirdparty->code_fournisseur) && $thirdparty->codefournisseur_modifiable()) {
+				$thirdparty->code_fournisseur = 'auto';
+				$allowmodcodefournisseur = 1;
+			}
+			if (!empty($thirdparty->client) && empty($thirdparty->code_client) && $thirdparty->codeclient_modifiable()) {
+				$thirdparty->code_client = 'auto';
+				$allowmodcodeclient = 1;
+			}
+
+			$result = $thirdparty->update(0, $user, 1, $allowmodcodeclient, $allowmodcodefournisseur);
 			if ($result < 0) {
 				$this->error = $thirdparty->error;
 				$this->errors = $thirdparty->errors;


### PR DESCRIPTION
Found on a fresh instance whose setup makes the thirdparty code mandatory. Synchronizing incoming
documents stopped on the third flow and left the ninety-seven behind it untouched:

```
Synchronisation interrompue sur le flux # 3 / 100 (Flux i_219558)
ERROR_SYNCFLOW - Failed to synchronize flow i_219558: ... Thirdparty sync or creation error:
Thirdparty update error: ,ErrorSupplierCodeRequired.
Aborting synchronization due to errors.
```

Nothing was wrong with the flow, nor with the document: the vendor thirdparty had been saved — by an
import, a provisioning script, an API call — with no `code_fournisseur`, and the instance carries
`MAIN_COMPANY_CODE_ALWAYS_REQUIRED`. `Societe::verify()` then refuses **every** update of that
thirdparty, forever, and the module updates it on each incoming document to enrich it.

## What was wrong

Three separate things, and only the first one is visible in the message.

**1. The vendor code was only asked for when the thirdparty was not a vendor yet.**

```php
if (!$thirdparty->fournisseur) {
    $thirdparty->fournisseur = 1;
    $thirdparty->code_fournisseur = 'auto';
}
$result = $thirdparty->update(0, $user);
```

An existing vendor with an empty code never entered that branch, so it went to `update()` with the
empty code `verify()` refuses: `check_codefournisseur()` → `mod_codeclient_*::verif()` → `-2` →
`ErrorSupplierCodeRequired`.

**2. Passing the code was never enough to store it.** `Societe::update()` writes the code columns only
when the matching allowmod flag is set — so even the branch above validated a code and then dropped it:

```php
if ($supplier) {
    $sql .= ", code_fournisseur = ".(!empty($this->code_fournisseur) ? "'".$this->db->escape($this->code_fournisseur)."'" : "null");
}
```

`$supplier` is `!empty($allowmodcodefournisseur) && !empty($this->fournisseur)`, and the module passed
`update(0, $user)`, i.e. `$allowmodcodefournisseur = 0`. Measured, not deduced: calling it that way
returns `1`, the object holds `SU2608-00002`, and the row in `llx_societe` still holds `null` — so a
thirdparty flagged as a vendor by the module came back with the empty code that refuses the next
update. `societe/card.php` passes `$object->oldcopy->codefournisseur_modifiable()` there, which is
what this branch now does too.

**3. The customer half was invisible.** `verify()` checks both codes, but each checker overwrites the
error list of the previous one:

```php
$result = $mod->verif($this->db, $this->code_client, $this, 0);
if ($result) {
    $this->error = $mod->error;
    $this->errors = $mod->errors;   // <- wipes what check_codeclient() had just added
}
```

So a thirdparty that is a customer *and* a vendor with both codes empty reports only
`ErrorSupplierCodeRequired`, and fixing the vendor side alone moves the failure to
`ErrorCustomerCodeRequired` — which is exactly what happened on the first attempt here. The leading
comma in the message is the same core habit seen elsewhere: `->error` is empty and everything is in
`->errors`.

## What this does

The code is asked for whenever it is missing, on both sides, and only where the numbering module
allows it to be set — `codefournisseur_modifiable()` / `codeclient_modifiable()`, the same test the
thirdparty card makes before saving. The allowmod flags are passed so the generated code is actually
stored:

```php
if (empty($thirdparty->code_fournisseur) && $thirdparty->codefournisseur_modifiable()) {
    $thirdparty->code_fournisseur = 'auto';
    $allowmodcodefournisseur = 1;
}
if (!empty($thirdparty->client) && empty($thirdparty->code_client) && $thirdparty->codeclient_modifiable()) {
    $thirdparty->code_client = 'auto';
    $allowmodcodeclient = 1;
}
$result = $thirdparty->update(0, $user, 1, $allowmodcodeclient, $allowmodcodefournisseur);
```

Nothing is forced: an instance whose numbering module forbids setting the code gets exactly today's
behaviour, and an instance that does not make the code mandatory never enters any of this — the codes
are already there, or the core does not ask for them. The customer code is set on a customer only, and
only when it is empty; a code that exists is never touched.

The comment of the vendor flag, which was in French, is in English now.

## Tests

Real synchronization on the instance where this was found (Dolibarr 22.0.5, SuperPDP sandbox), with the
thirdparty put back in the failing state — both codes `null` — before each run:

| | result |
|---|---|
| before, negative control | `Thirdparty update error: ,ErrorSupplierCodeRequired` — aborted on flow 3/100, nothing synced |
| after | `Thirdparty Burger Queen updated successfully`, `code_client=CU2608-00001`, `code_fournisseur=SU2608-00002` read back from `llx_societe` in a separate process |

The run then stops further on, on a missing product with the manual action the module offers for it,
which is the expected behaviour of an instance with product auto-creation disabled and not this branch's
business.

Replayed on the versions the module supports, on one instance per version, inside a transaction that is
rolled back: the thirdparty is emptied of both codes, `mod_codeclient_monkey` and
`MAIN_COMPANY_CODE_ALWAYS_REQUIRED` are set in memory, the old code path and the new one run on it, and
the row is read back from the database rather than from the object.

| | 17.0.4 | 20.0.4 | 23.0.3 | 24.0.0-beta |
|---|---|---|---|---|
| old path | `-3` `ErrorSupplierCodeRequired` | `-3` `ErrorSupplierCodeRequired` | `-3` `ErrorSupplierCodeRequired` | `-3` `ErrorSupplierCodeRequired` |
| this branch | `1`, both codes stored | `1`, both codes stored | `1`, both codes stored | `1`, both codes stored |

`update()` has carried `$allowmodcodeclient` / `$allowmodcodefournisseur` with these semantics since 17,
and `codeclient_modifiable()` / `codefournisseur_modifiable()` exist in all eight, so nothing here is
version-dependent — checked in the core of each rather than assumed.

## Adjacent, left alone

The creation path already passes `'auto'` and `create()` writes the code columns unconditionally, so it
was never affected. And `->error` being empty while `->errors` carries everything is a core habit this
branch does not try to paper over — the message keeps its leading comma.
