### PR TITLE
CHANGE [einvoicing] Remove the getMultidirVersion backport, which nothing calls

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -23,6 +23,11 @@ CHANGE: GETPOSTFLOAT(), a function the core gained in Dolibarr 20 and that the m
 versions below, moves from the library of the module to compat/functions.lib.php, where the module keeps
 what it copies from the core. Pure move, guard included: the library requires that file, so the two call
 sites of admin/setup.php keep finding the function where they used to.
+CHANGE: getDolGlobalFloat(), a function the core gained in Dolibarr 21 and that the module backports for
+the versions below, moves from the library of the module to compat/functions.lib.php, where the module
+keeps what it copies from the core. Pure move, guard included: the library requires that file, so the
+eight call sites of PriceHelper - the rounding rule of the totals - keep finding the function where they
+used to.
 
 CHANGE: dolPrintHTMLForAttribute(), a function the core only gained in Dolibarr 19, was backported in
 the library of the module, among its own functions. It now sits in compat/functions.lib.php, next to the

--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -19,6 +19,10 @@ than one authentication method in the same request. An installation that set
 ESALINK_AUTHENT_USING_CLIENT_CREDENTIAL as a workaround keeps working: the constant is now without
 effect, and the request it used to select is the default.
 
+CHANGE: the backport of getMultidirVersion() is removed. That function entered the core in Dolibarr 20
+and the module carried a copy of it for the versions below, but it calls it nowhere - not once in the
+whole repository - so the copy was never reached on any version.
+
 CHANGE: GETPOSTFLOAT(), a function the core gained in Dolibarr 20 and that the module backports for the
 versions below, moves from the library of the module to compat/functions.lib.php, where the module keeps
 what it copies from the core. Pure move, guard included: the library requires that file, so the two call

--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -33,6 +33,10 @@ versions below, moves from the library of the module to compat/functions.lib.php
 what it copies from the core. Pure move, guard included: the library requires that file, so the two call
 sites - the temporary directory the providers write a retrieved test invoice into - keep finding the
 function where they used to.
+CHANGE: dolPrintHTML(), a function the core gained in Dolibarr 18 and that the module backports for
+Dolibarr 17, moves from the library of the module to compat/functions.lib.php, where the module keeps
+what it copies from the core. Pure move, guard included: the library requires that file, so the seven
+call sites keep finding the function where they used to.
 
 CHANGE: dolPrintHTMLForAttribute(), a function the core only gained in Dolibarr 19, was backported in
 the library of the module, among its own functions. It now sits in compat/functions.lib.php, next to the

--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -28,6 +28,11 @@ the versions below, moves from the library of the module to compat/functions.lib
 keeps what it copies from the core. Pure move, guard included: the library requires that file, so the
 eight call sites of PriceHelper - the rounding rule of the totals - keep finding the function where they
 used to.
+CHANGE: getMultidirTemp(), a function the core gained in Dolibarr 20 and that the module backports for the
+versions below, moves from the library of the module to compat/functions.lib.php, where the module keeps
+what it copies from the core. Pure move, guard included: the library requires that file, so the two call
+sites - the temporary directory the providers write a retrieved test invoice into - keep finding the
+function where they used to.
 
 CHANGE: dolPrintHTMLForAttribute(), a function the core only gained in Dolibarr 19, was backported in
 the library of the module, among its own functions. It now sits in compat/functions.lib.php, next to the

--- a/einvoicing/compat/functions.lib.php
+++ b/einvoicing/compat/functions.lib.php
@@ -25,6 +25,23 @@
 
 // @phan-file-suppress PhanRedefineFunction
 
+if (!function_exists('getDolGlobalFloat')) {
+	/**
+	 *  Return a Dolibarr global constant value, converted into float.
+	 *  Provided as a polyfill for Dolibarr < 21, where this function does not exist yet.
+	 *
+	 *  @param  string  $key        Name of the constant
+	 *  @param  float   $default    Default value if constant is not defined
+	 *  @return float               Value converted into float
+	 *  @since  Dolibarr V21
+	 */
+	function getDolGlobalFloat($key, $default = 0)
+	{
+		global $conf;
+		return (float) (isset($conf->global->$key) ? $conf->global->$key : $default);
+	}
+}
+
 if (!function_exists('GETPOSTDATE')) {
 	/**
 	 *  Return a timestamp built from the year, month, day (and optionally hour, minute, second) fields

--- a/einvoicing/compat/functions.lib.php
+++ b/einvoicing/compat/functions.lib.php
@@ -139,3 +139,19 @@ if (!function_exists('dolPrintHTMLForAttribute')) {
 		}
 	}
 }
+
+if (!function_exists('getMultidirTemp')) {
+	/**
+	 * Return the full path of the directory where a module (or an object of a module) stores its temporary files.
+	 * Path may depends on the entity if a multicompany module is enabled.
+	 *
+	 * @param 	CommonObject 	$object 	Dolibarr common object
+	 * @param 	string 			$module 	Override object element, for example to use 'mycompany' instead of 'societe'
+	 * @param	int				$forobject	Return the more complete path for the given object instead of for the module only.
+	 * @return 	string|null					The path of the relative temp directory of the module
+	 */
+	function getMultidirTemp($object, $module = '', $forobject = 0)
+	{
+		return getMultidirOutputCompat($object, $module, $forobject, 'temp');
+	}
+}

--- a/einvoicing/compat/functions.lib.php
+++ b/einvoicing/compat/functions.lib.php
@@ -106,6 +106,20 @@ if (!function_exists('GETPOSTFLOAT')) {
 	}
 }
 
+if (!function_exists('dolPrintHTML')) {
+	/**
+	 * Return a string ready to be output on HTML page
+	 * To use text inside an attribute, use can use only dol_escape_htmltag()
+	 *
+	 * @param	string	$s		String to print
+	 * @return	string			String ready for HTML output
+	 */
+	function dolPrintHTML($s)
+	{
+		return dol_escape_htmltag(dol_htmlwithnojs(dol_string_onlythesehtmltags(dol_htmlentitiesbr($s), 1, 1, 1)), 1, 1, 'common', 0, 1);
+	}
+}
+
 if (!function_exists('dolPrintHTMLForAttribute')) {
 	/**
 	 * Return a string ready to be output into an HTML attribute (alt, title, data-html, ...)

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -396,20 +396,6 @@ if (!function_exists('einvoicingDolGetButtonActionDropdown')) {
 	}
 }
 
-if (!function_exists('dolPrintHTML')) {
-	/**
-	 * Return a string ready to be output on HTML page
-	 * To use text inside an attribute, use can use only dol_escape_htmltag()
-	 *
-	 * @param	string	$s		String to print
-	 * @return	string			String ready for HTML output
-	 */
-	function dolPrintHTML($s)  // @phan-suppress-current-line PhanRedefineFunction
-	{
-		return dol_escape_htmltag(dol_htmlwithnojs(dol_string_onlythesehtmltags(dol_htmlentitiesbr($s), 1, 1, 1)), 1, 1, 'common', 0, 1);
-	}
-}
-
 
 if (!method_exists('Societe', 'findNearest')) {
 	/**

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -341,21 +341,6 @@ function getMultidirOutputCompat($object, $module = '', $forobject = 0, $mode = 
 	}
 }
 
-if (!function_exists("getMultidirTemp")) {
-	/**
-	 * Return the full path of the directory where a module (or an object of a module) stores its temporary files.
-	 * Path may depends on the entity if a multicompany module is enabled.
-	 *
-	 * @param 	CommonObject 	$object 	Dolibarr common object
-	 * @param 	string 			$module 	Override object element, for example to use 'mycompany' instead of 'societe'
-	 * @param	int				$forobject	Return the more complete path for the given object instead of for the module only.
-	 * @return 	string|null					The path of the relative temp directory of the module
-	 */
-	function getMultidirTemp($object, $module = '', $forobject = 0)  // @phan-suppress-current-line PhanRedefineFunction
-	{
-		return getMultidirOutputCompat($object, $module, $forobject, 'temp');
-	}
-}
 
 if (!function_exists("getMultidirVersion")) {
 	/**

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -342,22 +342,6 @@ function getMultidirOutputCompat($object, $module = '', $forobject = 0, $mode = 
 }
 
 
-if (!function_exists("getMultidirVersion")) {
-	/**
-	 * Return the full path of the directory where a module (or an object of a module) stores its versioned files.
-	 * Path may depends on the entity if a multicompany module is enabled.
-	 *
-	 * @param 	CommonObject 	$object 	Dolibarr common object
-	 * @param 	string 			$module 	Override object element, for example to use 'mycompany' instead of 'societe'
-	 * @param	int				$forobject	Return the more complete path for the given object instead of for the module only.
-	 * @return string|null					The path of the relative version directory of the module
-	 */
-	function getMultidirVersion($object, $module = '', $forobject = 0)  // @phan-suppress-current-line PhanRedefineFunction
-	{
-		return getMultidirOutputCompat($object, $module, $forobject, 'version');
-	}
-}
-
 
 
 if (!function_exists('einvoicingDolGetButtonActionDropdown')) {

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -374,22 +374,6 @@ if (!function_exists("getMultidirVersion")) {
 }
 
 
-if (!function_exists('getDolGlobalFloat')) {
-	/**
-	 *  Return a Dolibarr global constant value, converted into float.
-	 *  Provided as a polyfill for Dolibarr < 21, where this function does not exist yet.
-	 *
-	 *  @param  string  $key        Name of the constant
-	 *  @param  float   $default    Default value if constant is not defined
-	 *  @return float               Value converted into float
-	 *  @since  Dolibarr V21
-	 */
-	function getDolGlobalFloat($key, $default = 0)  // @phan-suppress-current-line PhanRedefineFunction
-	{
-		global $conf;
-		return (float) (isset($conf->global->$key) ? $conf->global->$key : $default);
-	}
-}
 
 if (!function_exists('einvoicingDolGetButtonActionDropdown')) {
 	/**


### PR DESCRIPTION
`getMultidirVersion()` entered the core in **Dolibarr 20**, and the module carries a copy of it, guarded
by `function_exists()`, for the versions below.

**Nothing calls it.** Not the module, not anything else in the repository - the only three matches for the
name are the definition itself, its guard, and the phan stub of the core. So on 20 and above the guard
skips it, and on 17 to 19 the copy is defined and never reached.

Its siblings are moving to `compat/functions.lib.php`, next to what the module really uses. Rather than
move a copy nothing reaches, this removes it. **Say the word if you would rather keep it for a future
caller** and it moves to `compat/` like the others instead - the change is one block either way.

## Tested

Live on eight instances, Dolibarr **17.0.4, 18.0.10, 19.0.4, 20.0.4, 21.0.4, 22.0.5, 23.0.3 and
24.0.0-beta**, sharing the same checkout of the module.

A move has one property to prove: every caller still reaches the same function, returning the same value.
So the check is not "the page answers 200" but a probe that loads only the library of the module - the way
callers do - and reports, for each backported helper, whether it is defined, **which file provides it**
(`ReflectionFunction::getFileName()`) and what it returns on fixed inputs. Run before and after, on
Dolibarr 17 (the copy is used), 20 and 23 (the core provides it, the guard skips the copy).

| Dolibarr | before | after |
|---|---|---|
| 17.0.4 | `lib/einvoicing.lib.php`, returns `.../documents/einvoicing` | **not defined** |
| 20.0.4 | core | core, unchanged |
| 23.0.3 | core | core, unchanged |

On 17 the function simply stops existing, which is what "nothing calls it" means in practice. Every other
helper of the probe is unchanged on the three versions.

Nothing else moved in the probe: same value everywhere, and 20 and 23 untouched.

- Module unit tests, file by file, on the eight cores: 112 files, no failure.
- `phpcs` (Dolibarr ruleset) clean on both files.
- The whole family merged together, then probed again on 17, 20 and 23: the six helpers all answer from
  `compat/functions.lib.php`, with the same values.

## This is one of a chain, and it merges without a conflict

The module backports six helpers of `core/lib/functions.lib.php`. They move to `compat/` one function per
PR, and the PRs are **stacked in a straight line** so that none of them ever needs a merge resolution:

| order | PR | function | in the core since |
|---|---|---|---|
| 1 | #619 | `GETPOSTDATE()` - also creates the file | 18 |
| 2 | #620 | `dolPrintHTMLForAttribute()` | 19 |
| 3 | #623 | `GETPOSTFLOAT()` | 20 |
| 4 | #624 | `getDolGlobalFloat()` | 21 |
| 5 | #625 | `getMultidirTemp()` | 20 |
| 6 | #626 | `dolPrintHTML()` | 18 |
| 7 | #627 | `getMultidirVersion()` - removed, nothing calls it | 20 |

Each one is based on the one above it, so **merged in that order they all apply cleanly** - no conflict in
`compat/functions.lib.php`, none in `ChangeLog.md`. Merging a later one alone brings the earlier ones with
it, which is also fine; only the reverse order would need work.

They were siblings at first, and two of them inserted at the same point of the file: the merge then asked
for a resolution, and a mechanical union of the two sides silently dropped the closing braces of the first
function - `php -l` answering `Unclosed '{'`. Restacking them removes that trap entirely rather than
leaving it for whoever merges.
