### PR TITLE
FIX #581 : the instance hash in the XML comment depends on the button that generated the document

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -267,6 +267,14 @@ checks both on any update and reports only the last of the two, which made the c
 behind the vendor error. Marking a thirdparty as a vendor also stores its new code now, which passing
 the code alone never did: update() writes the code columns only when it is allowed to modify them.
 
+FIX: The same invoice no longer produces two different documents depending on the button that generated
+it. The comment opening the XML names the instance it was produced on, and that name comes from
+getHashUniqueIdOfRegistration(), a function of the blockedlog library that only the paths going through
+the PDF builder happen to load - so generating from the attached files carried the hash, while
+regenerating from the e-invoicing menu, which calls the writer directly, silently dropped it. The
+library is now loaded where the comment is written. Nothing changes below Dolibarr 23, where that
+function does not exist yet, and nothing changes on the PDF path (issue #581).
+
 ## 1.0.3
 
 FIX: The totals of the generated document now follow the rounding convention of the instance. Dolibarr

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -1899,6 +1899,14 @@ class CIIProtocol extends AbstractProtocol
 		$doc->appendChild($root);
 
 		// Add comment
+		// getHashUniqueIdOfRegistration() lives in the blockedlog library, which only the paths going through
+		// the PDF builder happen to include (pdf.lib.php). Load it here as well, otherwise the very same invoice
+		// is stamped with the instance hash or not depending on the button that triggered the generation.
+		// The library ships with older versions too, but the function itself only appeared in Dolibarr 23,
+		// so both guards stay: nothing is stamped below 23, exactly as before.
+		if (!function_exists('getHashUniqueIdOfRegistration') && file_exists(DOL_DOCUMENT_ROOT.'/blockedlog/lib/blockedlog.lib.php')) {
+			include_once DOL_DOCUMENT_ROOT.'/blockedlog/lib/blockedlog.lib.php';
+		}
 		$hash_unique_id = '';
 		if (function_exists('getHashUniqueIdOfRegistration')) {
 			$algo = 'sha256';

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -1902,9 +1902,9 @@ class CIIProtocol extends AbstractProtocol
 		// getHashUniqueIdOfRegistration() lives in the blockedlog library, which only the paths going through
 		// the PDF builder happen to include (pdf.lib.php). Load it here as well, otherwise the very same invoice
 		// is stamped with the instance hash or not depending on the button that triggered the generation.
-		// The library ships with older versions too, but the function itself only appeared in Dolibarr 23,
-		// so both guards stay: nothing is stamped below 23, exactly as before.
-		if (!function_exists('getHashUniqueIdOfRegistration') && file_exists(DOL_DOCUMENT_ROOT.'/blockedlog/lib/blockedlog.lib.php')) {
+		// The library ships with every supported version, the function itself only from Dolibarr 23, so the
+		// function_exists() below still decides: nothing is stamped under 23, exactly as before.
+		if (!function_exists('getHashUniqueIdOfRegistration')) {
 			include_once DOL_DOCUMENT_ROOT.'/blockedlog/lib/blockedlog.lib.php';
 		}
 		$hash_unique_id = '';


### PR DESCRIPTION
Closes #581.

## What @casta saw

The same invoice, generated twice, gives two different XML headers:

```
-  <!--Einvoice XML generated by Dolibarr 23.0.3 - ...-->
+  <!--Einvoice XML generated by Dolibarr 23.0.3 - ... - Instance public hash 2a6fd218...-->
```

The hash is there when the document is produced by the **Generate** button of the attached files, and
gone when it is produced by **Facture Électronique → Régénérer**. Their diagnosis was right, and the
core says why.

## Why

`CIIProtocol::buildXML()` guards the stamp with `function_exists('getHashUniqueIdOfRegistration')`, and
never loads the file that declares it. That function lives in `blockedlog/lib/blockedlog.lib.php`, and
in a Dolibarr 23 checkout the only place that pulls the library into an invoice request is the PDF
builder:

```php
// htdocs/core/lib/pdf.lib.php:785, pdfWriteBlockedLogSignature()
include_once DOL_DOCUMENT_ROOT.'/blockedlog/lib/blockedlog.lib.php';
```

`main.inc.php:3786` includes it too, but only on `index.php` or with `&forceregistration=1`.

So the **Generate** button goes through `generateDocument()` → PDF model → `pdf.lib.php` → library
loaded → `function_exists()` true → hash written. **Régénérer** (`action=generate_einvoice`) calls
`$protocol->generateInvoice()` directly, which never touches the PDF builder → `function_exists()`
false → no hash. Nothing was ever version- or setup-dependent: it is purely which include chain the
request happened to walk.

## The fix

Load the library where the comment is written, then keep the existing guard.

Both guards stay on purpose, and no `DOL_VERSION` test replaces them: the library file already ships
with Dolibarr 17 to 22, it is the *function* that appeared in 23, so `function_exists()` is the only
test that means what it says. Below 23 nothing is stamped, exactly as today. Nothing at include time in
that library executes anything — it declares functions only, in every version checked.

## Measured, on the eight versions

Same invoice on each instance, generated through the **Régénérer** path
(`$protocol->generateInvoice()`, the code the button runs):

| Dolibarr | before | after |
|---|---|---|
| 17.0.4 | no hash | no hash |
| 18.0.10 | no hash | no hash |
| 19.0.4 | no hash | no hash |
| 20.0.4 | no hash | no hash |
| 21.0.4 | no hash | no hash |
| 22.0.5 | no hash | no hash |
| 23.0.3 | **no hash** | **hash** |
| 24.0.0-beta | **no hash** | **hash** |

Control on the same eight, through the PDF path (`generateDocument()`): unchanged, and now identical to
what the regenerate path produces on the same instance.

`EInvoicingSamplesTest`, `CIIProtocolTest` and `CIIProfileShapeTest` pass on all eight (3 + 5 + 15 tests).
`phpcs` clean with the repository ruleset.

## Note for @casta

Your instinct that it should not matter is right — it is a comment, no rule of EN 16931 or of the
CTC-FR schematron reads it, and no receiving software does. What it did hide is the asymmetry itself:
two code paths building the same document out of two different include states. That is worth removing
even when the visible symptom is cosmetic.