### PR TITLE
FIX: the e-invoicing columns of the list are counted one too many, into a key that may not exist

### DIFF
--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -1368,6 +1368,18 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 
 		$contexts = explode(':', $parameters['context']);
 
+		// Every block below counts the cells it prints into the caller's column counter, which sizes the
+		// footer of the list. A hook is not guaranteed to receive that counter already built, so make sure
+		// of it once, before the first increment rather than after it. Only create the key when it is
+		// missing: the caller passes its own counter by reference (list.php builds 'totalarray' =>
+		// &$totalarray), so replacing an existing one would write through that reference and reset the
+		// count it has already accumulated.
+		if (!array_key_exists('totalarray', $parameters)) {
+			$parameters['totalarray'] = array('nbfield' => 0);
+		} elseif (!array_key_exists('nbfield', $parameters['totalarray'])) {
+			$parameters['totalarray']['nbfield'] = 0;
+		}
+
 		if (in_array('invoicelist', $contexts) && !getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP')) {
 			$einvoicing = new EInvoicing($db);
 			$checkConfig = $einvoicing->checkModulePrerequisites();
@@ -1397,13 +1409,6 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 				}
 				print '</td>';
 				if (isset($parameters['i']) && empty($parameters['i'])) {
-					if (!array_key_exists('totalarray', $parameters)) {
-						$parameters['totalarray'] = array('nbfield' => 0);
-					} elseif (!array_key_exists('nbfield', $parameters['totalarray'])) {
-						$parameters['totalarray']['nbfield'] = 0;
-					}
-
-					$parameters['totalarray']['nbfield']++;
 					$parameters['totalarray']['nbfield']++;
 				}
 			}


### PR DESCRIPTION
Follow-up to f5157454 ("Fix Column einvoice source not visible in customer invoice list"), which turned
the phan check red on `main` and, with it, on every pull request opened since. Two things in
`printFieldListValue()`, both about the counter the caller sizes the footer of the list with.

## The guard comes after the increment it protects

```php
if (isset($parameters['i']) && empty($parameters['i'])) {
    $parameters['totalarray']['nbfield']++;          // line 1387
}

// ... thirteen lines further down:
if (!array_key_exists('totalarray', $parameters)) {
    $parameters['totalarray'] = array('nbfield' => 0);
} elseif (!array_key_exists('nbfield', $parameters['totalarray'])) {
    $parameters['totalarray']['nbfield'] = 0;
}
```

The first column counts itself into a key nothing has created yet. That is what phan reports as
`PhanTypeArraySuspiciousNullable` on line 1387, and what a caller that does not pass that counter meets
as `Undefined array key "totalarray"`.

The guard is hoisted to the top of the method, where it also covers the supplier invoice and thirdparty
blocks, which had none. It still only creates the key when it is missing, and that part matters: the core
passes **its own counter by reference** — `'totalarray' => &$totalarray` in `compta/facture/list.php` —
so replacing an existing one would write through that reference and reset the count already accumulated
by the columns rendered before the hook.

## The e-invoice file column counts itself twice

The same block prints one `<td>` and increments twice. For the invoice list the module prints three
headers in `printFieldListTitle()` and three cells in `printFieldListValue()`, so the counter has to end
at three. It ended at four whenever the "e-invoice file" column is shown.

## Measured

Harness calling the two hooks through `HookManager`, with the parameter array built exactly as
`list.php` builds it, reference included:

| Dolibarr | before | after |
|---|---|---|
| 17.0.4 | headers=3 cells=3 **nbfield=4** + `Undefined array key "totalarray"` | headers=3 cells=3 **nbfield=3**, no notice |
| 18.0.10 | same | same |
| 19.0.4 | same | same |
| 20.0.4 | same | same |
| 21.0.4 | same | same |
| 22.0.5 | same | same |
| 23.0.3 | same | same |
| 24.0.0-beta | same | same |

A caller passing no `totalarray` at all no longer raises anything.

phan 5.5.2 with this repository's config and baseline, the command the workflow runs:

```
before : einvoicing/class/actions_einvoicing.class.php:1387 PhanTypeArraySuspiciousNullable
after  : nothing on einvoicing
```

`EInvoicingSamplesTest`, `CIIProtocolTest` and `CIIProfileShapeTest` green on the eight supported
versions (3 + 11 + 15 tests). `phpcs` clean.

No ChangeLog entry: this repairs code added the same day and never released, so an entry would describe
a defect no user has met. Say the word if you would rather have one.