### PR TITLE
NEW #605 [einvoicing] One ref_supplier lookup for the import paths, tolerant on demand

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -2,6 +2,23 @@
 
 ## 1.0.4
 
+NEW: The reference a received e-invoice carries can now be matched against a ref_supplier that was
+typed with extra text around it. The five lookups the import runs on ref_supplier - the duplicate
+check, the referenced documents at document and at line level, and the source invoice of a credit
+note - were as many copies of the same exact-match query, in the CII path and again in the Factur-X
+one. A supplier invoice entered by hand as "PAY123 - FA202610 - dinner" was therefore never
+recognised as the one the XML calls "FA202610", and the import stopped on a document it could not
+find. Those call sites now share SupplierInvoiceHelper::findIdByRef(), which is still exact by
+default: the hidden option EINVOICING_TOLERANT_SUPPLIER_REF_MATCH adds a fallback, tried only when
+the exact match found nothing, and narrow enough that it cannot answer for the wrong invoice. A
+reference shorter than EINVOICING_TOLERANT_SUPPLIER_REF_MIN_LENGTH (8) or purely numeric is never
+searched for as a substring; the substring must be delimited by a non alphanumeric character or by
+an edge of the ref_supplier, so "FA202610" matches "PAY123 - FA202610 - dinner" but not "FA2026100";
+and the whitespace manual entry adds - "FA 2026 10", tabs and non-breaking spaces included - is
+tolerated without losing the boundary it forms. Several candidates are reported as an ambiguity
+instead of being guessed, and a database failure is no longer reported to the user as a missing
+document.
+
 FIX: A third party recognised as a private individual is no longer reported as misconfigured when
 EINVOICING_SKIP_B2C is on (issue #600). The option already kept B2C invoices out of the e-invoicing
 scope - needEInvoiceManagement() answers "do not manage" on them, since B2C is reported by e-reporting

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -44,6 +44,7 @@ dol_include_once('einvoicing/class/protocols/AbstractProtocol.class.php');
 dol_include_once('einvoicing/class/protocols/CommonProtocol.class.php');
 dol_include_once('einvoicing/class/einvoicing.class.php');
 dol_include_once('einvoicing/class/utils/XmlPatcher.class.php');
+dol_include_once('einvoicing/class/utils/SupplierInvoiceHelper.class.php');
 dol_include_once('einvoicing/lib/einvoicing.lib.php');
 
 
@@ -860,23 +861,17 @@ class CIIProtocol extends AbstractProtocol
 		}
 
 		// Check if this invoice has already been imported for this supplier
-		$sql = "SELECT rowid as id FROM " . MAIN_DB_PREFIX . "facture_fourn";
-		$sql .= " WHERE ref_supplier = '" . $db->escape($parsedHeader['documentno']) . "'";
-		$sql .= " AND fk_soc = " . ((int) $socId);
-		$sql .= " AND entity IN (" . getEntity('facture_fourn') . ")";
-		$resql = $db->query($sql);
-		if ($resql) {
-			if ($db->num_rows($resql) > 0) {
-				$supplierInvoiceId = $db->fetch_object($resql)->id;
-				$einvoicing->cleanUpTemporaryFiles(); // Clean up temp files to remove retrieved Einvoice file since invoice already exists
+		$supplierInvoiceId = SupplierInvoiceHelper::findIdByRef($parsedHeader['documentno'] ?? null, (int) $socId);
+		if ($supplierInvoiceId < 0) {
+			return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($supplierInvoiceId, $parsedHeader['documentno'] ?? '', 'while checking whether it was already imported')];
+		}
+		if ($supplierInvoiceId > 0) {
+			$einvoicing->cleanUpTemporaryFiles(); // Clean up temp files to remove retrieved Einvoice file since invoice already exists
 
-				// FIXME supplierinvoice already found but may be that documents are not linked (this is done later but only after creating invoice,
-				// may be we should also do it in this case to fix inconsistent data).
+			// FIXME supplierinvoice already found but may be that documents are not linked (this is done later but only after creating invoice,
+			// may be we should also do it in this case to fix inconsistent data).
 
-				return ['res' => $supplierInvoiceId, 'message' => 'Supplier Invoice with reference ' . $parsedHeader['documentno'] . ' already exists'];
-			}
-		} else {
-			return ['res' => -1, 'message' => 'Database error while checking existing supplier invoice: ' . $db->lasterror()];
+			return ['res' => $supplierInvoiceId, 'message' => 'Supplier Invoice with reference ' . $parsedHeader['documentno'] . ' already exists'];
 		}
 
 		// Check if all referenced documents in the invoice exist in Dolibarr for the same supplier, if not return with error since we need them for correct linking in the invoice
@@ -886,9 +881,11 @@ class CIIProtocol extends AbstractProtocol
 				$dateDoc = $invoiceRefDoc['FormattedIssueDateTime'] ?? null;
 				$typeDoc = $invoiceRefDoc['TypeCode'] ?? null;
 
-				$sql = "SELECT rowid FROM " . MAIN_DB_PREFIX . "facture_fourn WHERE ref_supplier = '" . $db->escape($refDoc) . "' AND fk_soc = " . ((int) $socId) . " AND entity IN (" . getEntity('facture_fourn') . ") LIMIT 1";
-				$resql = $db->query($sql);
-				if ($db->num_rows($resql) != 1) {
+				$refDocInvoiceId = SupplierInvoiceHelper::findIdByRef($refDoc, (int) $socId);
+				if ($refDocInvoiceId < 0) {
+					return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($refDocInvoiceId, $refDoc, 'linked to document ' . ($parsedHeader['documentno'] ?? ''))];
+				}
+				if ($refDocInvoiceId == 0) {
 					return ['res' => -1, 'message' => 'Document : ' . $refDoc . ' linked to document ' . $parsedHeader['documentno'] . ' not found in Dolibarr'];
 				}
 			}
@@ -913,16 +910,13 @@ class CIIProtocol extends AbstractProtocol
 			$firstRefDoc = reset($parsedHeader['invoiceRefDocs']);
 			$refSourceSupplier = !empty($firstRefDoc['IssuerAssignedID']) ? (string) $firstRefDoc['IssuerAssignedID'] : '';
 			if ($refSourceSupplier !== '') {
-				$sqlSource = "SELECT rowid FROM " . MAIN_DB_PREFIX . "facture_fourn WHERE ref_supplier = '" . $db->escape($refSourceSupplier) . "' AND fk_soc = " . ((int) $socId) . " AND entity IN (" . getEntity('facture_fourn') . ") LIMIT 1";
-				$resqlSource = $db->query($sqlSource);
-				if ($resqlSource) {
-					$objSource = $db->fetch_object($resqlSource);
-					if ($objSource) {
-						$supplierInvoice->fk_facture_source = (int) $objSource->rowid;
-						dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Linked to source invoice id=' . $supplierInvoice->fk_facture_source, LOG_DEBUG);
-					} else {
-						dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Source invoice ref_supplier="' . $refSourceSupplier . '" not found for ' . ($parsedHeader['documentno'] ?? ''), LOG_WARNING);
-					}
+				$sourceInvoiceId = SupplierInvoiceHelper::findIdByRef($refSourceSupplier, (int) $socId);
+				if ($sourceInvoiceId > 0) {
+					$supplierInvoice->fk_facture_source = $sourceInvoiceId;
+					dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Linked to source invoice id=' . $supplierInvoice->fk_facture_source, LOG_DEBUG);
+				} else {
+					// Not found, ambiguous or database error: leave fk_facture_source empty rather than link the wrong invoice
+					dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Source invoice ref_supplier="' . $refSourceSupplier . '" not resolved (code ' . $sourceInvoiceId . ') for ' . ($parsedHeader['documentno'] ?? ''), LOG_WARNING);
 				}
 			}
 		}
@@ -1000,12 +994,13 @@ class CIIProtocol extends AbstractProtocol
 					$dateDoc = $doc['FormattedIssueDateTime'] ?? null;
 					$typeDoc = $doc['TypeCode'] ?? null;
 
-					$sql = "SELECT rowid FROM " . MAIN_DB_PREFIX . "facture_fourn WHERE ref_supplier = '" . $db->escape($refDoc) . "' AND fk_soc = " . ((int) $socId) . " AND entity IN (" . getEntity('facture_fourn') . ") LIMIT 1";
-					$resql = $db->query($sql);
-					if ($db->num_rows($resql) != 1) {
+					$linkedObjectId = SupplierInvoiceHelper::findIdByRef($refDoc, (int) $socId);
+					if ($linkedObjectId < 0) {
+						return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($linkedObjectId, $refDoc, 'linked to document ' . ($parsedHeader['documentno'] ?? ''))];
+					}
+					if ($linkedObjectId == 0) {
 						return ['res' => -1, 'message' => 'Document : ' . $refDoc . ' linked to document ' . $parsedHeader['documentno'] . ' not found in Dolibarr'];
 					}
-					$linkedObjectId = $db->fetch_object($resql)->rowid;
 
 					// Fetch Object
 					$linkedObject = new FactureFournisseur($db);
@@ -1166,9 +1161,11 @@ class CIIProtocol extends AbstractProtocol
 					$lineRefDocType = $refDoc['typeCode'] ?? null;
 					$lineRefDocDate = $refDoc['issueDate'] ?? null;
 
-					$sql = "SELECT rowid FROM " . MAIN_DB_PREFIX . "facture_fourn WHERE ref_supplier = '" . $db->escape($lineRefDocId) . "' AND fk_soc = " . ((int) $parsedLine['supplierId']) . " AND entity IN (" . getEntity('facture_fourn') . ") LIMIT 1";
-					$resql = $db->query($sql);
-					if ($db->num_rows($resql) != 1) {
+					$linkedObjectId = SupplierInvoiceHelper::findIdByRef($lineRefDocId, (int) $parsedLine['supplierId']);
+					if ($linkedObjectId < 0) {
+						return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($linkedObjectId, $lineRefDocId, 'linked to line ' . $parsedLine['lineid'])];
+					}
+					if ($linkedObjectId == 0) {
 						return [
 							'res' => -1,
 							'message' => 'Document "' . $lineRefDocId . '" linked to line ' . $parsedLine['lineid'] . ' was not found in Dolibarr. Please verify why this document is missing (deleted, not imported, or not provided by the supplier). To resolve this issue, you must manually create the invoice using the supplier invoice reference "' . $lineRefDocId . '".'
@@ -1178,7 +1175,6 @@ class CIIProtocol extends AbstractProtocol
 
 					// Load linked supplier invoice
 					$linkedObject = new FactureFournisseur($db);
-					$linkedObjectId = $db->fetch_object($resql)->rowid;
 					$resFetchLinkedObject = $linkedObject->fetch($linkedObjectId);
 					if ($resFetchLinkedObject > 0) {
 						/*

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -1470,23 +1470,17 @@ class FacturXProtocol extends CIIProtocol
 		}
 
 		// Check if this invoice has already been imported for this supplier
-		$sql = "SELECT rowid as id FROM " . MAIN_DB_PREFIX . "facture_fourn";
-		$sql .= " WHERE ref_supplier = '" . $db->escape($parsedHeader['documentno']) . "'";
-		$sql .= " AND fk_soc = " . ((int) $socId);
-		$sql .= " AND entity IN (" . getEntity('facture_fourn') . ")";
-		$resql = $db->query($sql);
-		if ($resql) {
-			if ($db->num_rows($resql) > 0) {
-				$supplierInvoiceId = $db->fetch_object($resql)->id;
-				$einvoicing->cleanUpTemporaryFiles(); // Clean up temp files to remove retrieved Einvoice file since invoice already exists
+		$supplierInvoiceId = SupplierInvoiceHelper::findIdByRef($parsedHeader['documentno'] ?? null, (int) $socId);
+		if ($supplierInvoiceId < 0) {
+			return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($supplierInvoiceId, $parsedHeader['documentno'] ?? '', 'while checking whether it was already imported')];
+		}
+		if ($supplierInvoiceId > 0) {
+			$einvoicing->cleanUpTemporaryFiles(); // Clean up temp files to remove retrieved Einvoice file since invoice already exists
 
-				// FIXME supplierinvoice already found but may be that documents are not linked (this is done later but only after creating invoice,
-				// may be we should also do it in this case to fix inconsistent data).
+			// FIXME supplierinvoice already found but may be that documents are not linked (this is done later but only after creating invoice,
+			// may be we should also do it in this case to fix inconsistent data).
 
-				return ['res' => $supplierInvoiceId, 'message' => 'Supplier Invoice with reference ' . $parsedHeader['documentno'] . ' already exists'];
-			}
-		} else {
-			return ['res' => -1, 'message' => 'Database error while checking existing supplier invoice: ' . $db->lasterror()];
+			return ['res' => $supplierInvoiceId, 'message' => 'Supplier Invoice with reference ' . $parsedHeader['documentno'] . ' already exists'];
 		}
 
 		// Check if all referenced documents in the invoice exist in Dolibarr for the same supplier, if not return with error since we need them for correct linking in the invoice
@@ -1496,9 +1490,11 @@ class FacturXProtocol extends CIIProtocol
 				$dateDoc = $invoiceRefDoc['FormattedIssueDateTime'] ?? null;
 				$typeDoc = $invoiceRefDoc['TypeCode'] ?? null;
 
-				$sql = "SELECT rowid FROM " . MAIN_DB_PREFIX . "facture_fourn WHERE ref_supplier = '" . $db->escape($refDoc) . "' AND fk_soc = " . ((int) $socId) . " AND entity IN (" . getEntity('facture_fourn') . ") LIMIT 1";
-				$resql = $db->query($sql);
-				if ($db->num_rows($resql) != 1) {
+				$refDocInvoiceId = SupplierInvoiceHelper::findIdByRef($refDoc, (int) $socId);
+				if ($refDocInvoiceId < 0) {
+					return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($refDocInvoiceId, $refDoc, 'linked to document ' . ($parsedHeader['documentno'] ?? ''))];
+				}
+				if ($refDocInvoiceId == 0) {
 					return ['res' => -1, 'message' => 'Document : ' . $refDoc . ' linked to document ' . $parsedHeader['documentno'] . ' not found in Dolibarr'];
 				}
 			}
@@ -1523,16 +1519,13 @@ class FacturXProtocol extends CIIProtocol
 			$firstRefDoc = reset($parsedHeader['invoiceRefDocs']);
 			$refSourceSupplier = !empty($firstRefDoc['IssuerAssignedID']) ? (string) $firstRefDoc['IssuerAssignedID'] : '';
 			if ($refSourceSupplier !== '') {
-				$sqlSource = "SELECT rowid FROM " . MAIN_DB_PREFIX . "facture_fourn WHERE ref_supplier = '" . $db->escape($refSourceSupplier) . "' AND fk_soc = " . ((int) $socId) . " AND entity IN (" . getEntity('facture_fourn') . ") LIMIT 1";
-				$resqlSource = $db->query($sqlSource);
-				if ($resqlSource) {
-					$objSource = $db->fetch_object($resqlSource);
-					if ($objSource) {
-						$supplierInvoice->fk_facture_source = (int) $objSource->rowid;
-						dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Linked to source invoice id=' . $supplierInvoice->fk_facture_source, LOG_DEBUG);
-					} else {
-						dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Source invoice ref_supplier="' . $refSourceSupplier . '" not found for ' . ($parsedHeader['documentno'] ?? ''), LOG_WARNING);
-					}
+				$sourceInvoiceId = SupplierInvoiceHelper::findIdByRef($refSourceSupplier, (int) $socId);
+				if ($sourceInvoiceId > 0) {
+					$supplierInvoice->fk_facture_source = $sourceInvoiceId;
+					dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Linked to source invoice id=' . $supplierInvoice->fk_facture_source, LOG_DEBUG);
+				} else {
+					// Not found, ambiguous or database error: leave fk_facture_source empty rather than link the wrong invoice
+					dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Source invoice ref_supplier="' . $refSourceSupplier . '" not resolved (code ' . $sourceInvoiceId . ') for ' . ($parsedHeader['documentno'] ?? ''), LOG_WARNING);
 				}
 			}
 		}
@@ -1610,12 +1603,13 @@ class FacturXProtocol extends CIIProtocol
 					$dateDoc = $doc['FormattedIssueDateTime'] ?? null;
 					$typeDoc = $doc['TypeCode'] ?? null;
 
-					$sql = "SELECT rowid FROM " . MAIN_DB_PREFIX . "facture_fourn WHERE ref_supplier = '" . $db->escape($refDoc) . "' AND fk_soc = " . ((int) $socId) . " AND entity IN (" . getEntity('facture_fourn') . ") LIMIT 1";
-					$resql = $db->query($sql);
-					if ($db->num_rows($resql) != 1) {
+					$linkedObjectId = SupplierInvoiceHelper::findIdByRef($refDoc, (int) $socId);
+					if ($linkedObjectId < 0) {
+						return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($linkedObjectId, $refDoc, 'linked to document ' . ($parsedHeader['documentno'] ?? ''))];
+					}
+					if ($linkedObjectId == 0) {
 						return ['res' => -1, 'message' => 'Document : ' . $refDoc . ' linked to document ' . $parsedHeader['documentno'] . ' not found in Dolibarr'];
 					}
-					$linkedObjectId = $db->fetch_object($resql)->rowid;
 
 					// Fetch Object
 					$linkedObject = new FactureFournisseur($db);

--- a/einvoicing/class/utils/SupplierInvoiceHelper.class.php
+++ b/einvoicing/class/utils/SupplierInvoiceHelper.class.php
@@ -704,6 +704,176 @@ class SupplierInvoiceHelper
 	}
 
 	/**
+	 * Find the supplier invoice of a given supplier whose ref_supplier is the given reference.
+	 *
+	 * The default is an exact match, which is the only safe rule while the quality of the incoming
+	 * data is unknown: a wrong match on a duplicate check silently drops an invoice that is then
+	 * never imported, and a wrong match on a referenced document links the new invoice to the wrong
+	 * one. With the option below off, this is exactly the query the callers used to run inline.
+	 *
+	 * The hidden option EINVOICING_TOLERANT_SUPPLIER_REF_MATCH adds a fallback, tried only when the
+	 * exact match found nothing. It accepts a ref_supplier that was typed manually with extra text
+	 * around the reference, or with stray whitespace inside it, e.g.
+	 * "PLTHDDD5OAAABBB - TEST-GROUP-2026-07-06-19407 - EVENEMENT 30/06/2026 A PARIS" for a document
+	 * whose reference in the XML is only "TEST-GROUP-2026-07-06-19407". That fallback stays narrow:
+	 * a reference shorter than EINVOICING_TOLERANT_SUPPLIER_REF_MIN_LENGTH (8) or purely numeric is
+	 * never searched for as a substring, the substring must be delimited so that "FA202610" does not
+	 * match "FA2026100", and an ambiguity is reported instead of guessed.
+	 *
+	 * @param	string|null	$ref	Reference to look for (ExchangedDocument/ID or IssuerAssignedID of the XML)
+	 * @param	int			$socId	Id of the supplier thirdparty
+	 * @return	int					Invoice id (>0) on a single certain match, 0 when not found, -1 on database error, -2 when several invoices match
+	 */
+	public static function findIdByRef($ref, int $socId): int
+	{
+		global $db;
+
+		$ref = trim((string) $ref);
+		if ($ref === '' || $socId <= 0) {
+			return 0;
+		}
+
+		// Exact match. Always tried first, and always enough on its own.
+		$sql = "SELECT rowid FROM " . $db->prefix() . "facture_fourn";
+		$sql .= " WHERE ref_supplier = '" . $db->escape($ref) . "'";
+		$sql .= " AND fk_soc = " . ((int) $socId);
+		$sql .= " AND entity IN (" . getEntity('facture_fourn') . ")";
+		$sql .= " LIMIT 1";
+		$resql = $db->query($sql);
+		if (!$resql) {
+			dol_syslog(__METHOD__ . ' ' . $db->lasterror(), LOG_ERR);
+			return -1;
+		}
+		$obj = $db->fetch_object($resql);
+		$db->free($resql);
+		if ($obj) {
+			return (int) $obj->rowid;
+		} elseif (getDolGlobalInt('EINVOICING_TOLERANT_SUPPLIER_REF_MATCH')) {
+			// Tolerant fallback, opt-in and deliberately narrow. Everything that widens the match is
+			// enclosed in this branch on purpose: no code path reaches it while the option is off.
+			$refNoSpaces = self::normalizeRef($ref);
+			if (dol_strlen($refNoSpaces) < getDolGlobalInt('EINVOICING_TOLERANT_SUPPLIER_REF_MIN_LENGTH', 8) || ctype_digit($refNoSpaces)) {
+				// A short or purely numeric reference is a substring of far too many others, do not even try
+				return 0;
+			}
+
+			$sql = "SELECT rowid, ref_supplier FROM " . $db->prefix() . "facture_fourn";
+			$sql .= " WHERE REPLACE(ref_supplier, ' ', '') LIKE '%" . $db->escape($db->escapeforlike($refNoSpaces)) . "%'";
+			$sql .= " AND fk_soc = " . ((int) $socId);
+			$sql .= " AND entity IN (" . getEntity('facture_fourn') . ")";
+			$resql = $db->query($sql);
+			if (!$resql) {
+				dol_syslog(__METHOD__ . ' ' . $db->lasterror(), LOG_ERR);
+				return -1;
+			}
+			$matches = array();
+			while ($obj = $db->fetch_object($resql)) {
+				// The SQL LIKE is only a prefilter, the delimiter rule below is what decides
+				if (self::refEmbedsReference($obj->ref_supplier, $ref)) {
+					$matches[(int) $obj->rowid] = (int) $obj->rowid;
+				}
+			}
+			$db->free($resql);
+
+			if (count($matches) > 1) {
+				dol_syslog(__METHOD__ . ' several supplier invoices embed reference "' . $ref . '" for socid ' . ((int) $socId) . ', ids ' . implode(',', $matches), LOG_WARNING);
+				return -2;
+			}
+			if (count($matches) == 1) {
+				$found = (int) reset($matches);
+				dol_syslog(__METHOD__ . ' reference "' . $ref . '" matched supplier invoice id ' . $found . ' by tolerant match', LOG_NOTICE);
+				return $found;
+			}
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Build the message of a lookup that findIdByRef() could not answer.
+	 *
+	 * A database failure and an ambiguous reference are two different problems, and neither of them
+	 * is a missing document, so neither may be reported as one.
+	 *
+	 * @param	int			$code		Negative code returned by findIdByRef()
+	 * @param	string|null	$ref		Reference that was looked for
+	 * @param	string		$context	Where that reference comes from, appended to the message
+	 * @return	string					Message to report to the caller
+	 */
+	public static function refLookupErrorMessage(int $code, $ref, string $context): string
+	{
+		global $db;
+
+		if ($code == -2) {
+			return 'Several supplier invoices match reference "' . $ref . '" ' . $context . ', cannot determine which one to use';
+		}
+
+		return 'Database error while looking for a supplier invoice with reference "' . $ref . '" ' . $context . ': ' . $db->lasterror();
+	}
+
+	/**
+	 * Tell whether a ref_supplier embeds a reference as a delimited substring.
+	 *
+	 * Both values are compared without their whitespace, so that a ref_supplier typed as
+	 * "FA 2026 10" matches the reference "FA202610". The reference must be bounded on both sides by
+	 * a non alphanumeric character, by a removed gap or by an edge of the string, so that "FA202610"
+	 * matches "PAY123 - FA202610 - dinner" but not "FA2026100". Comparison is case insensitive, as
+	 * the SQL prefilter of findIdByRef() is under the usual collations.
+	 *
+	 * @param	string|null	$refSupplier	ref_supplier value read from database
+	 * @param	string|null	$ref			Reference looked for
+	 * @return	bool						True when the reference is embedded as a delimited substring
+	 */
+	public static function refEmbedsReference($refSupplier, $ref): bool
+	{
+		$needle = self::normalizeRef($ref);
+		if ($needle === '') {
+			return false;
+		}
+
+		// Whitespace is removed so that "FA 2026 10" matches "FA202610", but removing it must not
+		// destroy the boundary it forms: remember where a gap was, it counts as a delimiter.
+		$haystack = '';
+		$gapBefore = array();
+		$pendingGap = false;
+		foreach (preg_split('//u', (string) $refSupplier, -1, PREG_SPLIT_NO_EMPTY) as $char) {
+			if (preg_match('/^(\s|\xc2\xa0)$/u', $char)) {
+				$pendingGap = true;
+				continue;
+			}
+			$gapBefore[strlen($haystack)] = $pendingGap;
+			$pendingGap = false;
+			$haystack .= $char;
+		}
+		$gapBefore[strlen($haystack)] = $pendingGap;
+
+		$length = strlen($needle);
+		$offset = 0;
+		while (($pos = stripos($haystack, $needle, $offset)) !== false) {
+			$end = $pos + $length;
+			$startIsBounded = ($pos == 0 || !empty($gapBefore[$pos]) || !ctype_alnum($haystack[$pos - 1]));
+			$endIsBounded = ($end >= strlen($haystack) || !empty($gapBefore[$end]) || !ctype_alnum($haystack[$end]));
+			if ($startIsBounded && $endIsBounded) {
+				return true;
+			}
+			$offset = $pos + 1;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Strip from a reference the whitespace that manual entry adds (space, tab, non breaking space).
+	 *
+	 * @param	string|null	$value	Raw reference
+	 * @return	string				Reference without any whitespace
+	 */
+	private static function normalizeRef($value): string
+	{
+		return (string) preg_replace('/(\s|\xc2\xa0)+/u', '', (string) $value);
+	}
+
+	/**
 	 * Round an amount according to a number of digits after decimal point and return it.
 	 *
 	 * @param float $amount    		The amount to round

--- a/einvoicing/test/phpunit/SupplierInvoiceHelperTest.php
+++ b/einvoicing/test/phpunit/SupplierInvoiceHelperTest.php
@@ -23,6 +23,8 @@
  *                  business rule (issue #286): SupplierInvoiceHelper::abandonRefusedSupplierInvoice(),
  *                  SupplierInvoiceHelper::onOutboundStatusMessageValidated() and their dispatch from
  *                  EInvoicing::updateStatusMessageValidation().
+ *                  Also covers SupplierInvoiceHelper::findIdByRef() and the delimiter rule of its
+ *                  opt-in tolerant fallback (SupplierInvoiceHelper::refEmbedsReference()).
  *      \remarks    To run this script as CLI: phpunit filename.php
  */
 
@@ -84,6 +86,9 @@ class SupplierInvoiceHelperTest extends CommonClassTest
 		parent::setUp();
 
 		$conf->global->EINVOICING_SEND_APPROVED_ON_VALIDATION = '0';
+		// findIdByRef() is exact by default; the tests that are about the tolerant fallback turn it on
+		$conf->global->EINVOICING_TOLERANT_SUPPLIER_REF_MATCH = '0';
+		unset($conf->global->EINVOICING_TOLERANT_SUPPLIER_REF_MIN_LENGTH);
 	}
 
 	/**
@@ -907,5 +912,239 @@ class SupplierInvoiceHelperTest extends CommonClassTest
 		$einvoicing = new EInvoicing($db);
 		$offered = array_map('intval', array_keys($einvoicing->getSendableStatusesForReceivedInvoice($creditNote->id, 'invoice_supplier')));
 		$this->assertContains(EInvoicing::STATUS_APPROVED, $offered);
+	}
+
+	/**
+	 * Build a reference no other row of the instance can carry, long enough and not purely numeric,
+	 * so the fixtures of the findIdByRef() tests never collide with real data.
+	 *
+	 * @return string	Unique reference
+	 */
+	private function uniqueSupplierRef()
+	{
+		return 'PR605' . strtoupper(bin2hex(random_bytes(5)));
+	}
+
+	/**
+	 * Create a draft supplier invoice carrying an explicit ref_supplier.
+	 *
+	 * @param	string	$refSupplier	Value to store in ref_supplier
+	 * @param	int		$socId			Supplier id, resolved to any existing third party when 0
+	 * @return	FactureFournisseur		The created invoice
+	 */
+	private function createSupplierInvoiceWithRef($refSupplier, $socId = 0)
+	{
+		global $db, $user;
+
+		$localobject = new FactureFournisseur($db);
+		$localobject->initAsSpecimen();
+		$localobject->ref_supplier = $refSupplier;
+		$localobject->socid = ($socId > 0 ? $socId : $this->getAnyThirdpartyId());
+		$result = $localobject->create($user);
+		$this->assertGreaterThan(0, $result, $localobject->errorsToString());
+
+		return $localobject;
+	}
+
+	/**
+	 * The delimiter rule of the tolerant fallback, on its own: no database, no option, just the
+	 * cases that decide whether the fallback is safe enough to be offered at all.
+	 *
+	 * @return void
+	 */
+	public function testRefEmbedsReferenceDelimiterRule()
+	{
+		$cases = array(
+			// stored ref_supplier, reference looked for, expected
+			array('PLTHDDD5OAAABBB - TEST-GROUP-2026-07-06-19407 - EVENEMENT 30/06/2026 A PARIS', 'TEST-GROUP-2026-07-06-19407', true),
+			array('TEST-GROUP-2026-07-06-19407', 'TEST-GROUP-2026-07-06-19407', true),
+			array('FA202610', 'FA202610', true),
+			array('PAY123 - FA202610 - dinner', 'FA202610', true),
+			array('X-FA202610', 'FA202610', true),
+			array('fa202610', 'FA202610', true),
+			// A gap that was removed still counts as a delimiter
+			array('acompte FA 2026 10 solde', 'FA202610', true),
+			array("acompte FA\xc2\xa02026 10 solde", 'FA202610', true),
+			array("acompte\tFA202610 solde", 'FA202610', true),
+			array('facture FA202610 du 12/03', 'FA 2026 10', true),
+			// The first occurrence is glued, the second one is delimited
+			array('FA2026100 et FA202610', 'FA202610', true),
+			// The cases the rule exists for: a longer reference must not answer for a shorter one
+			array('FA2026100', 'FA202610', false),
+			array('INV-2026-1000', 'INV-2026-100', false),
+			array('XFA202610', 'FA202610', false),
+			array('FA202610suite', 'FA202610', false),
+			// Nothing to look for, nothing to look into
+			array('', 'FA202610', false),
+			array('FA202610', '', false),
+			array('FA202610', '   ', false),
+			array(null, 'FA202610', false),
+			array('FA202610', null, false),
+		);
+
+		foreach ($cases as $case) {
+			list($stored, $ref, $expected) = $case;
+			$this->assertSame(
+				$expected,
+				SupplierInvoiceHelper::refEmbedsReference($stored, $ref),
+				'ref_supplier "' . $stored . '" against reference "' . $ref . '"'
+			);
+		}
+	}
+
+	/**
+	 * The exact match is the default and needs no option.
+	 *
+	 * @return void
+	 */
+	public function testFindIdByRefMatchesAnExactReference()
+	{
+		$ref = $this->uniqueSupplierRef();
+		$invoice = $this->createSupplierInvoiceWithRef($ref);
+
+		$this->assertSame((int) $invoice->id, SupplierInvoiceHelper::findIdByRef($ref, (int) $invoice->socid));
+	}
+
+	/**
+	 * A reference nothing carries is not found, and an empty one is not looked for at all.
+	 *
+	 * @return void
+	 */
+	public function testFindIdByRefReportsAnUnknownReferenceAsNotFound()
+	{
+		$socId = $this->getAnyThirdpartyId();
+
+		$this->assertSame(0, SupplierInvoiceHelper::findIdByRef($this->uniqueSupplierRef(), $socId));
+		$this->assertSame(0, SupplierInvoiceHelper::findIdByRef('', $socId));
+		$this->assertSame(0, SupplierInvoiceHelper::findIdByRef(null, $socId));
+		$this->assertSame(0, SupplierInvoiceHelper::findIdByRef($this->uniqueSupplierRef(), 0));
+	}
+
+	/**
+	 * Without the option, a reference buried in a longer ref_supplier is NOT found: this is the
+	 * behaviour that existed before the helper, and it stays the default.
+	 *
+	 * @return void
+	 */
+	public function testFindIdByRefIgnoresAnEmbeddedReferenceByDefault()
+	{
+		$ref = $this->uniqueSupplierRef();
+		$invoice = $this->createSupplierInvoiceWithRef('PAY123 - ' . $ref . ' - dinner');
+
+		$this->assertSame(0, SupplierInvoiceHelper::findIdByRef($ref, (int) $invoice->socid));
+	}
+
+	/**
+	 * With the option on, that same reference is found.
+	 *
+	 * @return void
+	 */
+	public function testFindIdByRefMatchesAnEmbeddedReferenceWhenTolerant()
+	{
+		global $conf;
+
+		$ref = $this->uniqueSupplierRef();
+		$invoice = $this->createSupplierInvoiceWithRef('PAY123 - ' . $ref . ' - dinner');
+
+		$conf->global->EINVOICING_TOLERANT_SUPPLIER_REF_MATCH = '1';
+
+		$this->assertSame((int) $invoice->id, SupplierInvoiceHelper::findIdByRef($ref, (int) $invoice->socid));
+	}
+
+	/**
+	 * The case the tolerant matching of PR #605 got wrong: an invoice numbered one digit longer must
+	 * never answer for the shorter reference, or the incoming invoice is silently declared a
+	 * duplicate and never imported.
+	 *
+	 * @return void
+	 */
+	public function testFindIdByRefRefusesALongerGluedReferenceWhenTolerant()
+	{
+		global $conf;
+
+		$ref = $this->uniqueSupplierRef();
+		$invoice = $this->createSupplierInvoiceWithRef($ref . '0');
+
+		$conf->global->EINVOICING_TOLERANT_SUPPLIER_REF_MATCH = '1';
+
+		$this->assertSame(0, SupplierInvoiceHelper::findIdByRef($ref, (int) $invoice->socid));
+	}
+
+	/**
+	 * An exact match answers alone, even when other invoices embed the same reference.
+	 *
+	 * @return void
+	 */
+	public function testFindIdByRefPrefersTheExactMatch()
+	{
+		global $conf;
+
+		$ref = $this->uniqueSupplierRef();
+		$exact = $this->createSupplierInvoiceWithRef($ref);
+		$this->createSupplierInvoiceWithRef('PAY123 - ' . $ref . ' - dinner', (int) $exact->socid);
+
+		$conf->global->EINVOICING_TOLERANT_SUPPLIER_REF_MATCH = '1';
+
+		$this->assertSame((int) $exact->id, SupplierInvoiceHelper::findIdByRef($ref, (int) $exact->socid));
+	}
+
+	/**
+	 * Two candidates and no exact match is an ambiguity, reported as such instead of guessed.
+	 *
+	 * @return void
+	 */
+	public function testFindIdByRefReportsSeveralCandidatesWhenTolerant()
+	{
+		global $conf;
+
+		$ref = $this->uniqueSupplierRef();
+		$first = $this->createSupplierInvoiceWithRef('PAY123 - ' . $ref . ' - dinner');
+		$this->createSupplierInvoiceWithRef('PAY456 - ' . $ref . ' - taxi', (int) $first->socid);
+
+		$conf->global->EINVOICING_TOLERANT_SUPPLIER_REF_MATCH = '1';
+
+		$this->assertSame(-2, SupplierInvoiceHelper::findIdByRef($ref, (int) $first->socid));
+	}
+
+	/**
+	 * A short or purely numeric reference is a substring of far too many others, so the tolerant
+	 * fallback does not even look for it.
+	 *
+	 * @return void
+	 */
+	public function testFindIdByRefNeverSubstringSearchesAShortOrNumericReference()
+	{
+		global $conf;
+
+		$shortRef = 'AB12';
+		$numericRef = (string) mt_rand(100000000, 999999999);
+		$invoice = $this->createSupplierInvoiceWithRef('PAY123 - ' . $shortRef . ' - ' . $numericRef . ' - dinner');
+
+		$conf->global->EINVOICING_TOLERANT_SUPPLIER_REF_MATCH = '1';
+
+		$this->assertSame(0, SupplierInvoiceHelper::findIdByRef($shortRef, (int) $invoice->socid));
+		$this->assertSame(0, SupplierInvoiceHelper::findIdByRef($numericRef, (int) $invoice->socid));
+
+		// The minimum length is configurable, and lowering it brings the short reference back
+		$conf->global->EINVOICING_TOLERANT_SUPPLIER_REF_MIN_LENGTH = '4';
+		$this->assertSame((int) $invoice->id, SupplierInvoiceHelper::findIdByRef($shortRef, (int) $invoice->socid));
+	}
+
+	/**
+	 * An ambiguity and a database failure are two different problems, and neither of them is a
+	 * missing document.
+	 *
+	 * @return void
+	 */
+	public function testRefLookupErrorMessageDistinguishesAmbiguityFromDatabaseError()
+	{
+		$ambiguous = SupplierInvoiceHelper::refLookupErrorMessage(-2, 'FA202610', 'linked to document FA202611');
+		$this->assertStringContainsString('Several supplier invoices match', $ambiguous);
+		$this->assertStringContainsString('FA202610', $ambiguous);
+		$this->assertStringContainsString('linked to document FA202611', $ambiguous);
+
+		$dbError = SupplierInvoiceHelper::refLookupErrorMessage(-1, 'FA202610', 'linked to document FA202611');
+		$this->assertStringContainsString('Database error', $dbError);
+		$this->assertStringNotContainsString('Several supplier invoices match', $dbError);
 	}
 }


### PR DESCRIPTION
Follows #605, at @frederic34's invitation ([comment](https://github.com/Dolibarr/dolibarr-community-modules/pull/605#issuecomment-5381861225)). Same need, same starting idea - the five copy-pasted `SELECT ... WHERE ref_supplier = ...` blocks deserve a single helper - with @eldy's request kept: **the default stays an exact match**.

## The need

An accountant rarely stores the bare document reference. `ref_supplier` gets a payment reference prefixed to it and a free-text description appended, e.g.

```
PLTHDDD5OAAABBB - TEST-GROUP-2026-07-06-19407 - EVENEMENT 30/06/2026 A PARIS
```

for a document the XML numbers `TEST-GROUP-2026-07-06-19407`. The import never recognised it, and stopped on a referenced document it could not find.

## Why the matching rule has to be narrow

A substring match that answers with the first row it finds does not merely risk a false positive, it loses an invoice:

- already in base for supplier S: `ref_supplier = "FA2026100"`
- an e-invoice arrives with `documentno = "FA202610"`
- the duplicate check matches `FA2026100`, answers `res > 0`, `"Supplier Invoice with reference FA202610 already exists"`, cleans the temporary files and marks the flow processed

`FA202610` is never created, and nothing in the UI or the logs says so. Any sequential numbering (`INV-1` … `INV-10` … `INV-100`) walks into it. On the referenced-document lookups the same false positive does not lose data, but it sets `fk_facture_source` and the line links to the wrong invoice.

## What this PR does

**One helper, `SupplierInvoiceHelper::findIdByRef()`**, replacing nine inline queries: five in `CIIProtocol` (duplicate check, referenced documents at document level twice, at line level, and the source invoice of a credit note) and four more in `FacturXProtocol`, whose `doCreateSupplierInvoiceFromSource()` carries a copy of the same logic - so the two paths cannot drift apart again.

**Exact match by default.** With the option off the query is byte-for-byte the one that was there before; nothing changes for anybody who does not ask for it.

**A hidden option, `EINVOICING_TOLERANT_SUPPLIER_REF_MATCH`**, off by default, adds a fallback tried *only* when the exact match found nothing, and bounded so that it cannot answer for the wrong invoice:

- a reference shorter than `EINVOICING_TOLERANT_SUPPLIER_REF_MIN_LENGTH` (8) or purely numeric is never searched for as a substring;
- the substring must be **delimited** on both sides by a non alphanumeric character or by an edge of the string, so `FA202610` matches `PAY123 - FA202610 - dinner` but not `FA2026100`;
- the whitespace manual entry adds (`FA 2026 10`, tabs and non-breaking spaces included) is tolerated - and the gap it leaves still counts as a delimiter, which is the part worth getting right: stripping the spaces would otherwise destroy the boundary they form.

**Distinct return codes**: `>0` found, `0` not found, `-1` database error, `-2` several matches. The call sites now say which one happened. Before this, a SQL failure was reported to the user as a missing document and `$db->lasterror()` was dropped; an ambiguity is now reported rather than guessed.

| stored `ref_supplier` | searched ref | result |
|---|---|---|
| `PLTHDDD5OAAABBB - TEST-GROUP-2026-07-06-19407 - EVENEMENT 30/06/2026 A PARIS` | `TEST-GROUP-2026-07-06-19407` | match |
| `PAY123 - FA202610 - dinner` | `FA202610` | match |
| `acompte FA 2026 10 solde` | `FA202610` | match |
| `FA2026100 et FA202610` | `FA202610` | match (second occurrence) |
| `fa202610` | `FA202610` | match |
| `FA2026100` | `FA202610` | **no match** |
| `INV-2026-1000` | `INV-2026-100` | **no match** |
| `XFA202610` | `FA202610` | **no match** |
| `FA202610suite` | `FA202610` | **no match** |

## Tests

`SupplierInvoiceHelperTest` gains 10 tests (39 in the file now): the delimiter rule case by case, and the lookup itself against the database - exact match, option off, embedded reference, glued longer reference, ambiguity, short and purely numeric references, and the configurable minimum length.

## What was run, and where

On a bench of **eight Dolibarr instances, 17.0.4 to 24.0.0-beta**, all sharing the deployed module:

- the whole PHPUnit suite of the module, file by file, on 18.0.10 (the minimum the module declares) and 23.0.3: **15 files, all green**;
- `SupplierInvoiceHelperTest` on the eight instances: 39 tests, 272 assertions, green on each;
- a **real import bench** driving `CIIProtocol::createSupplierInvoiceFromSource()` on the eight instances, checking on the live database: nominal import, re-import answering "already exists" without creating a second invoice, the retyped `ref_supplier` ignored with the option off and matched with it on, the glued longer reference refused *and the shorter document actually created*, two candidates reported as ambiguous with nothing created, and a missing referenced document reported as missing rather than as a database error;
- each imported invoice then **read back from a second process**, which is what catches a transaction left open;
- the same through `FacturXProtocol::createSupplierInvoiceFromSource()` on 17, 18, 23 and 24.

The bench scripts are not part of the PR; happy to attach them if useful.
