### PR TITLE
CHANGE [einvoicing] Move the getDolGlobalFloat backport to compat/

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -23,6 +23,11 @@ CHANGE: GETPOSTFLOAT(), a function the core gained in Dolibarr 20 and that the m
 versions below, moves from the library of the module to compat/functions.lib.php, where the module keeps
 what it copies from the core. Pure move, guard included: the library requires that file, so the two call
 sites of admin/setup.php keep finding the function where they used to.
+CHANGE: getDolGlobalFloat(), a function the core gained in Dolibarr 21 and that the module backports for
+the versions below, moves from the library of the module to compat/functions.lib.php, where the module
+keeps what it copies from the core. Pure move, guard included: the library requires that file, so the
+eight call sites of PriceHelper - the rounding rule of the totals - keep finding the function where they
+used to.
 
 CHANGE: dolPrintHTMLForAttribute(), a function the core only gained in Dolibarr 19, was backported in
 the library of the module, among its own functions. It now sits in compat/functions.lib.php, next to the

--- a/einvoicing/compat/functions.lib.php
+++ b/einvoicing/compat/functions.lib.php
@@ -25,6 +25,23 @@
 
 // @phan-file-suppress PhanRedefineFunction
 
+if (!function_exists('getDolGlobalFloat')) {
+	/**
+	 *  Return a Dolibarr global constant value, converted into float.
+	 *  Provided as a polyfill for Dolibarr < 21, where this function does not exist yet.
+	 *
+	 *  @param  string  $key        Name of the constant
+	 *  @param  float   $default    Default value if constant is not defined
+	 *  @return float               Value converted into float
+	 *  @since  Dolibarr V21
+	 */
+	function getDolGlobalFloat($key, $default = 0)
+	{
+		global $conf;
+		return (float) (isset($conf->global->$key) ? $conf->global->$key : $default);
+	}
+}
+
 if (!function_exists('GETPOSTDATE')) {
 	/**
 	 *  Return a timestamp built from the year, month, day (and optionally hour, minute, second) fields

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -374,22 +374,6 @@ if (!function_exists("getMultidirVersion")) {
 }
 
 
-if (!function_exists('getDolGlobalFloat')) {
-	/**
-	 *  Return a Dolibarr global constant value, converted into float.
-	 *  Provided as a polyfill for Dolibarr < 21, where this function does not exist yet.
-	 *
-	 *  @param  string  $key        Name of the constant
-	 *  @param  float   $default    Default value if constant is not defined
-	 *  @return float               Value converted into float
-	 *  @since  Dolibarr V21
-	 */
-	function getDolGlobalFloat($key, $default = 0)  // @phan-suppress-current-line PhanRedefineFunction
-	{
-		global $conf;
-		return (float) (isset($conf->global->$key) ? $conf->global->$key : $default);
-	}
-}
 
 if (!function_exists('einvoicingDolGetButtonActionDropdown')) {
 	/**


### PR DESCRIPTION
`getDolGlobalFloat()` entered the core in **Dolibarr 21**. The module carries a copy of it, guarded by
`function_exists()`, for the versions below - and that copy sits in `lib/einvoicing.lib.php`, among the
functions the module itself owns, where nothing tells a reader it is core code.

`compat/` is where this module keeps what it backports from the core, so the copy moves to
`compat/functions.lib.php`, next to the other helpers of `core/lib/functions.lib.php`. The library
`require_once`s that file, so the **eight call sites in `PriceHelper`** keep finding the function where
they used to. Those read `MAIN_ROUNDING_RULE_TOT` on the path that decides the totals of a document, which
is why the body is left strictly untouched - it is a verbatim copy of the core function of 23 and 24,
checked character for character.

## Tested

Live on eight instances, Dolibarr **17.0.4, 18.0.10, 19.0.4, 20.0.4, 21.0.4, 22.0.5, 23.0.3 and
24.0.0-beta**, sharing the same checkout of the module.

A move has one property to prove: every caller still reaches the same function, returning the same value.
So the check is not "the page answers 200" but a probe that loads only the library of the module - the way
callers do - and reports, for each backported helper, whether it is defined, **which file provides it**
(`ReflectionFunction::getFileName()`) and what it returns on fixed inputs. Run before and after, on
Dolibarr 17 (the copy is used), 20 and 23 (the core provides it, the guard skips the copy).

| Dolibarr | before | after | value for `MAIN_ROUNDING_RULE_TOT` |
|---|---|---|---|
| 17.0.4 | `lib/einvoicing.lib.php` | **`compat/functions.lib.php`** | `0` → `0` |
| 20.0.4 | `lib/einvoicing.lib.php` | **`compat/functions.lib.php`** | `0` → `0` |
| 23.0.3 | core | core | `0` → `0` |

Nothing else moved in the probe: same value everywhere, and 20 and 23 untouched.

- Module unit tests, file by file, on the eight cores: 112 files, no failure.
- `phpcs` (Dolibarr ruleset) clean on both files.
- The whole family merged together, then probed again on 17, 20 and 23: the six helpers all answer from
  `compat/functions.lib.php`, with the same values.

## This is one of a chain, and it merges without a conflict

The module backports six helpers of `core/lib/functions.lib.php`. They move to `compat/` one function per
PR, and the PRs are **stacked in a straight line** so that none of them ever needs a merge resolution:

| order | PR | function | in the core since |
|---|---|---|---|
| 1 | #619 | `GETPOSTDATE()` - also creates the file | 18 |
| 2 | #620 | `dolPrintHTMLForAttribute()` | 19 |
| 3 | #623 | `GETPOSTFLOAT()` | 20 |
| 4 | #624 | `getDolGlobalFloat()` | 21 |
| 5 | #625 | `getMultidirTemp()` | 20 |
| 6 | #626 | `dolPrintHTML()` | 18 |
| 7 | #627 | `getMultidirVersion()` - removed, nothing calls it | 20 |

Each one is based on the one above it, so **merged in that order they all apply cleanly** - no conflict in
`compat/functions.lib.php`, none in `ChangeLog.md`. Merging a later one alone brings the earlier ones with
it, which is also fine; only the reverse order would need work.

They were siblings at first, and two of them inserted at the same point of the file: the merge then asked
for a resolution, and a mechanical union of the two sides silently dropped the closing braces of the first
function - `php -l` answering `Unclosed '{'`. Restacking them removes that trap entirely rather than
leaving it for whoever merges.
