### PR TITLE
FIX [einvoicing] Auto-send to the AP only on the generation that follows a validation

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -19,6 +19,21 @@ tolerated without losing the boundary it forms. Several candidates are reported 
 instead of being guessed, and a database failure is no longer reported to the user as a missing
 document.
 
+FIX: The automatic transmission to the Access Point no longer fires on a document rebuild that has
+nothing to do with a validation. EINVOICING_AUTO_SEND_ON_GENERATION says it transmits "on invoice
+validation", but it lived in afterPDFCreation(), a hook called for every rebuild of the invoice PDF
+and unable to tell what asked for one. Recording a payment rebuilds the invoice document from inside
+Paiement::create(), and so do the "Generate" button of the invoice card and any mass or scheduled PDF
+rebuild. On an invoice validated before the module was set up - or deliberately left to be sent by
+hand - the first such rebuild deposited it at the Access Point on its own: an invoice dated three
+months earlier was submitted at the moment its payment was entered, and being transmitted from then
+on, it also unlocked the cash-in status (212) that the very same payment reported next. The
+BILL_VALIDATE trigger now marks the invoice for the rest of the request - it runs inside
+Facture::validate(), before the caller regenerates the document, and for no other reason - and the
+auto-send is limited to a generation that carries that mark. Nothing changes for the validation flow,
+in the card, in a mass action or through the API; every other rebuild still regenerates the e-invoice
+file and now leaves the transmission to the "Send" button.
+
 FIX: A third party recognised as a private individual is no longer reported as misconfigured when
 EINVOICING_SKIP_B2C is on (issue #600). The option already kept B2C invoices out of the e-invoicing
 scope - needEInvoiceManagement() answers "do not manage" on them, since B2C is reported by e-reporting

--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -203,12 +203,21 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 							// Optionally transmit to the Access Point right after generation (opt-in + idempotent) and if not yet generated.
 							// Without this, validation only generates the Factur-X; the invoice is never sent to the
 							// PA (transmission was a manual "send_to_pdp" click only).
-							// Two guards, because one is not enough: 'transmitted' reads the syncstatus, which
-							// generateInvoice() just reset to GENERATED a few lines above, so it stops seeing a
+							// Restricted to the generation that follows a validation, which is what the option says
+							// it does. This hook is called for every rebuild of the invoice PDF, and several of them
+							// happen long after the validation and with nobody asking for a transmission: recording a
+							// payment rebuilds the document from inside Paiement::create(), and so do the "Generate"
+							// button of the invoice card and any mass/cron PDF rebuild. On an invoice validated before
+							// the module was set up - or deliberately left to be sent by hand - the first of those
+							// rebuilds used to deposit it at the PA on its own, months after its date, and to unlock
+							// the cash-in status (212) that the very same payment then reported.
+							// Then two more guards, because one is not enough: 'transmitted' reads the syncstatus,
+							// which generateInvoice() just reset to GENERATED a few lines above, so it stops seeing a
 							// transmission from the second regeneration on. isTransmittedLockActive() reads the
 							// flow_id, which the first submission assigned and nothing clears, so it holds for good
 							// (and honors EINVOICING_ALLOW_RESEND_TRANSMITTED like the manual send does).
-							if (getDolGlobalString('EINVOICING_AUTO_SEND_ON_GENERATION') && empty($currentStatusDetails['transmitted'])
+							if (getDolGlobalString('EINVOICING_AUTO_SEND_ON_GENERATION') && EInvoicing::isInvoiceValidatedInThisRequest($invoiceObject->id)
+								&& empty($currentStatusDetails['transmitted'])
 								&& !$einvoicing->isTransmittedLockActive($invoiceObject->id, $invoiceObject->ref) && $precheckresult >= 0) {
 								dol_syslog("actions_einvoicing: Invoice seems not yet transmitted and EINVOICING_AUTO_SEND_ON_GENERATION is on, so we try to send it");
 

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -57,6 +57,19 @@ class EInvoicing
 	 */
 	public $errors = array();
 
+	/**
+	 * Ids of the customer invoices whose validation happened during the current request.
+	 *
+	 * The hook that generates the e-invoice, afterPDFCreation(), is called for every rebuild of the
+	 * invoice PDF and cannot tell what asked for it. The BILL_VALIDATE trigger can: it runs inside
+	 * Facture::validate(), before the caller regenerates the document, and it runs for no other
+	 * reason. Marking the invoice there is what lets the hook recognise the generation that follows a
+	 * validation - the only one EINVOICING_AUTO_SEND_ON_GENERATION is meant to transmit.
+	 *
+	 * @var int[]
+	 */
+	private static $validatedinthisrequest = array();
+
 
 	// Dolibarr internal statuses
 	public const STATUS_UNKNOWN             = 0;		// By default, before the e-invoice has been generated
@@ -499,6 +512,30 @@ class EInvoicing
 	public function __construct($db)
 	{
 		$this->db = $db;
+	}
+
+	/**
+	 * Record that a customer invoice has just been validated, from the BILL_VALIDATE trigger.
+	 *
+	 * @param  int	$invoiceid	Id of the validated invoice
+	 * @return void
+	 */
+	public static function setInvoiceValidatedInThisRequest($invoiceid)
+	{
+		if ($invoiceid > 0 && !in_array((int) $invoiceid, self::$validatedinthisrequest, true)) {
+			self::$validatedinthisrequest[] = (int) $invoiceid;
+		}
+	}
+
+	/**
+	 * Tell whether this customer invoice has been validated during the current request.
+	 *
+	 * @param  int	$invoiceid	Id of the invoice
+	 * @return bool				True if the invoice went through BILL_VALIDATE in this very request
+	 */
+	public static function isInvoiceValidatedInThisRequest($invoiceid)
+	{
+		return in_array((int) $invoiceid, self::$validatedinthisrequest, true);
 	}
 
 

--- a/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
+++ b/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
@@ -70,7 +70,8 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 
 		dol_syslog("Trigger '".$this->name."' for action '".$action."' launched by ".__FILE__.". id=".$object->id);
 
-		// Note: Option EINVOICING_AUTO_SEND_ON_GENERATION is managed in hook afterPDFCreation().
+		// Note: Option EINVOICING_AUTO_SEND_ON_GENERATION is managed in hook afterPDFCreation(), which is
+		// told by the BILL_VALIDATE case below that a validation is what triggers the coming generation.
 
 		// THIRD PARTIES
 		if ($action == 'COMPANY_CREATE' || $action == 'COMPANY_MODIFY') {
@@ -148,6 +149,11 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 		if ($action == 'BILL_VALIDATE') {
 			/** @var Facture $object */
 			'@phan-var-force Facture $object';
+
+			// Tell the afterPDFCreation() hook that the document rebuild about to happen is the one that
+			// follows a validation. Set unconditionally and before anything else: this only records a fact
+			// about the request, and the hook is the one place that decides what to do with it.
+			EInvoicing::setInvoiceValidatedInThisRequest($object->id);
 
 			if (!getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP')) {		// If sync Dolibarr to AP is on
 				$einvoicing = new EInvoicing($this->db);


### PR DESCRIPTION
## The problem

`EINVOICING_AUTO_SEND_ON_GENERATION` is described, in its own label and help text, as transmitting the e-invoice to the Access Point **on invoice validation**:

> Automatically transmit to the AP on invoice validation
> If enabled, the e-invoice is transmitted to the Access Point automatically right after it is generated (on invoice validation), without using the "Send" button.

It is implemented in `ActionsEInvoicing::afterPDFCreation()`, a hook called for **every** rebuild of the invoice PDF, which cannot tell what asked for one. Several rebuilds happen long after the validation, with nobody asking for a transmission:

* `Paiement::create()` regenerates the invoice document on its own ("Regenerate the document after inserting payment"), so **recording a payment transmits the invoice**;
* the "Generate" button of the invoice card;
* any mass or scheduled PDF rebuild.

On an invoice that was validated before the module was set up, or deliberately left to be sent by hand, the first such rebuild deposits it at the Access Point on its own.

### Seen in production

An invoice dated 2026-05-29, generated by nobody and never sent, was deposited at the Access Point at the exact second its payment was entered (`Paiement::create` → `commonGenerateDocument` → `afterPDFCreation` → `sendInvoice`, flow submitted 3 months after the invoice date, and refused by the platform).

And the transmission does not stop there. The document rebuild runs **inside** `Paiement::create()`, i.e. *before* the `PAYMENT_CUSTOMER_CREATE` trigger the same payment fires next. So by the time `sendCashedInStatus()` asks whether the invoice ever reached the platform, the answer has just become yes — and a cash-in status **212 (Encaissée)** is reported for an invoice whose deposit the operator never asked for. Reproduced on the sandbox, see the table below.

## The fix

`Facture::validate()` fires `BILL_VALIDATE` and does not generate any document; the caller (`/compta/facture/card.php`, a mass action) regenerates it right after, in the same request. So the trigger is the one place that knows a validation is what the coming generation follows.

The `BILL_VALIDATE` case now marks the invoice for the rest of the request, and the auto-send is limited to a generation carrying that mark. Every other rebuild still regenerates the e-invoice file exactly as before, and leaves the transmission to the "Send" button.

## Tested

Sandbox (dolidev, Dolibarr 23.0.3, SUPERPDP), same scenario each time: an invoice validated while the option was off (so generated, never transmitted), then the option turned on, then a payment recorded in a **separate** request - the situation of the production case above. Service lines, `TAX_MODE_SELL_SERVICE = payment`, so the cash-in is one the reform wants reported.

| scenario | before | after |
| --- | --- | --- |
| payment on an invoice never transmitted | invoice deposited, flow `i_349964` | not transmitted, no flow |
| ... and its cash-in status | **212 sent**, flow `ie_994033` | none |
| validation with the option on (nominal) | transmitted, flow `i_349952` | transmitted, flow `i_349989` |
| payment on an invoice transmitted at validation (nominal) | 212 sent, flow `ie_994074` | 212 sent, unchanged |

Also run:

* the full PHPUnit suite of the module, file by file, on **dd18 (18.0.10)** and **dd23 (23.0.3)** - 15 files, all green;
* one complete sandbox E2E cycle on the branch: invoice `TRI-FA-2608-0182` issued on dolidev, flow `i_349983`, received on dd23 as supplier invoice 2394 with its line periods intact, statuses 200 and 201 back on the issuer;
* `phpcs` with the repository ruleset: clean.

## Which transmissions still happen (audit of the core, versions 17 to 24)

`Facture::validate()` fires `BILL_VALIDATE` and generates no document, on all eight versions: the caller regenerates it right after, in the same request. Every core path that validates a customer invoice does so with the trigger enabled (none passes `notrigger`), so the mark is always set before the generation that follows.

| path | validate + generateDocument in one request | auto-send |
| --- | --- | --- |
| invoice card, "Validate" (`compta/facture/card.php`) | yes, identical shape on 17 → 24 | unchanged, tested on 18.0.10 and 23.0.3 |
| mass action "Validate" (`core/actions_massactions.inc.php`) | yes | unchanged |
| recurring invoices (`facture-rec.class.php`, cron or button) | yes | unchanged |
| TakePOS (validates and cashes in the same request) | yes | unchanged, tested |
| recording a payment | no — `Paiement::create()` rebuilds the document | **stopped, this is the point** |
| "Generate" button, mass or scheduled PDF rebuild | no | **stopped** |
| member subscription, `paymentok.php`, REST `validate()` | no document is generated at all | never fired, before or after |

One behaviour change to be aware of: with `MAIN_DISABLE_PDF_AUTOUPDATE` set, validation generates nothing, so the e-invoice used to be generated *and transmitted* by the first manual "Generate" later on. It is now generated there and left to the "Send" button — the same two explicit steps as any other manual generation.

The change lives in the module layer only — the trigger, the hook and `EInvoicing` — and touches no file under `class/providers/`, so every provider behaves the same way.
