### PR TITLE
FIX #600 [einvoicing] Do not demand a professional id of a B2C third party

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -16,8 +16,9 @@ company without a professional id is still blocked, option or not.
 The same invoices could also reach that pre-check through the other end: needEInvoiceManagement()
 answers with a status code, and the two codes meaning "out of scope" (98 and 99) are truthy, so the
 callers that only tested its answer for truth treated an ignored invoice as one to e-invoice. They
-now compare against the codes, which also removes the generation button from an invoice explicitly
-excluded from e-invoicing.
+now ask the boolean question instead - mustManageEInvoice() for an invoice, isIgnoredStatus() for a
+stored status - both reading a single list of the codes that keep an invoice out of the scope. This
+also removes the generation button from an invoice explicitly excluded from e-invoicing.
 
 FIX: The Factur-X files the module produces are now valid PDF/A-3, which they had never been - and a
 Factur-X file that is not a PDF/A-3 file is not a conformant Factur-X, whatever its XML says (veraPDF

--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -2,6 +2,23 @@
 
 ## 1.0.4
 
+FIX: A third party recognised as a private individual is no longer reported as misconfigured when
+EINVOICING_SKIP_B2C is on (issue #600). The option already kept B2C invoices out of the e-invoicing
+scope - needEInvoiceManagement() answers "do not manage" on them, since B2C is reported by e-reporting
+and not transmitted as an e-invoice - but the pre-check of the third party knew nothing about it and
+still demanded a professional id, an identifier a private individual has no reason to own. Generating
+or sending such an invoice failed on "The customer has no professional id (SIREN)", and the invoice
+could be refused altogether where EINVOICING_EINVOICE_CANCEL_IF_EINVOICE_FAILS is set. The pre-check
+now reads the same Societe::isACompany() as the decision does, so both ends of the chain agree on who
+is B2C, and neither the professional id nor the routing id is required of a private individual. A
+company without a professional id is still blocked, option or not.
+
+The same invoices could also reach that pre-check through the other end: needEInvoiceManagement()
+answers with a status code, and the two codes meaning "out of scope" (98 and 99) are truthy, so the
+callers that only tested its answer for truth treated an ignored invoice as one to e-invoice. They
+now compare against the codes, which also removes the generation button from an invoice explicitly
+excluded from e-invoicing.
+
 FIX: The Factur-X files the module produces are now valid PDF/A-3, which they had never been - and a
 Factur-X file that is not a PDF/A-3 file is not a conformant Factur-X, whatever its XML says (veraPDF
 1.30.2 rejected every one of them, on Dolibarr 17 to 24 alike). The cause that belongs to the module is

--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -103,18 +103,15 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 		if ($invoiceObject instanceof Facture) {
 			/** @var Facture $invoiceObject */
 
-			// needEInvoiceManagement() answers with a status code, not a boolean: STATUS_IGNORE (99) and
-			// STATUS_IGNORE_2 (98) both mean "out of the e-invoicing scope" yet are truthy, so testing the
-			// return value alone let an ignored invoice (a B2C one when EINVOICING_SKIP_B2C is on, typically)
-			// walk into the checks below and be reported as misconfigured. Only the "to generate" answer opens
-			// the real-time generation.
-			$needEinvoice = $einvoicing->needEInvoiceManagement($invoiceObject);
-			if ($needEinvoice && $needEinvoice != $einvoicing::STATUS_IGNORE && $needEinvoice != $einvoicing::STATUS_IGNORE_2) {
+			// Ask the boolean question: needEInvoiceManagement() answers with a status code, and the codes
+			// meaning "out of the e-invoicing scope" are truthy, so testing its answer for truth alone let an
+			// ignored invoice (a B2C one when EINVOICING_SKIP_B2C is on, typically) walk into the checks below
+			// and be reported as misconfigured.
+			if ($einvoicing->mustManageEInvoice($invoiceObject)) {
 				// Get current status of e-invoice
 				$currentStatusDetails = $einvoicing->fetchLastknownInvoiceStatus($invoiceObject->id, $invoiceObject->ref);
 
-				if (!isset($currentStatusDetails['code']) ||
-					($currentStatusDetails['code'] != $einvoicing::STATUS_IGNORE && $currentStatusDetails['code'] != $einvoicing::STATUS_IGNORE_2)) {
+				if (!isset($currentStatusDetails['code']) || !EInvoicing::isIgnoredStatus($currentStatusDetails['code'])) {
 					if ($invoiceObject->status != $invoiceObject::STATUS_DRAFT	// Never generate/transmit an e-invoice for a DRAFT (note: at validation the invoice has already status VALIDATED when Dolibarr regenerates the final PDF, so the legitimate flow is preserved).
 						&& !getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP')
 						&& getDolGlobalString('EINVOICING_EINVOICE_IN_REAL_TIME')) {
@@ -322,11 +319,10 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 			if ($object->status == Facture::STATUS_VALIDATED || $object->status == Facture::STATUS_CLOSED) {
 				// if E-invoice is not generated, show button to generate e-invoice
 				// STATUS_IGNORE_2 has no entry in STATUS_LABEL_KEYS, so the "unknown code" fallback below used to
-				// offer the generation button on an invoice explicitly excluded from e-invoicing. Exclude both
-				// ignore codes explicitly: an ignored invoice has nothing to generate.
+				// offer the generation button on an invoice explicitly excluded from e-invoicing. An ignored
+				// invoice has nothing to generate, whatever its code is known or not.
 				if (
-					$currentStatusDetails['code'] != $einvoicing::STATUS_IGNORE
-					&& $currentStatusDetails['code'] != $einvoicing::STATUS_IGNORE_2
+					!EInvoicing::isIgnoredStatus($currentStatusDetails['code'])
 					&& ($currentStatusDetails['code'] == $einvoicing::STATUS_NOT_GENERATED
 						|| !array_key_exists($currentStatusDetails['code'], $einvoicing::STATUS_LABEL_KEYS))
 				) {

--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -103,8 +103,13 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 		if ($invoiceObject instanceof Facture) {
 			/** @var Facture $invoiceObject */
 
+			// needEInvoiceManagement() answers with a status code, not a boolean: STATUS_IGNORE (99) and
+			// STATUS_IGNORE_2 (98) both mean "out of the e-invoicing scope" yet are truthy, so testing the
+			// return value alone let an ignored invoice (a B2C one when EINVOICING_SKIP_B2C is on, typically)
+			// walk into the checks below and be reported as misconfigured. Only the "to generate" answer opens
+			// the real-time generation.
 			$needEinvoice = $einvoicing->needEInvoiceManagement($invoiceObject);
-			if ($needEinvoice) {
+			if ($needEinvoice && $needEinvoice != $einvoicing::STATUS_IGNORE && $needEinvoice != $einvoicing::STATUS_IGNORE_2) {
 				// Get current status of e-invoice
 				$currentStatusDetails = $einvoicing->fetchLastknownInvoiceStatus($invoiceObject->id, $invoiceObject->ref);
 
@@ -316,9 +321,14 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 
 			if ($object->status == Facture::STATUS_VALIDATED || $object->status == Facture::STATUS_CLOSED) {
 				// if E-invoice is not generated, show button to generate e-invoice
+				// STATUS_IGNORE_2 has no entry in STATUS_LABEL_KEYS, so the "unknown code" fallback below used to
+				// offer the generation button on an invoice explicitly excluded from e-invoicing. Exclude both
+				// ignore codes explicitly: an ignored invoice has nothing to generate.
 				if (
-					$currentStatusDetails['code'] == $einvoicing::STATUS_NOT_GENERATED
-					|| !array_key_exists($currentStatusDetails['code'], $einvoicing::STATUS_LABEL_KEYS)
+					$currentStatusDetails['code'] != $einvoicing::STATUS_IGNORE
+					&& $currentStatusDetails['code'] != $einvoicing::STATUS_IGNORE_2
+					&& ($currentStatusDetails['code'] == $einvoicing::STATUS_NOT_GENERATED
+						|| !array_key_exists($currentStatusDetails['code'], $einvoicing::STATUS_LABEL_KEYS))
 				) {
 					$url_button[] = array(
 						'lang' => 'einvoicing',

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -70,6 +70,17 @@ class EInvoicing
 	public const STATUS_IGNORE_2            = 98;		// Never sync (for another reason than ereporting, not used yet)
 	public const STATUS_IGNORE              = 99;		// Never sync
 
+	/**
+	 * The two codes above, as a list: they keep an invoice out of the e-invoicing scope, it is never
+	 * generated nor sent (B2C invoices reported by e-reporting, TakePOS tickets synced by the cash
+	 * closing, ...). Grouped here so that adding an "ignore" code is honoured by every caller at
+	 * once, through isIgnoredStatus().
+	 */
+	public const STATUS_IGNORE_CODES = [
+		self::STATUS_IGNORE,
+		self::STATUS_IGNORE_2
+	];
+
 	// PDP / PA normalized statuses
 	// public const STATUS_DEPOSITED           = 200;
 	// public const STATUS_ISSUED              = 201;
@@ -2973,7 +2984,9 @@ class EInvoicing
 
 
 	/**
-	 * Return if an invoice need EInvoicing management.
+	 * Return the e-invoicing status an invoice qualifies for. This is the status to store, not an
+	 * answer to "must this invoice be e-invoiced?": the codes meaning "out of scope" are truthy, so
+	 * never test this answer for truth alone, call mustManageEInvoice() for that question.
 	 *
 	 * @param 	Facture|FactureRec		$object		Object
 	 * @return 	int 								self::STATUS_NOT_GENERATED if the invoice object need management of EInvoicing, self::STATUS_IGNORE or self::self::STATUS_IGNORE_2 if not.
@@ -3029,6 +3042,33 @@ class EInvoicing
 		// TODO Add hook
 
 		return $return;
+	}
+
+
+	/**
+	 * Return if an invoice must be managed by EInvoicing. Boolean counterpart of
+	 * needEInvoiceManagement(), which answers with a status code.
+	 *
+	 * @param 	Facture|FactureRec		$object		Object
+	 * @return 	bool								True if the invoice is in the e-invoicing scope
+	 */
+	public function mustManageEInvoice($object)
+	{
+		$status = $this->needEInvoiceManagement($object);
+
+		return !empty($status) && !self::isIgnoredStatus($status);
+	}
+
+
+	/**
+	 * Return if a status code keeps the invoice out of the e-invoicing scope.
+	 *
+	 * @param 	int|string				$status		Status code, a self::STATUS_* value
+	 * @return 	bool								True if the invoice must never be e-invoiced
+	 */
+	public static function isIgnoredStatus($status)
+	{
+		return in_array((int) $status, self::STATUS_IGNORE_CODES, true);
 	}
 
 

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -61,14 +61,14 @@ class EInvoicing
 	// Dolibarr internal statuses
 	public const STATUS_UNKNOWN             = 0;		// By default, before the e-invoice has been generated
 
-	public const STATUS_NOT_GENERATED       = 5;		// To sync
-	public const STATUS_GENERATED           = 10;
+	public const STATUS_NOT_GENERATED       = 5;		// To generate then to sync
+	public const STATUS_GENERATED           = 10;		// To sync
 	public const STATUS_AWAITING_VALIDATION = 15;		// Einvoice received but not yet analyzed by your AP
 	public const STATUS_AWAITING_ACK        = 20;		// Einvoice received and analyzed by your AP. Next step happen when doing sync.
 	public const STATUS_ERROR               = 25;
 
 	public const STATUS_IGNORE_2            = 98;		// Never sync (for another reason than ereporting, not used yet)
-	public const STATUS_IGNORE              = 99;		// Never sync
+	public const STATUS_IGNORE              = 99;		// Never sync (will be processed by ereporting)
 
 	/**
 	 * The two codes above, as a list: they keep an invoice out of the e-invoicing scope, it is never

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -886,11 +886,19 @@ class EInvoicing
 		$baseErrors = [];
 		$baseWarnings = [];
 
+		// A private individual has no professional id, and when EINVOICING_SKIP_B2C is on that third party is
+		// out of the e-invoicing scope anyway (B2C is reported by e-reporting, not transmitted as an e-invoice):
+		// its missing SIREN must not be reported as a blocking configuration error. Detection is delegated to
+		// Societe::isACompany(), the same way needEInvoiceManagement() does, so both ends of the chain agree.
+		$isB2C = getDolGlobalInt('EINVOICING_SKIP_B2C') && is_object($thirdparty) && !$thirdparty->isACompany();
+
 		if (empty($thirdparty->name)) {
 			$baseErrors[] = $langs->trans("FxCheckErrorCustomerName");
 		}
 		if (empty($thirdparty->idprof1)) {
-			$baseErrors[] = $langs->trans("FxCheckErrorCustomerIDPROF1");
+			if (!$isB2C) {
+				$baseErrors[] = $langs->trans("FxCheckErrorCustomerIDPROF1");
+			}
 		} elseif (!empty($thirdparty->country_code) && $thirdparty->country_code === 'FR') {
 			// Validate SIREN/SIRET format based on length (French companies only)
 			$idprof1 = preg_replace('/\s+/', '', (string) $thirdparty->idprof1);
@@ -925,7 +933,9 @@ class EInvoicing
 		$routing_id = $this->getBuyerCommunicationURI($thirdparty);
 		// If EINVOICING_BLOCK_INVOICE_NO_ROUTING_ID is off, we use the profid as einvoice id and we already have the previous error message of
 		// profid missing. But if on, we also add a message dedicated to einvoice ID.
-		if (getDolGlobalString('EINVOICING_BLOCK_INVOICE_NO_ROUTING_ID') && empty($routing_id)) {
+		// Same reason as for the professional id above: a B2C third party is not addressed on the network, so
+		// having no routing id is expected and must not block.
+		if (getDolGlobalString('EINVOICING_BLOCK_INVOICE_NO_ROUTING_ID') && empty($routing_id) && !$isB2C) {
 			$baseErrors[] = $langs->trans("FxCheckErrorCustomerRoutingID");
 		}
 		if ($thirdparty->tva_assuj && empty($thirdparty->tva_intra)) {

--- a/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
+++ b/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
@@ -410,7 +410,10 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 	{
 		$einvoicing = new EInvoicing($this->db);
 
-		if (!$einvoicing->needEInvoiceManagement($invoice)) {
+		// A status code, not a boolean: the two ignore codes are truthy (98 and 99), so test the answer we
+		// actually want. An invoice out of the e-invoicing scope has no cash-in to report.
+		$needEinvoice = $einvoicing->needEInvoiceManagement($invoice);
+		if (!$needEinvoice || $needEinvoice == $einvoicing::STATUS_IGNORE || $needEinvoice == $einvoicing::STATUS_IGNORE_2) {
 			return;
 		}
 

--- a/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
+++ b/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
@@ -410,10 +410,9 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 	{
 		$einvoicing = new EInvoicing($this->db);
 
-		// A status code, not a boolean: the two ignore codes are truthy (98 and 99), so test the answer we
-		// actually want. An invoice out of the e-invoicing scope has no cash-in to report.
-		$needEinvoice = $einvoicing->needEInvoiceManagement($invoice);
-		if (!$needEinvoice || $needEinvoice == $einvoicing::STATUS_IGNORE || $needEinvoice == $einvoicing::STATUS_IGNORE_2) {
+		// Ask the boolean question: needEInvoiceManagement() answers with a status code whose ignore values
+		// are truthy. An invoice out of the e-invoicing scope has no cash-in to report.
+		if (!$einvoicing->mustManageEInvoice($invoice)) {
 			return;
 		}
 

--- a/einvoicing/test/phpunit/AllTests.php
+++ b/einvoicing/test/phpunit/AllTests.php
@@ -123,6 +123,8 @@ class AllTests
 		$suite->addTestSuite('RecipientDirectoryTest');
 		require_once dirname(__FILE__).'/SellerVatRegimeTest.php';
 		$suite->addTestSuite('SellerVatRegimeTest');
+		require_once dirname(__FILE__).'/SkipB2CPrecheckTest.php';
+		$suite->addTestSuite('SkipB2CPrecheckTest');
 		require_once dirname(__FILE__).'/SupplierInvoiceHelperTest.php';
 		$suite->addTestSuite('SupplierInvoiceHelperTest');
 		require_once dirname(__FILE__).'/TransmittedLockTest.php';

--- a/einvoicing/test/phpunit/SkipB2CPrecheckTest.php
+++ b/einvoicing/test/phpunit/SkipB2CPrecheckTest.php
@@ -1,0 +1,261 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/SkipB2CPrecheckTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for the third party pre-check when EINVOICING_SKIP_B2C is on, issue #600.
+ *                  A private individual has no professional id, and with that option on the invoice is
+ *                  already out of the e-invoicing scope (needEInvoiceManagement() answers STATUS_IGNORE):
+ *                  the pre-check must not report the missing SIREN as a blocking configuration error.
+ *                  The detection of a private individual is Societe::isACompany(), the same one the
+ *                  decision uses, so both ends of the chain agree on who is B2C.
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+// See VatPointDateCodeTest for why DOLIBARR_HTDOCS is honoured before the relative path.
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
+dol_include_once('einvoicing/class/einvoicing.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class SkipB2CPrecheckTest extends CommonClassTest
+{
+	/**
+	 * A French third party carrying no professional id at all, described the way a customer card
+	 * records a private individual: nature "Particulier" (TE_PRIVATE), no SIREN, no SIRET, no VAT
+	 * number. Societe::isACompany() answers 0 on it.
+	 *
+	 * @return	Societe
+	 */
+	private function privateIndividual()
+	{
+		global $db;
+
+		$thirdparty = new Societe($db);
+		$thirdparty->name = 'Particulier';
+		$thirdparty->typent_code = 'TE_PRIVATE';
+		$thirdparty->country_code = 'FR';
+		$thirdparty->address = '3 rue des Particuliers';
+		$thirdparty->zip = '86000';
+		$thirdparty->town = 'Poitiers';
+		$thirdparty->tva_assuj = 0;
+
+		return $thirdparty;
+	}
+
+	/**
+	 * The same customer card, but for a company that has not been given its SIREN: it declares a VAT
+	 * number, which is what makes isACompany() answer "company" on every supported core - up to
+	 * Dolibarr 19 a third party carrying neither a VAT number nor a professional id is never one,
+	 * whatever its nature says, so a fixture relying on the nature alone would not be portable.
+	 *
+	 * @return	Societe
+	 */
+	private function companyWithoutProfessionalId()
+	{
+		$thirdparty = $this->privateIndividual();
+		$thirdparty->name = 'Company';
+		$thirdparty->typent_code = '';
+		$thirdparty->tva_assuj = 1;
+		$thirdparty->tva_intra = 'FR11123456782';
+
+		return $thirdparty;
+	}
+
+	/** @var array<string,string> Core options this test pins, saved as they were found */
+	private $savedoptions = array();
+
+	/**
+	 * Pin the two core options Societe::isACompany() reads besides the identifiers and the nature of
+	 * the third party, so the fixtures mean the same thing on every instance the suite runs against:
+	 * MAIN_CUSTOMERS_ARE_COMPANIES_EVEN_IF_SET_AS_INDIVIDUAL would make a company of the private
+	 * individual, and MAIN_UNKNOWN_CUSTOMERS_ARE_COMPANIES decides for a third party whose nature is
+	 * left unknown.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void
+	{
+		global $conf;
+
+		parent::setUp();
+
+		foreach (array('MAIN_UNKNOWN_CUSTOMERS_ARE_COMPANIES', 'MAIN_CUSTOMERS_ARE_COMPANIES_EVEN_IF_SET_AS_INDIVIDUAL') as $option) {
+			$this->savedoptions[$option] = getDolGlobalString($option);
+		}
+		$conf->global->MAIN_UNKNOWN_CUSTOMERS_ARE_COMPANIES = 1;
+		unset($conf->global->MAIN_CUSTOMERS_ARE_COMPANIES_EVEN_IF_SET_AS_INDIVIDUAL);
+	}
+
+	/**
+	 * Reset the options after each test, whatever the test did with them.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void
+	{
+		global $conf;
+
+		unset($conf->global->EINVOICING_SKIP_B2C);
+		foreach ($this->savedoptions as $option => $value) {
+			if ($value === '') {
+				unset($conf->global->$option);
+			} else {
+				$conf->global->$option = $value;
+			}
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The bug of issue #600: with the option off, nothing changes and a missing professional id stays
+	 * the blocking error it has always been. This is also what the fix must keep doing for everybody
+	 * who never turns the option on.
+	 *
+	 * @return void
+	 */
+	public function testTheMissingProfessionalIdStillBlocksWhenTheOptionIsOff()
+	{
+		global $conf, $db, $langs;
+
+		unset($conf->global->EINVOICING_SKIP_B2C);
+		$langs->load("einvoicing@einvoicing");
+
+		$einvoicing = new EInvoicing($db);
+		$check = $einvoicing->validatethirdpartyConfiguration($this->privateIndividual());
+
+		$this->assertSame(-1, $check['res']);
+		$this->assertStringContainsString($langs->trans("FxCheckErrorCustomerIDPROF1"), $check['message']);
+	}
+
+	/**
+	 * With the option on, the very same third party is out of scope and its missing SIREN is not an
+	 * error any more: nothing blocks the invoice, and nothing is reported about a professional id a
+	 * private individual is not supposed to have.
+	 *
+	 * @return void
+	 */
+	public function testTheMissingProfessionalIdDoesNotBlockAB2CThirdPartyWhenTheOptionIsOn()
+	{
+		global $conf, $db, $langs;
+
+		$conf->global->EINVOICING_SKIP_B2C = 1;
+		$langs->load("einvoicing@einvoicing");
+
+		$thirdparty = $this->privateIndividual();
+		// Cast: isACompany() answers 0 on some cores and false on others (Dolibarr 20 to 22), and this
+		// test is about who is a company, not about which of the two the core happens to return.
+		$this->assertSame(0, (int) $thirdparty->isACompany(), 'the fixture must be seen as a private individual');
+
+		$einvoicing = new EInvoicing($db);
+		$check = $einvoicing->validatethirdpartyConfiguration($thirdparty);
+
+		$this->assertNotSame(-1, $check['res']);
+		$this->assertStringNotContainsString($langs->trans("FxCheckErrorCustomerIDPROF1"), $check['message']);
+	}
+
+	/**
+	 * The option only excuses private individuals. A company without a professional id is still a
+	 * company that cannot be e-invoiced, whatever the option says, so its error must survive.
+	 *
+	 * @return void
+	 */
+	public function testACompanyWithoutProfessionalIdStillBlocksWhenTheOptionIsOn()
+	{
+		global $conf, $db, $langs;
+
+		$conf->global->EINVOICING_SKIP_B2C = 1;
+		$langs->load("einvoicing@einvoicing");
+
+		$thirdparty = $this->companyWithoutProfessionalId();
+		$this->assertNotSame(0, (int) $thirdparty->isACompany(), 'the fixture must be seen as a company');
+
+		$einvoicing = new EInvoicing($db);
+		$check = $einvoicing->validatethirdpartyConfiguration($thirdparty);
+
+		$this->assertSame(-1, $check['res']);
+		$this->assertStringContainsString($langs->trans("FxCheckErrorCustomerIDPROF1"), $check['message']);
+	}
+
+	/**
+	 * The routing id is the other identifier a private individual has no reason to own: with
+	 * EINVOICING_BLOCK_INVOICE_NO_ROUTING_ID on, a B2C third party must not be blocked on it either,
+	 * while a company still is.
+	 *
+	 * @return void
+	 */
+	public function testTheRoutingIdDoesNotBlockAB2CThirdPartyEither()
+	{
+		global $conf, $db, $langs;
+
+		$conf->global->EINVOICING_SKIP_B2C = 1;
+		$savblock = getDolGlobalString('EINVOICING_BLOCK_INVOICE_NO_ROUTING_ID');
+		$conf->global->EINVOICING_BLOCK_INVOICE_NO_ROUTING_ID = 1;
+		$langs->load("einvoicing@einvoicing");
+
+		$einvoicing = new EInvoicing($db);
+		$b2c = $einvoicing->validatethirdpartyConfiguration($this->privateIndividual());
+		$company = $einvoicing->validatethirdpartyConfiguration($this->companyWithoutProfessionalId());
+
+		if ($savblock === '') {
+			unset($conf->global->EINVOICING_BLOCK_INVOICE_NO_ROUTING_ID);
+		} else {
+			$conf->global->EINVOICING_BLOCK_INVOICE_NO_ROUTING_ID = $savblock;
+		}
+
+		$this->assertStringNotContainsString($langs->trans("FxCheckErrorCustomerRoutingID"), $b2c['message']);
+		$this->assertStringContainsString($langs->trans("FxCheckErrorCustomerRoutingID"), $company['message']);
+	}
+
+	/**
+	 * The two ignore codes are what needEInvoiceManagement() answers for an invoice out of the
+	 * e-invoicing scope, and both are truthy: a caller that only tests the answer for truth treats
+	 * them as "to be e-invoiced". Pinned here because that is what let an ignored invoice reach the
+	 * pre-check in the first place, and the callers now compare against these codes.
+	 *
+	 * @return void
+	 */
+	public function testTheIgnoreCodesAreTruthySoTheyMustBeComparedNotTested()
+	{
+		$this->assertTrue((bool) EInvoicing::STATUS_IGNORE);
+		$this->assertTrue((bool) EInvoicing::STATUS_IGNORE_2);
+		$this->assertNotSame(EInvoicing::STATUS_NOT_GENERATED, EInvoicing::STATUS_IGNORE);
+	}
+}

--- a/einvoicing/test/phpunit/SkipB2CPrecheckTest.php
+++ b/einvoicing/test/phpunit/SkipB2CPrecheckTest.php
@@ -247,8 +247,9 @@ class SkipB2CPrecheckTest extends CommonClassTest
 	/**
 	 * The two ignore codes are what needEInvoiceManagement() answers for an invoice out of the
 	 * e-invoicing scope, and both are truthy: a caller that only tests the answer for truth treats
-	 * them as "to be e-invoiced". Pinned here because that is what let an ignored invoice reach the
-	 * pre-check in the first place, and the callers now compare against these codes.
+	 * them as "to be e-invoiced". That is what let an ignored invoice reach the pre-check in the first
+	 * place, and the callers now ask isIgnoredStatus() instead, which reads the STATUS_IGNORE_CODES
+	 * list - so a new ignore code added there is honoured by all of them at once.
 	 *
 	 * @return void
 	 */
@@ -257,5 +258,18 @@ class SkipB2CPrecheckTest extends CommonClassTest
 		$this->assertTrue((bool) EInvoicing::STATUS_IGNORE);
 		$this->assertTrue((bool) EInvoicing::STATUS_IGNORE_2);
 		$this->assertNotSame(EInvoicing::STATUS_NOT_GENERATED, EInvoicing::STATUS_IGNORE);
+
+		$this->assertSame(
+			array(EInvoicing::STATUS_IGNORE, EInvoicing::STATUS_IGNORE_2),
+			EInvoicing::STATUS_IGNORE_CODES,
+			'every ignore code must be listed, that list is what the callers read'
+		);
+		foreach (EInvoicing::STATUS_IGNORE_CODES as $code) {
+			$this->assertTrue(EInvoicing::isIgnoredStatus($code));
+			// The stored status read from the database is a string: the helper must answer the same on it.
+			$this->assertTrue(EInvoicing::isIgnoredStatus((string) $code));
+		}
+		$this->assertFalse(EInvoicing::isIgnoredStatus(EInvoicing::STATUS_NOT_GENERATED));
+		$this->assertFalse(EInvoicing::isIgnoredStatus(EInvoicing::STATUS_GENERATED));
 	}
 }


### PR DESCRIPTION
Fixes #600.
Fixes #606 - the same defect, reported from the manual regeneration of the PDF.

## What happens

`EINVOICING_SKIP_B2C` already keeps invoices of private individuals out of the e-invoicing scope:
`needEInvoiceManagement()` answers `STATUS_IGNORE` on them (#319 / #321), since B2C is reported by
e-reporting and not transmitted as an e-invoice. The pre-check of the third party never learned about
that option, so `validatethirdpartyConfiguration()` still reported the missing SIREN of a private
individual as a **blocking** error, and generating or sending the invoice failed on
`FxCheckErrorCustomerIDPROF1` - "The customer has no professional id (SIREN)". Where
`EINVOICING_EINVOICE_CANCEL_IF_EINVOICE_FAILS` is set, the invoice is refused outright.

Reproduced on Dolibarr 23.0.3 with the reporter's setup - a French third party, nature "Particulier"
(`TE_PRIVATE`), no SIREN, no SIRET, no VAT number:

```
isACompany()                = 0
needEInvoiceManagement()    = 99   (STATUS_IGNORE)   <- the decision is right
checkRequiredinformations() = -1   "Le client ne possède pas d'identifiant professionnel (SIREN)."
```

The invoice does not have to be freshly created to get there. When the stored status is 99 the
real-time path skips the checks, but any invoice whose stored status is *not* 99 walks straight into
them: invoices validated **before** the option was turned on, third parties flagged "Particulier"
afterwards, invoices predating the module. Those keep `STATUS_NOT_GENERATED`, which is also the status
that offers the "Generate e-invoice" button.

## The fix

**The pre-check reads the same detection as the decision.** `validatethirdpartyConfiguration()` now
asks `Societe::isACompany()` - the core's own definition of a company, already used by
`needEInvoiceManagement()` - and asks a private individual for neither a professional id nor a routing
id when `EINVOICING_SKIP_B2C` is on. Both ends of the chain agree on who is B2C, and no second
definition of "private individual" is introduced. A company without a professional id is still
blocked, option or not.

**A status code is not a boolean.** `needEInvoiceManagement()` returns a status, and the two codes
meaning "out of scope" (98, 99) are truthy, so callers that merely tested the answer for truth treated
an ignored invoice as one to e-invoice - which is the other way into the pre-check. They now ask the
boolean question instead of spelling the comparison out: `mustManageEInvoice($invoice)` in
`afterPDFCreation()` and in the cash-in status of the trigger, `isIgnoredStatus($code)` where a stored
status is already at hand - the generation button, which `STATUS_IGNORE_2` reached through the
"unknown status code" fallback since 98 has no entry in `STATUS_LABEL_KEYS`. Both read one list,
`STATUS_IGNORE_CODES`, so an ignore code added there is honoured by every caller at once instead of
being chased through the module. `needEInvoiceManagement()` keeps answering the status code, which is
what two of its callers persist; its doc block now says so.

## Tests

New `test/phpunit/SkipB2CPrecheckTest.php` (5 tests), registered in `AllTests.php`. It pins the two
core options `isACompany()` reads besides the identifiers, so the fixtures mean the same thing on
every supported core - up to Dolibarr 19 a third party carrying neither a VAT number nor a
professional id is never a company, whatever its nature says.

Run file by file on **8 instances, Dolibarr 17.0.4 / 18.0.10 / 19.0.4 / 20.0.4 / 21.0.4 / 22.0.5 /
23.0.3 / 24.0.0-beta**: the whole module suite is green on all of them, new file included.

The two tests that describe the bug were also run against **unpatched `main`** (Dolibarr 22) and fail
there, as they should:

```
1) testTheMissingProfessionalIdDoesNotBlockAB2CThirdPartyWhenTheOptionIsOn
   Failed asserting that -1 is not identical to -1.
2) testTheRoutingIdDoesNotBlockAB2CThirdPartyEither
   Failed asserting that '... Le client ne dispose pas d'une adresse de facturation électronique.'
   does not contain "Le client ne dispose pas d'une adresse de facturation électronique."
```

Live on Dolibarr 23.0.3, on real invoices of a real "Particulier" third party:

| invoice | need | stored status | real-time guard | checkRequiredinformations |
|---|---|---|---|---|
| B2C, stored status stale (5) | 99 | 5 | false | 1, no message |
| B2C, stored status ignore (99) | 99 | 99 | false | 1, no message |
| B2C, fresh invoice | 99 | 99 | false | 1, no message |
| company (control) | 5 | 10 | **true** | 1, no message |

and the error path still bites: a real company whose SIREN is empty, with the option on, is still
answered `-1 / FxCheckErrorCustomerIDPROF1`. The generation button is offered for status 5, and no
longer for 98 or 99.

A full sandbox cycle was run on the deployed branch - new invoice emitted, routed by the Access Point,
received on the other instance with its line periods intact, statuses 200 and 201 back on the sender.


## Tests of the cleanup itself

The rewrite must answer exactly what the hand-written comparisons answered, so it was measured rather
than assumed. On Dolibarr 23.0.3, the 200 latest invoices of the instance were walked twice, option
off then on (286 fetched invoice states in all): for each one, the old writing and the new helper were
evaluated side by side on the three conditions rewritten - the real-time guard, the stored status the
guard reads, the generation button. **0 mismatch.**

Live on the same instance, on invoices created for the occasion (option on):

| fresh invoice | isACompany() | need | stored | PDF generation | files produced | after payment |
|---|---|---|---|---|---|---|
| B2C third party | 0 | 99 | 99 | 1, no error | the PDF only | 99 |
| company with a SIREN (control) | 2 | 5 | 5 | 1, no error | PDF + `_cii.xml` | 10 |

and the generation button, hook actually executed on the invoice card: offered on a stored status of 5
and on an unknown code (42), never on 98 nor on 99.

Module suite re-run file by file on Dolibarr 23.0.3 and 18.0.10 (the minimum claimed): green on both,
`SkipB2CPrecheckTest` included, which now also pins the list and the helper.


## Validation on the 8 supported cores, and a round trip in both directions

The branch was deployed on the bench (the 8 instances and the emitting one share the clone), and
everything below was **run**, not read.

**The suite, file by file, on the 8 cores** - Dolibarr 17.0.4, 18.0.10, 19.0.4, 20.0.4, 21.0.4,
22.0.5, 23.0.3, 24.0.0-beta: 13 files, 121 tests, 723 assertions, **green on all 8**, identical
counts everywhere.

**The decision itself, live on the 8 cores**: on each instance, with `EINVOICING_SKIP_B2C` on, one
fresh invoice for a private individual and one for a French company, both through the nominal path
(create, validate, `generateDocument()` - the hook is what decides). On all 8: the B2C invoice answers
`need=99 / must=false`, is stored `99`, produces its PDF and **no XML, no flow**; the company invoice
answers `need=5 / must=true` and is generated.

**Round trip, both directions, with B2C invoices interleaved.** Each side emitted a mixed batch -
company, private individual, company, private individual - through the nominal path, with
`EINVOICING_AUTO_SEND_ON_GENERATION` on, so nothing was sent by hand: the module alone decided what
left the instance.

| direction | invoice | customer | need | stored | files | flow | received in front |
|---|---|---|---|---|---|---|---|
| 23.0.3 → 23.0.3 | TRI-FA-2608-0162 | company | 5 | 201 | PDF + `_cii.xml` | `i_337244` | supplier invoice 1650, line period intact |
| | TRI-FA-2608-0163 | **B2C** | 99 | 99 | PDF only | none | nothing, as intended |
| | TRI-FA-2608-0164 | company | 5 | 201 | PDF + `_cii.xml` | `i_337248` | supplier invoice 1651, line period intact |
| | TRI-FA-2608-0165 | **B2C** | 99 | 99 | PDF only | none | nothing, as intended |
| back | DD23-FA-2608-0006 | company | 5 | 201 | PDF + `_cii.xml` | `i_337261` | supplier invoice 284, line period intact |
| | DD23-FA-2608-0007 | **B2C** | 99 | 99 | PDF only | none | nothing, as intended |
| | DD23-FA-2608-0008 | company | 5 | 201 | PDF + `_cii.xml` | `i_337262` | supplier invoice 285, line period intact |
| | DD23-FA-2608-0009 | **B2C** | 99 | 99 | PDF only | none | nothing, as intended |

The four company invoices came back to their sender at status **201** (200 then 201 received and
attached). For the four B2C invoices, the tables were read directly rather than trusted: **no row in
`einvoicing_document`, none in `einvoicing_lifecycle_msg`, no `flow_id`** - only the "do not manage"
line the creation trigger writes. On the invoice card, a B2C invoice offers neither "Generate" nor
"Send" (only the core "Regenerate" entry, greyed for lack of permission, which this PR does not touch).

**The cash-in status, the third rewritten caller, on real payments**: a full payment on the company
invoice sends its **212** (`flow ie_958126`, `validation=Ok`); the same payment on the B2C invoice
sends nothing and raises nothing.

**The error path still bites**: a real company with a VAT number but no SIREN, option on, is answered
`-1 / FxCheckErrorCustomerIDPROF1` by both the third-party check and `checkRequiredinformations()`, and
its invoice is left with its PDF alone - no e-invoice, no flow.

The bench was put back as it was afterwards: options restored, previously deployed branch checked out
again.

