### PR TITLE
fix(einvoicing): received supplier-invoice status dropdown shows "Array"

### DIFF
--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2025		Laurent Destailleur		<eldy@users.sourceforge.net>
  * Copyright (C) 2026		Charlene Benke			<charlene@patas-monkey.com>
  * Copyright (C) 2026       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2026		Jose Martinez				<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -473,7 +474,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 						'lang' => 'einvoicing',
 						'enabled' => true,
 						'perm' => ($forcedisabling ? -1 : ((bool) $user->hasRight("fournisseur", "facture", "creer") && empty($forcedisabling))),
-						'label' => (string) $label,
+						'label' => (string) (is_array($label) ? ($label['label'] ?? '') : $label),
 						'url' => '/fourn/facture/card.php?id=' . $object->id . '&action=sendStatusMessage&pdpstatuscode=' . $code . '&token=' . newToken()
 					);
 				}


### PR DESCRIPTION
### Bug

On a **received supplier invoice**, the **"E-invoice"** action button opens a dropdown whose items all read **`Array`** instead of the sendable PDP statuses:

`addMoreActionsButtons()` (context `invoice_supplier`) builds the dropdown from `getSendableStatusesForReceivedInvoice()` → `getEinvoiceStatusOptions()`. That method was changed to return **array-shaped values** (`['label' => ..., 'data-html' => ...]`, as its docblock now documents), but this consumer still does:

```php
'label' => (string) $label,
```

Casting the array to a string yields the literal `"Array"`, one per sendable status.

### Fix

Extract the `label` field, with a fallback so the code also works if a plain string is returned:

```php
'label' => (string) (is_array($label) ? ($label['label'] ?? '') : $label),
```

### Notes

- Reproduced on Dolibarr 23.0.3 with a supplier invoice in a "received" PDP state offering several sendable statuses.
- Only this consumer was affected; the select-list consumers already handle the array shape.

Draft for maintainer review.
