### PR TITLE
[Einvoicing] Fix #588: the unprocessed Factur-X invoice is downloadable again

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -295,6 +295,17 @@ still allows - a status the platform accepted is not proposed a second time, a r
 and an approval only takes the refusal away with it. The query it replaces also compared the direction
 and the validation status against their stored case, which matches nothing on PostgreSQL (issue #548).
 
+FIX: A synchronization interrupted on a Factur-X invoice lets you download the document that stopped it
+again. The document list offers the last invoice that could not be processed under a fixed name, and it
+kept asking for facturx.pdf, a name nobody has written since the Factur-X reception was merged into the
+CII protocol: the received document is promoted to a slot named after the protocol file extension, so it
+lands in einvoice.pdf and the page pointed at nothing. The name is now asked of the protocols themselves,
+both by the page and by the clean-up that empties the slots at the start of a run - which was leaving the
+Factur-X one behind, too - so a protocol added later gets its slot without a page to update. The readable
+view that comes with some flows follows the same rule: it is offered when it exists, where it used to be
+offered on a Factur-X failure although its file is never written under that name, and never on a CII one
+although it is written there (issue #588).
+
 ## 1.0.3
 
 FIX: The totals of the generated document now follow the rounding convention of the instance. Dolibarr

--- a/einvoicing/class/protocols/AbstractProtocol.class.php
+++ b/einvoicing/class/protocols/AbstractProtocol.class.php
@@ -54,6 +54,9 @@ abstract class AbstractProtocol
 	/** @const string The profile used to generate XML */
 	protected const BUILD_XML_PROFILE = ''; // Must be overridden by subclasses
 
+	/** @const string Fixed file name of the readable view of the last invoice that could not be processed */
+	public const INCOMING_DIAGNOSTIC_READABLE_FILE_NAME = 'einvoice_readable.pdf';
+
 	/**
 	 * @param DoliDB $db Db
 	 */
@@ -273,6 +276,20 @@ abstract class AbstractProtocol
 	}
 
 	/**
+	 * Fixed file name of the "last invoice that could not be processed" diagnostic of this protocol,
+	 * relative to the module temp directory. Derived from the protocol file extension, so a received
+	 * CII document lands in einvoice.xml and a Factur-X one in einvoice.pdf. The pages that offer the
+	 * diagnostic for download must ask for the name here rather than hardcode it, otherwise a protocol
+	 * whose extension differs writes a slot nobody looks at (#588).
+	 *
+	 * @return	string		File name (no directory part)
+	 */
+	public static function getIncomingDiagnosticFileName()
+	{
+		return 'einvoice.' . static::INVOICE_FILE_EXTENSION;
+	}
+
+	/**
 	 * Clean up the per-call working temp files of an inbound invoice, while preserving the
 	 * "last invoice that could not be processed" diagnostic shown (and downloadable) in the
 	 * document list view.
@@ -285,13 +302,14 @@ abstract class AbstractProtocol
 	 * @param	string	$tempDir			Module temp directory
 	 * @param	string	$workFile			Unique working file for the received document
 	 * @param	string	$workReadable		Unique working file for the readable view (may not exist)
-	 * @param	string	$diagName			Fixed diagnostic filename for the received document
-	 * @param	string	$diagReadableName	Fixed diagnostic filename for the readable view
 	 * @param	bool	$failed				True if processing failed (keep the diagnostic), false otherwise
 	 * @return	void
 	 */
-	protected function cleanupIncomingTempFiles($tempDir, $workFile, $workReadable, $diagName, $diagReadableName, $failed)
+	protected function cleanupIncomingTempFiles($tempDir, $workFile, $workReadable, $failed)
 	{
+		$diagName = static::getIncomingDiagnosticFileName();
+		$diagReadableName = static::INCOMING_DIAGNOSTIC_READABLE_FILE_NAME;
+
 		if ($failed) {
 			// Keep the failed file(s) as the downloadable "last unprocessed invoice" diagnostic.
 			if (file_exists($workFile)) {

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -696,7 +696,7 @@ class CIIProtocol extends AbstractProtocol
 			$result = $this->doCreateSupplierInvoiceFromSource($file, $ReadableViewFile, $flowId, $tempFile, $tempFileReadableView);
 		} finally {
 			$failed = !is_array($result) || !isset($result['res']) || $result['res'] < 0;
-			$this->cleanupIncomingTempFiles($tempDir, $tempFile, $tempFileReadableView, 'einvoice.' . static::INVOICE_FILE_EXTENSION, 'einvoice_readable.pdf', $failed);
+			$this->cleanupIncomingTempFiles($tempDir, $tempFile, $tempFileReadableView, $failed);
 
 			// The invoice import transaction is opened by doCreateSupplierInvoiceFromSource() once the
 			// vendor has been synchronized. Close it here so every early return - and any exception -

--- a/einvoicing/class/protocols/ProtocolManager.class.php
+++ b/einvoicing/class/protocols/ProtocolManager.class.php
@@ -80,6 +80,29 @@ class ProtocolManager
 	}
 
 	/**
+	 * File names of the "last invoice that could not be processed" diagnostic slots, one per enabled
+	 * protocol (the readable view has a single name, AbstractProtocol::INCOMING_DIAGNOSTIC_READABLE_FILE_NAME).
+	 * Asking the protocols keeps the pages that display or clear the diagnostic in step with the names
+	 * the reception actually writes.
+	 *
+	 * @return string[]		File names, relative to the module temp directory
+	 */
+	public function getIncomingDiagnosticFileNames()
+	{
+		dol_include_once('/einvoicing/class/protocols/AbstractProtocol.class.php');
+
+		$names = array();
+		foreach (array_keys($this->protocolsList) as $name) {
+			$protocol = $this->getProtocol($name);
+			if ($protocol instanceof AbstractProtocol) {
+				$names[] = $protocol::getIncomingDiagnosticFileName();
+			}
+		}
+
+		return array_values(array_unique($names));
+	}
+
+	/**
 	 * Get protocol instance by name.
 	 *
 	 * @param string 	$name 			Name of the protocol to retrieve ('FACTURX', 'CII', 'UBL').

--- a/einvoicing/class/protocols/ProtocolManager.class.php
+++ b/einvoicing/class/protocols/ProtocolManager.class.php
@@ -85,7 +85,7 @@ class ProtocolManager
 	 * Asking the protocols keeps the pages that display or clear the diagnostic in step with the names
 	 * the reception actually writes.
 	 *
-	 * @return string[]		File names, relative to the module temp directory
+	 * @return list<string>		File names, relative to the module temp directory
 	 */
 	public function getIncomingDiagnosticFileNames()
 	{

--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -885,7 +885,15 @@ abstract class AbstractPDPProvider
 		global $conf;
 
 		$tempDir = $conf->einvoicing->dir_temp;
-		$diagFiles = array('facturx.pdf', 'facturx_readable.pdf', 'einvoice.xml', 'einvoice_readable.pdf');
+
+		$protocolManager = new ProtocolManager($this->db);
+		$diagFiles = $protocolManager->getIncomingDiagnosticFileNames();
+		$diagFiles[] = AbstractProtocol::INCOMING_DIAGNOSTIC_READABLE_FILE_NAME;
+		// Names used before the Factur-X reception was merged into CIIProtocol: no longer written, only
+		// cleaned up here so an installation upgraded with such a leftover does not keep it forever.
+		$diagFiles[] = 'facturx.pdf';
+		$diagFiles[] = 'facturx_readable.pdf';
+
 		foreach ($diagFiles as $f) {
 			if (file_exists($tempDir . '/' . $f)) {
 				dol_delete_file($tempDir . '/' . $f);

--- a/einvoicing/document_list.php
+++ b/einvoicing/document_list.php
@@ -75,6 +75,7 @@ include_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 include_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
 include_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php';
 include_once __DIR__.'/class/providers/PDPProviderManager.class.php';
+include_once __DIR__.'/class/protocols/ProtocolManager.class.php';
 
 // load module libraries
 include_once __DIR__.'/class/document.class.php';
@@ -243,8 +244,12 @@ if (!$permissiontoread) {
 	accessforbidden();
 }
 
-$filePathFacturX = $conf->einvoicing->dir_temp . '/facturx.pdf';
-$filePathCII = $conf->einvoicing->dir_temp . '/einvoice.xml';
+// Fixed slots of the "last invoice that could not be processed" diagnostic, written by
+// AbstractProtocol::cleanupIncomingTempFiles(): one per protocol (einvoice.xml for a CII flow,
+// einvoice.pdf for a Factur-X one), plus the readable view when the platform provided one.
+$protocolManager = new ProtocolManager($db);
+$diagFileNames = $protocolManager->getIncomingDiagnosticFileNames();
+$diagReadableFileName = AbstractProtocol::INCOMING_DIAGNOSTIC_READABLE_FILE_NAME;
 
 
 /*
@@ -728,27 +733,33 @@ $last_sync_info .= '</span>';
 // Last supplier invoice that could not be processed by the system
 $last_supplier_invoice_error = '';
 
-if (file_exists($filePathFacturX)) {
-	$urlOriginalFile = DOL_URL_ROOT . '/document.php?modulepart=einvoicing&file=' . urlencode('temp/facturx.pdf');
-	$urlConvertedFile = DOL_URL_ROOT . '/document.php?modulepart=einvoicing&file=' . urlencode('temp/facturx_readable.pdf');
-
-	$last_supplier_invoice_error = '<span class="opacitylowx">'.img_picto('', 'times', 'class="pictofixedwidth"');
-	$last_supplier_invoice_error .= ' ' . $langs->trans("LastSupplierInvoiceCouldNotBeProcessed");
-	$last_supplier_invoice_error .= '<i class="fas fa-info-circle em088 opacityhigh classfortooltip" title="'. $langs->trans("LastSupplierInvoiceCouldNotBeProcessedInfo") .'"></i>';
-	$last_supplier_invoice_error .= ' : </span>';
-	$last_supplier_invoice_error .= '<a href="'.$urlOriginalFile.'">' . $langs->trans("facturXDownloadOriginal") . ' ' . img_picto('', 'download', 'class="pictofixedwidth"') . '</a>';
-	$last_supplier_invoice_error .= ' <span class="opacitylow">|</span> ';
-	$last_supplier_invoice_error .= '<a href="'.$urlConvertedFile.'">' . $langs->trans("facturXDownloadConverted") . ' ' . img_picto('', 'download', 'class="pictofixedwidth"') . '</a>';
+// Keep the most recent slot: a run may have failed on a CII flow and on a Factur-X one.
+$diagFileName = '';
+$diagFileDate = 0;
+foreach ($diagFileNames as $f) {
+	$diagFilePath = $conf->einvoicing->dir_temp . '/' . $f;
+	if (file_exists($diagFilePath) && filemtime($diagFilePath) >= $diagFileDate) {
+		$diagFileName = $f;
+		$diagFileDate = filemtime($diagFilePath);
+	}
 }
 
-if (file_exists($filePathCII)) {
-	$urlOriginalFile = DOL_URL_ROOT . '/document.php?modulepart=einvoicing&file=' . urlencode('temp/einvoice.xml');
+if ($diagFileName) {
+	$urlOriginalFile = DOL_URL_ROOT . '/document.php?modulepart=einvoicing&file=' . urlencode('temp/' . $diagFileName);
 
 	$last_supplier_invoice_error = '<span class="opacitylowx">'.img_picto('', 'times', 'class="pictofixedwidth"');
 	$last_supplier_invoice_error .= ' ' . $langs->trans("LastSupplierInvoiceCouldNotBeProcessed");
 	$last_supplier_invoice_error .= '<i class="fas fa-info-circle em088 opacityhigh classfortooltip" title="'. $langs->trans("LastSupplierInvoiceCouldNotBeProcessedInfo") .'"></i>';
 	$last_supplier_invoice_error .= ' : </span>';
 	$last_supplier_invoice_error .= '<a href="'.$urlOriginalFile.'">' . $langs->trans("facturXDownloadOriginal") . ' ' . img_picto('', 'download', 'class="pictofixedwidth"') . '</a>';
+
+	// The readable view is only stored when the platform provided one with the flow
+	if (file_exists($conf->einvoicing->dir_temp . '/' . $diagReadableFileName)) {
+		$urlConvertedFile = DOL_URL_ROOT . '/document.php?modulepart=einvoicing&file=' . urlencode('temp/' . $diagReadableFileName);
+
+		$last_supplier_invoice_error .= ' <span class="opacitylow">|</span> ';
+		$last_supplier_invoice_error .= '<a href="'.$urlConvertedFile.'">' . $langs->trans("facturXDownloadConverted") . ' ' . img_picto('', 'download', 'class="pictofixedwidth"') . '</a>';
+	}
 }
 
 // Form for sync action


### PR DESCRIPTION
Fixes #588.

When a synchronization is interrupted on a received invoice, the failed document is promoted to a fixed
diagnostic slot that the document list offers for download, under "Last supplier invoice that could not
be synchronized". The slot is named after the protocol file extension
(`AbstractProtocol::cleanupIncomingTempFiles()`): `einvoice.xml` for a CII flow, `einvoice.pdf` for a
Factur-X one. `document_list.php` asked for `temp/facturx.pdf` and `temp/einvoice.xml` instead, and
nobody has written `facturx.pdf` since PR #389 merged the Factur-X reception into `CIIProtocol` - the
public wrapper is inherited since then, so the name follows the extension. A Factur-X failure therefore
filled a slot no page looked at, and `clearIncomingDiagnosticFiles()` missed `einvoice.pdf` at the start
of a run for the same reason.

## What this changes

The name is derived once and asked for, instead of being repeated in each place that needs it:

- `AbstractProtocol::getIncomingDiagnosticFileName()` returns the slot of a protocol, and
  `cleanupIncomingTempFiles()` uses it rather than receiving it from its caller (two parameters gone);
- `ProtocolManager::getIncomingDiagnosticFileNames()` returns the slots of the enabled protocols, which
  is what `document_list.php` and `clearIncomingDiagnosticFiles()` now ask for. A protocol added later
  gets its slot without a page to update.

The list keeps the most recent slot, since a run may have failed on a CII flow and on a Factur-X one.
`clearIncomingDiagnosticFiles()` still deletes `facturx.pdf` / `facturx_readable.pdf` so an installation
upgraded with such a leftover does not keep it forever.

The readable view follows the same rule: it is offered when `einvoice_readable.pdf` exists. The page used
to print that link unconditionally next to a Factur-X failure, pointing at `facturx_readable.pdf` which
is never written, and never next to a CII one although the file is written for both protocols whenever
the platform provides a readable view with the flow.

## Test

Tested live on Dolibarr 22.0.5 against SuperPDP, on a synchronization interrupted by a product missing
from the database, the automatic creation of products being disabled.

Before: the run stops on the flow, `documents/einvoicing/temp/einvoice.pdf` is written (43 kB), and the
document list reports the failure with no link to the document.

After, replaying the same synchronization: the run clears the slot and the failed flow re-creates it,
`ProtocolManager::getIncomingDiagnosticFileNames()` returns `einvoice.xml, einvoice.pdf` on that
instance, the page selects `einvoice.pdf` and offers it for download. No readable view was provided with
that flow, so the converted link is absent - where it used to be printed on a file that does not exist.

phpcs clean on the five files.
