### PR TITLE
FIX : [einvoicing] MySQL 8 compatibility of the supplier invoice list (error 1055)

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -2,6 +2,14 @@
 
 ## 1.0.4
 
+FIX: The supplier invoice list no longer fails on a MySQL server that keeps its default sql_mode. The
+columns the module adds to the SELECT of that list were never added to its GROUP BY, so MySQL refused the
+whole query with error 1055 (only_full_group_by) and the page reported a technical error instead of showing
+the list. MariaDB, whose default sql_mode does not include ONLY_FULL_GROUP_BY, accepted the same query,
+which is why the fault went unnoticed. The printFieldListGroupBy hook the core calls right after building
+its own GROUP BY - where it adds its extrafields for that very reason - is now implemented. Dolibarr 17 to
+21 are concerned; from Dolibarr 22 on the core builds no GROUP BY on that list at all.
+
 FIX: The Factur-X files the module produces are now valid PDF/A-3, which they had never been - and a
 Factur-X file that is not a PDF/A-3 file is not a conformant Factur-X, whatever its XML says (veraPDF
 1.30.2 rejected every one of them, on Dolibarr 17 to 24 alike). The cause that belongs to the module is

--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -1147,6 +1147,28 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 
 
 	/**
+	 * Add GROUP BY fields
+	 * Mandatory for the fields added by printFieldListSelect() on lists that build a GROUP BY clause,
+	 * otherwise MySQL rejects the query with sql_mode=only_full_group_by (error 1055).
+	 * Only supplierinvoicelist is concerned: thirdpartylist/societelist call the hook without any
+	 * GROUP BY clause, and productservicelist selects no column from the joined table.
+	 *
+	 * @param array<string,mixed> 	$parameters		Array of parameters
+	 * @param CommonObject			$object			Object invoice
+	 * @param string		 		$action			Code action
+	 * @param Hookmanager			$hookmanager	Hookmanager
+	 * @return int									Result
+	 */
+	public function printFieldListGroupBy($parameters, $object, &$action, $hookmanager)
+	{
+		if (in_array('supplierinvoicelist', explode(':', $parameters['context']), true)) {
+			$this->resprints .= ', ext.rowid, ext.provider';
+		}
+
+		return 0;
+	}
+
+	/**
 	 * Filter options
 	 *
 	 * @param array<string,mixed> 	$parameters		Array of parameters


### PR DESCRIPTION
## Symptom

With the module enabled, the supplier invoice list (`fourn/facture/list.php`) is unusable **on MySQL 8** — the page returns a technical error instead of the list:

> `DB_ERROR_1055` — Expression #62 of SELECT list is not in GROUP BY clause and contains nonaggregated column `ext.rowid` which is not functionally dependent on columns in GROUP BY clause; this is incompatible with `sql_mode=only_full_group_by`

Observed on Dolibarr 20.0.5 with MySQL 8.4.3, on a stock server: `ONLY_FULL_GROUP_BY` has been part of the default `sql_mode` since MySQL 5.7, so no unusual configuration is needed to hit this.

**MariaDB is not affected** — its default `sql_mode` does not include `ONLY_FULL_GROUP_BY` and it accepts the very same query. That is why the fault went unnoticed: this is a MySQL compatibility issue, not a regression.

## Cause

`printFieldListSelect()` adds `ext.rowid` and `ext.provider` to the SELECT of that list, but the module never implemented `printFieldListGroupBy()`. The page builds a `GROUP BY` for its `SUM(pf.amount)`, so both columns have to be declared there. The core calls the hook immediately after writing its own `GROUP BY` — where it appends its extrafields with the comment `//prevent error with sql_mode=only_full_group_by`.

## Fix

Implements `printFieldListGroupBy()`, for the `supplierinvoicelist` context only.

## Affected Dolibarr versions

| Dolibarr | `GROUP BY` on that list | Effect of this PR |
|---|---|---|
| 17 → 21 | built, hook called | fixes the error |
| 22 and later | none, hook not called | no-op |

## Scope

Only `supplierinvoicelist` is handled on purpose: `thirdpartylist` and `societelist` call the hook on a query that has no `GROUP BY` clause at all — emitting there would produce a syntax error — and `productservicelist` selects no column from the joined table.

No change to the result set on any server: `ext` is joined one-to-one on `element_id` + `element_type`.
