### PR TITLE
FIX Tell where to enter the VATEX code the message asks for

### DIFF
--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -1684,8 +1684,11 @@ trait CommonProtocol
 						}
 
 						if (empty($vatex)) {
+							// Say where the constant is entered: its name alone sends the administrator looking for a
+							// setup page that does not exist for it (it is a hidden constant, only Home - Setup - Other).
+							$urltoconstsetup = DOL_URL_ROOT.'/admin/const.php';
 							$errormsg = $langs->trans("UnknownVATEX1", $id, '0', $vat_src_code);
-							$errormsg .= '<br>'.$langs->trans("UnknownVATEX2a", '0', ($vat_src_code ? $vat_src_code : "''"), $constantforvatex);
+							$errormsg .= '<br>'.$langs->trans("UnknownVATEX2a", '0', ($vat_src_code ? $vat_src_code : "''"), $constantforvatex, $urltoconstsetup);
 							//$exemptionReason .= ' '.$langs->trans("ClickHere", $constantforvatex);		// Go on other setup page
 
 							throw new Exception('MISSINGSETUP: '.$errormsg);
@@ -1716,9 +1719,12 @@ trait CommonProtocol
 						}
 
 						if (empty($vatex)) {
+							// The dictionary has a lot of columns: name the one to fill, and name it with the label of
+							// the core so the administrator reads on screen the same words as in the message.
+							$langs->load("compta");
 							$urltovatdic = DOL_URL_ROOT.'/admin/dict.php?id=10';
 							$errormsg = $langs->trans("UnknownVATEX1", $id, '0', $vat_src_code);
-							$errormsg .= '<br>'.$langs->trans("UnknownVATEX2b", '0', ($vat_src_code ? $vat_src_code : "''"), $urltovatdic);
+							$errormsg .= '<br>'.$langs->trans("UnknownVATEX2b", '0', ($vat_src_code ? $vat_src_code : "''"), $urltovatdic, $langs->trans("VATExemptionCode"));
 							//$errormsg .= ' '.$langs->trans("ClickHere", $constantforvatex);		// Go on dictionary page
 
 							throw new Exception('MISSINGSETUP: '.$errormsg);

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -340,8 +340,8 @@ SetTheAccessPointConversionFormat=On your Access Point account, set the preferre
 DisabledInProductionMode=Disabled in production mode.
 ConnectTo=Connect
 UnknownVATEX1=Unknown exempting VAT reason for the line %s that has the VAT rate %s and VAT code '%s'.
-UnknownVATEX2a=The administrator must define a valid VATEX code (reason of VAT exemption) for the couple (VAT rate / code) = (%s / %s) into the constant %s.
-UnknownVATEX2b=The administrator must define a valid VATEX code (reason of VAT exemption) for the couple (VAT rate / code) = (%s / %s) into the <a href="%s" target="_blank">dictionary of VAT rates</a>.
+UnknownVATEX2a=The administrator must define a valid VATEX code (reason of VAT exemption) for the couple (VAT rate / code) = (%s / %s) into the constant %s, to be added from <a href="%s" target="_blank">Home - Setup - Other setup</a>.
+UnknownVATEX2b=The administrator must define a valid VATEX code (reason of VAT exemption) for the couple (VAT rate / code) = (%s / %s) into the <a href="%s" target="_blank">dictionary of VAT rates</a>, column "%s".
 IBANForSellerMandatoryOnCreditTransferButNotBankAcount=A payment mode was set to pay with credit transfer, but no default bank account to use for has been set.
 IBANForSellerMandatoryOnCreditTransferButNotBankAcount2=Set a default bank account in the configuration of the invoice module OR in the invoice itself (and check that this bank account has a BAN number defined).
 IBANForSellerMandatoryOnCreditTransferButNotBAN=A payment mode was set to pay with credit transfer, but the selected default bank account has no BAN number defined.


### PR DESCRIPTION
Follow-up of #593, wording only.

The "Unknown exempting VAT reason" message says what is missing but not where to put it, and the round trip on #593 came from exactly that. On **Dolibarr 23 and below** it ends with *"into the constant `MAIN_VAT_EXEMPTION_CODE_FOR_0`"*: that is not a place an administrator can go and look for, it is a hidden constant that only exists once it is created from *Home - Setup - Other setup*. The message now links to that page.

On **24 and above** the code is read from the VAT dictionary instead and the message already links to it, but that dictionary has fifteen columns. It now names the one to fill, and names it with the label of the core (`VATExemptionCode`, loaded from `compta`), so the words in the message are the words on the screen.

Nothing changes in the rules that decide when the message is raised, nor in the generated XML.

### Before / after, taken from a live run

Dolibarr 22.0.5, credit note with a line at 0 % and no exemption code set:

```
before: ... into the constant MAIN_VAT_EXEMPTION_CODE_FOR_0.
after : ... into the constant MAIN_VAT_EXEMPTION_CODE_FOR_0, to be added from
        <a href="/admin/const.php" target="_blank">Home - Setup - Other setup</a>.
```

Dolibarr 24.0.0-beta, invoice with a line at 0 % and `einvoice_vatex` empty in the dictionary:

```
before: ... into the <a href="/admin/dict.php?id=10">dictionary of VAT rates</a>.
after : ... into the <a href="/admin/dict.php?id=10">dictionary of VAT rates</a>,
        column "VAT exemption code".
```

### Tested

- 22.0.5: message above produced for real by `CIIProtocol::generateInvoice()`; with the constant set, generation still succeeds.
- 24.0.0-beta: message above produced for real; with `einvoice_vatex` filled in the dictionary, generation succeeds and the XML carries `<ram:ExemptionReasonCode>VATEX-FR-CGI261-4</ram:ExemptionReasonCode>`.
- `EInvoicingSamplesTest`: 3 tests / 6 assertions, green.
- phpcs with the repository ruleset: clean.

Translations: `en_US` only, as agreed. The other languages keep the three-parameter string until Transifex catches up — `sprintf()` simply ignores the extra parameter, so they show the previous wording rather than breaking.
