### PR TITLE
FIX #548 : approving a received invoice locks the statuses that come after it

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -267,6 +267,18 @@ checks both on any update and reports only the last of the two, which made the c
 behind the vendor error. Marking a thirdparty as a vendor also stores its new code now, which passing
 the code alone never did: update() writes the code columns only when it is allowed to modify them.
 
+FIX: Approving a received invoice no longer takes away the statuses that come after it. The einvoice
+button group of the supplier invoice card disappeared as soon as an "Approved" (205) or a "Refused"
+(210) status had been accepted by the platform, on the assumption that either of them closes the
+lifecycle. Only the refusal does - an invoice sent back to its vendor is not going to be paid - while
+an approved one is, and "Payment transmitted" (211) is what reports it. Since the normal order of
+things is to approve an invoice and then pay it, the manual 211 was already unreachable by the time
+anyone would want it, and re-opening the invoice did not bring it back: the condition never looked at
+the Dolibarr status of the invoice, only at what had been sent. The card now offers what the exchange
+still allows - a status the platform accepted is not proposed a second time, a refusal leaves nothing,
+and an approval only takes the refusal away with it. The query it replaces also compared the direction
+and the validation status against their stored case, which matches nothing on PostgreSQL (issue #548).
+
 ## 1.0.3
 
 FIX: The totals of the generated document now follow the rounding convention of the instance. Dolibarr

--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -445,40 +445,30 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 			$resql = $db->query($sql);
 			if ($resql && $db->num_rows($resql) > 0) {
 				$db->free($resql);
-				// Check if a final status (approved or rejected) has already been sent and validated
-				// → in this case, the lifecycle is complete, so we hide the button
-				$sqlFinal = "SELECT rowid FROM " . $db->prefix() . "einvoicing_lifecycle_msg";
-				$sqlFinal .= " WHERE element_id = " . (int) $object->id;
-				$sqlFinal .= " AND element_type = '" . $db->escape($object->element) . "'";
-				$sqlFinal .= " AND direction = 'out'";
-				$sqlFinal .= " AND lc_status IN (" . (int) EInvoicing::STATUS_APPROVED . ", " . (int) EInvoicing::STATUS_REFUSED . ")";
-				$sqlFinal .= " AND lc_validation_status = 'Ok'";
-				$sqlFinal .= " LIMIT 1";
-				$resqlFinal = $db->query($sqlFinal);
-				$hasFinalLifecycle = ($resqlFinal && $db->num_rows($resqlFinal) > 0);
-				$db->free($resqlFinal);
+				// Offer what the exchange still allows, rather than closing it on the first final status:
+				// the button group used to disappear as soon as an "Approved" (205) was accepted, while
+				// the payment - and the "Payment transmitted" (211) that reports it - necessarily comes
+				// after the approval (issue #548).
+				$availableStatuses = $einvoicing->getSendableStatusesForReceivedInvoice($object->id, $object->element);
 
-				if (!$hasFinalLifecycle) {
-					$availableStatuses = $einvoicing->getEinvoiceStatusOptions(1, 1, 1);
-					$url_button = array();
-					foreach ($availableStatuses as $code => $label) {
-						$url_button[] = array(
-							'lang' => 'einvoicing',
-							'enabled' => true,
-							'perm' => ($forcedisabling ? -1 : ((bool) $user->hasRight("fournisseur", "facture", "creer") && empty($forcedisabling))),
-							'label' => (string) $label,
-							'url' => '/fourn/facture/card.php?id=' . $object->id . '&action=sendStatusMessage&pdpstatuscode=' . $code . '&token=' . newToken()
-						);
-					}
+				$url_button = array();
+				foreach ($availableStatuses as $code => $label) {
+					$url_button[] = array(
+						'lang' => 'einvoicing',
+						'enabled' => true,
+						'perm' => ($forcedisabling ? -1 : ((bool) $user->hasRight("fournisseur", "facture", "creer") && empty($forcedisabling))),
+						'label' => (string) $label,
+						'url' => '/fourn/facture/card.php?id=' . $object->id . '&action=sendStatusMessage&pdpstatuscode=' . $code . '&token=' . newToken()
+					);
+				}
 
-					if (!empty($url_button)) {
-						if ((float) DOL_VERSION < 18) {
-							print einvoicingDolGetButtonActionDropdown($langs->trans('einvoice'), $url_button);
-						} elseif ((float) DOL_VERSION < 22) {
-							print dolGetButtonAction($langs->trans('einvoice'), '', 'default', $url_button, '', true);
-						} else {
-							print dolGetButtonAction('', $langs->trans('einvoice'), 'default', $url_button, '', true);
-						}
+				if (!empty($url_button)) {
+					if ((float) DOL_VERSION < 18) {
+						print einvoicingDolGetButtonActionDropdown($langs->trans('einvoice'), $url_button);
+					} elseif ((float) DOL_VERSION < 22) {
+						print dolGetButtonAction($langs->trans('einvoice'), '', 'default', $url_button, '', true);
+					} else {
+						print dolGetButtonAction('', $langs->trans('einvoice'), 'default', $url_button, '', true);
 					}
 				}
 			}

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -728,6 +728,38 @@ class EInvoicing
 	}
 
 	/**
+	 * Statuses a user may still send by hand on an invoice received through the platform.
+	 *
+	 * The sendable list is narrowed by what the platform already accepted for that invoice. A status
+	 * it accepted is not proposed again. "Refused" (210) ends the exchange - an invoice sent back to
+	 * its vendor is not going to be paid, so nothing else is owed on it. "Approved" (205) ends nothing:
+	 * the normal order of things is to approve an invoice and then pay it, and "Payment transmitted"
+	 * (211) is precisely what is sent afterwards. An approved invoice can no longer be refused either.
+	 *
+	 * @param	int		$elementId		Id of the invoice
+	 * @param	string	$elementType	Element type ('invoice_supplier')
+	 * @return	array<int,string>		Status code => label, empty when the exchange is over
+	 */
+	public function getSendableStatusesForReceivedInvoice($elementId, $elementType)
+	{
+		if ($this->hasSentStatusMessage($elementId, $elementType, self::STATUS_REFUSED, 1)) {
+			return array();
+		}
+
+		$statuses = $this->getEinvoiceStatusOptions(1, 1, 1);
+		if ($this->hasSentStatusMessage($elementId, $elementType, self::STATUS_APPROVED, 1)) {
+			unset($statuses[self::STATUS_REFUSED]);
+		}
+		foreach (array_keys($statuses) as $code) {
+			if ($this->hasSentStatusMessage($elementId, $elementType, (int) $code, 1)) {
+				unset($statuses[$code]);
+			}
+		}
+
+		return $statuses;
+	}
+
+	/**
 	 * Get reasons for a given status that will be used when sending supplier invoice status updates to PDP/PA (for statuses Refused, Disputed, Partially Approved, Suspended)
 	 *
 	 * @param int $status		Status ID
@@ -2746,15 +2778,21 @@ class EInvoicing
 	 * @param	int		$elementId		Id of the invoice
 	 * @param	string	$elementType	Element type ('facture', 'invoice_supplier')
 	 * @param	int		$statusCode		Lifecycle status looked for (200 to 213)
+	 * @param	int		$onlyAccepted	1 to count only the sends the platform accepted, 0 (default) to count any attempt
 	 * @return	bool					True if that status has already been sent
 	 */
-	public function hasSentStatusMessage($elementId, $elementType, $statusCode)
+	public function hasSentStatusMessage($elementId, $elementType, $statusCode, $onlyAccepted = 0)
 	{
 		$sql = "SELECT rowid FROM " . $this->db->prefix() . "einvoicing_lifecycle_msg";
 		$sql .= " WHERE element_type = '" . $this->db->escape($elementType) . "'";
 		$sql .= " AND element_id = " . (int) $elementId;
 		$sql .= " AND lc_status = " . (int) $statusCode;
 		$sql .= " AND LOWER(direction) = 'out'";
+		if ($onlyAccepted) {
+			// Stored as 'Ok', but compared lowercased like the direction above: on PostgreSQL an equality
+			// on the stored case is a comparison that silently matches nothing.
+			$sql .= " AND LOWER(lc_validation_status) = 'ok'";
+		}
 		$sql .= " LIMIT 1";
 
 		$resql = $this->db->query($sql);

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -738,7 +738,9 @@ class EInvoicing
 	 *
 	 * @param	int		$elementId		Id of the invoice
 	 * @param	string	$elementType	Element type ('invoice_supplier')
-	 * @return	array<int,string>		Status code => label, empty when the exchange is over
+	 * @return	array<string|int,array{label:string,data-html:string,disable?:int,css?:string}>	The sendable
+	 *									statuses of getEinvoiceStatusOptions() minus the ones the history rules
+	 *									out, so the same shape as that method; empty when the exchange is over
 	 */
 	public function getSendableStatusesForReceivedInvoice($elementId, $elementType)
 	{

--- a/einvoicing/test/phpunit/ReceivedInvoiceStatusesTest.php
+++ b/einvoicing/test/phpunit/ReceivedInvoiceStatusesTest.php
@@ -1,0 +1,191 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/ReceivedInvoiceStatusesTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for EInvoicing::getSendableStatusesForReceivedInvoice(): which lifecycle
+ *                  statuses a user may still send by hand on an invoice received through the platform,
+ *                  given what the platform already accepted for it. The rule the module got wrong is
+ *                  that approving an invoice does not end the exchange - the payment, and the status
+ *                  reporting it, come after the approval (issue #548).
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+// See RecipientDirectoryTest.php for why DOLIBARR_HTDOCS is honoured before the relative path.
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+dol_include_once('einvoicing/class/einvoicing.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+if (empty($user->id)) {
+	print "Load permissions for admin user nb 1\n";
+	$user->fetch(1);
+	// User::loadRights() only exists from Dolibarr 19 on, older versions name it getrights()
+	if (method_exists($user, 'loadRights')) {
+		$user->loadRights();
+	} else {
+		$user->getrights();
+	}
+}
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+
+
+/**
+ * Tests on the statuses still offered on a received invoice.
+ *
+ * Every test writes its lifecycle records on an element id that no invoice uses, inside the transaction
+ * CommonClassTest opens for the class and rolls back afterwards, so a run leaves nothing behind.
+ */
+class ReceivedInvoiceStatusesTest extends CommonClassTest
+{
+	/** @var int Element id used by the records written here: high enough not to collide with a real invoice */
+	const TEST_ELEMENT_ID = 999999002;
+
+	/** @var string Element type of a supplier invoice, the only side that receives */
+	const TEST_ELEMENT_TYPE = 'invoice_supplier';
+
+	/**
+	 * A provider has to be set for storeStatusMessage() to record anything, and start from no history.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void
+	{
+		global $conf, $db;
+
+		parent::setUp();
+
+		$conf->global->EINVOICING_PDP = 'SUPERPDP';
+
+		$db->query("DELETE FROM " . $db->prefix() . "einvoicing_lifecycle_msg WHERE element_id = " . (int) self::TEST_ELEMENT_ID);
+	}
+
+	/**
+	 * Record an outgoing status the way sendStatusMessage() does once the platform answered.
+	 *
+	 * @param	int		$statusCode			Lifecycle status sent
+	 * @param	string	$validationStatus	What the platform answered ('Ok' = accepted)
+	 * @return	void
+	 */
+	private function sent($statusCode, $validationStatus = 'Ok')
+	{
+		global $db;
+
+		$einvoicing = new EInvoicing($db);
+		$einvoicing->storeStatusMessage(self::TEST_ELEMENT_ID, self::TEST_ELEMENT_TYPE, $statusCode, '', 'Out', 'ie_999001', $validationStatus);
+	}
+
+	/**
+	 * What the card would offer for the test invoice, as a list of status codes.
+	 *
+	 * @return	int[]	Status codes still sendable
+	 */
+	private function offered()
+	{
+		global $db;
+
+		$einvoicing = new EInvoicing($db);
+
+		return array_map('intval', array_keys($einvoicing->getSendableStatusesForReceivedInvoice(self::TEST_ELEMENT_ID, self::TEST_ELEMENT_TYPE)));
+	}
+
+	/**
+	 * An invoice on which nothing was sent yet offers the whole sendable list.
+	 *
+	 * @return void
+	 */
+	public function testNothingSentYetOffersEverySendableStatus()
+	{
+		$offered = $this->offered();
+
+		$this->assertContains(EInvoicing::STATUS_APPROVED, $offered);
+		$this->assertContains(EInvoicing::STATUS_REFUSED, $offered);
+		$this->assertContains(EInvoicing::STATUS_PAYMENT_SENT, $offered);
+	}
+
+	/**
+	 * The regression this guards, and the point of issue #548: an approved invoice is going to be paid,
+	 * so "Payment transmitted" has to stay reachable. The card used to hide the whole button group as
+	 * soon as an "Approved" was accepted, which made the manual 211 unreachable in the normal order of
+	 * things - approve, then pay.
+	 *
+	 * @return void
+	 */
+	public function testApprovedStillAllowsThePaymentStatus()
+	{
+		$this->sent(EInvoicing::STATUS_APPROVED);
+
+		$offered = $this->offered();
+
+		$this->assertContains(EInvoicing::STATUS_PAYMENT_SENT, $offered, 'the payment status is what follows an approval');
+		$this->assertNotContains(EInvoicing::STATUS_APPROVED, $offered, 'an accepted status is not offered twice');
+		$this->assertNotContains(EInvoicing::STATUS_REFUSED, $offered, 'an approved invoice cannot then be refused');
+	}
+
+	/**
+	 * Refusing ends the exchange: an invoice sent back to its vendor is not going to be paid, so nothing
+	 * is left to send and the button group disappears.
+	 *
+	 * @return void
+	 */
+	public function testRefusedEndsTheExchange()
+	{
+		$this->sent(EInvoicing::STATUS_REFUSED);
+
+		$this->assertSame(array(), $this->offered());
+	}
+
+	/**
+	 * Once approved and paid, nothing is left either.
+	 *
+	 * @return void
+	 */
+	public function testApprovedThenPaidLeavesNothingToSend()
+	{
+		$this->sent(EInvoicing::STATUS_APPROVED);
+		$this->sent(EInvoicing::STATUS_PAYMENT_SENT);
+
+		$this->assertSame(array(), $this->offered());
+	}
+
+	/**
+	 * A status the platform refused is not a status sent: it has to stay offered, otherwise a rejected
+	 * send would leave the user with no way to retry.
+	 *
+	 * @return void
+	 */
+	public function testARejectedSendRemainsRetryable()
+	{
+		$this->sent(EInvoicing::STATUS_APPROVED, 'Error');
+
+		$offered = $this->offered();
+
+		$this->assertContains(EInvoicing::STATUS_APPROVED, $offered);
+		$this->assertContains(EInvoicing::STATUS_REFUSED, $offered, 'nothing was accepted, so the choice is still open');
+	}
+}


### PR DESCRIPTION
Closes #548.

@camlafit reported that once a supplier invoice is validated and fully paid, every e-invoice status
action is gone, so the "Payment transmitted" (211) can no longer be sent. The automatic 211 and the
manual one both landed on `main` earlier, but the report also pointed at something that was not fixed,
and that is what this PR is about.

## Why the actions disappear

The `einvoice` button group of the supplier invoice card was hidden as soon as an **Approved (205)** or
a **Refused (210)** status had been accepted by the platform, on the reading that either of them closes
the lifecycle.

Only the refusal does. An invoice sent back to its vendor is not going to be paid, so nothing more is
owed on it. An approved invoice, on the contrary, is precisely the one that gets paid — and the 211 is
what reports that payment. Since the normal order of things is *approve, then pay*, the button group
was already gone by the time anyone would want the 211. That also explains the last remark of the
report: re-opening the invoice does not bring the buttons back, because the condition never looked at
the Dolibarr status of the invoice at all, only at what had already been sent.

## What changes

The card now offers what the exchange still allows, instead of closing it on the first final status:

- a status the platform accepted is never proposed a second time;
- a **refusal** leaves nothing — the group disappears, as before;
- an **approval** only takes the refusal away with it, since an approved invoice cannot then be refused.

The decision moved out of the hook into `EInvoicing::getSendableStatusesForReceivedInvoice()`, so it can
be tested, and `hasSentStatusMessage()` gained an `$onlyAccepted` flag to express "already accepted by
the platform" rather than "already attempted" — a send the platform rejected has to stay retryable.

One thing found on the way: the inline query being replaced compared `direction = 'out'` and
`lc_validation_status = 'Ok'` against the case actually stored, which is `Out` and `Ok`. MySQL lets that
pass on a case-insensitive collation; PostgreSQL matches nothing, so on Postgres the gate never fired at
all. Both comparisons are lowercased now, like the direction test already in `hasSentStatusMessage()`.

## Measured

On real invoices of the bench, comparing the old gate with the new list on the same records:

| instance | invoice | already accepted | before | after |
|---|---|---|---|---|
| dd23 | SI2608-0052 | 205 | *no button* | **211** |
| dd23 | SI2608-0050 | 205 | *no button* | **211** |
| dd23 | SI2608-0049 | 205 | *no button* | **211** |
| dd24 | SI2606-0001 | 205 | *no button* | **211** |
| dd18 | (PROV479) | 205 | *no button* | **211** |
| dd23 | SI2608-0006 | 205, 211 | *no button* | *no button* |
| dd18 | SI2608-0003 | 205, 211 | *no button* | *no button* |
| dd24 | SI2607-0002 | 211, 210, 205 | *no button* | *no button* |

The 211 thus made reachable was then really sent, by hand, on `SI2608-0052` (Dolibarr 23, SuperPDP
sandbox): `sendStatusMessage(211) -> res:1`, flow `ie_915345`, `validation=Ok` — accepted by the
platform. The card closes afterwards, the invoice having nothing left to send.

New test `test/phpunit/ReceivedInvoiceStatusesTest.php`, 5 cases including "a rejected send stays
retryable": **OK on the eight supported versions** (17.0.4, 18.0.10, 19.0.4, 20.0.4, 21.0.4, 22.0.5,
23.0.3, 24.0.0-beta). `phpcs` clean with the repository ruleset.

A full sandbox cycle was run on this branch: emission fine (`code=15`, flow `i_323547`), but the routing
acknowledgement stayed `Pending` and the document was not delivered — a control cycle run on `main`
today behaves identically, so it is the sandbox and not this branch. Nothing here touches emission or
routing in any case.

The customer side is untouched, and was checked rather than assumed: recording a payment on a
transmitted customer invoice still sends the "Cashed in" (212) through the `PAYMENT_CUSTOMER_CREATE`
trigger — flow `ie_916003`, `validation=Ok`.