### PR TITLE
FIX [einvoicing] Two pages die on Dolibarr 17 on the supplier filter of their third party selector

### DIFF
--- a/einvoicing/product_mapping.php
+++ b/einvoicing/product_mapping.php
@@ -277,7 +277,14 @@ print '<input type="text" class="width200" name="flowid" value="'.dol_escape_htm
 print '</div>';
 print ' &nbsp; ';
 print '<div class="inline-block valignmiddle paddingright">'.$langs->trans("Supplier").' ';
-print $form->select_company($socid, 'socid', '(s.fournisseur:=:1)', 'SelectThirdParty', 0, 0, array(), 0, 'minwidth200');
+// Form::select_company() does not read this filter the same way on every version. Until Dolibarr 18
+// the criteria is appended to the query as it stands, so it has to be plain SQL; from 18 a criteria
+// holding parentheses is converted by forgeSQLFromUniversalSearchCriteria(), and on 24 that conversion
+// is no longer conditional - every criteria goes through it. Passing the Universal Search syntax to 17
+// therefore ends the page on "DB_ERROR_SYNTAX ... near ':=:1))'", and passing plain SQL to 24 would be
+// mangled the other way round.
+$vendorfilter = ((float) DOL_VERSION < 18) ? 's.fournisseur = 1' : '(s.fournisseur:=:1)';
+print $form->select_company($socid, 'socid', $vendorfilter, 'SelectThirdParty', 0, 0, array(), 0, 'minwidth200');
 print '</div>';
 print '<input type="submit" class="button small" value="'.$langs->trans("Refresh").'">';
 print '</form>';

--- a/einvoicing/vendorref_list.php
+++ b/einvoicing/vendorref_list.php
@@ -345,7 +345,14 @@ if ($leftcolumn) {
 	print '</td>';
 }
 print '<td class="liste_titre">';
-print $form->select_company($search_socid, 'search_socid', '(s.fournisseur:=:1)', '1', 0, 0, array(), 0, 'maxwidth200');
+// Form::select_company() does not read this filter the same way on every version. Until Dolibarr 18
+// the criteria is appended to the query as it stands, so it has to be plain SQL; from 18 a criteria
+// holding parentheses is converted by forgeSQLFromUniversalSearchCriteria(), and on 24 that conversion
+// is no longer conditional - every criteria goes through it. Passing the Universal Search syntax to 17
+// therefore ends the page on "DB_ERROR_SYNTAX ... near ':=:1))'", and passing plain SQL to 24 would be
+// mangled the other way round.
+$vendorfilter = ((float) DOL_VERSION < 18) ? 's.fournisseur = 1' : '(s.fournisseur:=:1)';
+print $form->select_company($search_socid, 'search_socid', $vendorfilter, '1', 0, 0, array(), 0, 'maxwidth200');
 print '</td>';
 print '<td class="liste_titre"><input type="text" class="flat maxwidth100" name="search_ref_fourn" value="'.dol_escape_htmltag($search_ref_fourn).'"></td>';
 print '<td class="liste_titre"></td>';


### PR DESCRIPTION
Two pages of the module answer a technical error on **Dolibarr 17**, the version
`modEInvoicing.class.php` declares as the minimum it supports (`need_dolibarr_version = array(17, -3)`):
`einvoicing/vendorref_list.php` and `einvoicing/product_mapping.php`.

Both narrow their third party selector to suppliers, and both write that criteria in the Universal Search
syntax:

```php
print $form->select_company($search_socid, 'search_socid', '(s.fournisseur:=:1)', ...);
```

`Form::select_company()` hands the criteria to `select_thirdparty_list()`, and **that method only converts
the Universal Search syntax from Dolibarr 18 on**. On 17 there is no conversion at all — the criteria is
appended to the query exactly as given:

```php
if ($filter) {
    $sql .= " AND (".$filter.")";
}
```

so the page runs

```sql
... WHERE s.entity IN (1) AND ((s.fournisseur:=:1)) ORDER BY nom ASC
```

and stops on `DB_ERROR_SYNTAX — check the manual ... near ':=:1)) ORDER BY nom ASC'`. The error page is
served in place of the list.

## Why the criteria has to depend on the version

The two forms are not interchangeable across the range the module supports:

| Dolibarr | what `select_thirdparty_list()` does with the criteria | plain SQL | Universal Search |
|---|---|---|---|
| 17 | appended as it stands | works | **breaks the query** |
| 18 → 23 | converted when it holds parentheses, appended as it stands otherwise | works (with a `dol_syslog` warning) | works |
| 24 | **always** converted, the parentheses test is gone | **mangled** | works |

So neither form alone covers 17 to 24, and the criteria is picked from the version:

```php
$vendorfilter = ((float) DOL_VERSION < 18) ? 's.fournisseur = 1' : '(s.fournisseur:=:1)';
```

## Tested

Live on eight instances, Dolibarr **17.0.4, 18.0.10, 19.0.4, 20.0.4, 21.0.4, 22.0.5, 23.0.3 and
24.0.0-beta**, sharing the same checkout of the module, both pages loaded over HTTP with a real session.

- **17.0.4**: both pages go from the error page to **HTTP 200**, with no PHP error and no warning of their
  own. On `main` the same two pages report `DB_ERROR_SYNTAX` there.
- **18 → 24**: both pages unchanged, HTTP 200, no error, no new warning.
- **The filter really filters**, which an error-free page alone would not prove: the number of entries
  offered by the selector was compared to the number of active suppliers in the database on 17, 18, 20, 21
  and 24 — 2/2, 3/3, 3/3, 2/2 and 8/8, against 3, 9, 10, 3 and 11 active third parties in total.
- Module unit tests, file by file, on the eight cores: 112 files, no failure.
- `phpcs` (Dolibarr ruleset) clean on both files.
