### PR TITLE
FIX [einvoicing] The SQL error of the third party lookup is dropped instead of logged

### DIFF
--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -472,8 +472,6 @@ if (!method_exists('Societe', 'findNearest')) {
 			return $rowid;
 		}
 
-		$errors = array();
-
 		dol_syslog("findNearest", LOG_DEBUG);
 		$tmpthirdparty = new Societe($db);
 
@@ -555,7 +553,7 @@ if (!method_exists('Societe', 'findNearest')) {
 				}
 			} else {
 				$error = $db->lasterror();
-				$errors[] = $db->lasterror();
+				dol_syslog($error, LOG_ERR);
 				$result = -3;
 			}
 			if ($result != 0) {
@@ -608,7 +606,7 @@ if (!method_exists('Societe', 'findNearest')) {
 				}
 			} else {
 				$error = $db->lasterror();
-				$errors[] = $db->lasterror();
+				dol_syslog($error, LOG_ERR);
 				$result = -3;
 			}
 		}


### PR DESCRIPTION
### What

In the `findNearest()` shim of `einvoicing.lib.php`, log the reason when the third party lookup query fails, instead of dropping it.

### Why

Both failing branches did this:

```php
$error = $db->lasterror();
$errors[] = $db->lasterror();
$result = -3;
```

`$errors` is a local array that is never read, and `$error` is never used either: the function returned `-3` and the reason for the failure was lost. The neighbouring branch of the very same function already logs its own error, so this only makes the two others consistent with it:

```php
$error = 'Fetch found several records. Rename one of thirdparties to avoid duplicate.';
dol_syslog($error, LOG_WARNING);
```

The now-unused `$errors = array();` declaration goes away with it. The return value is unchanged.

### Scope

This shim is only defined when the core has no `Societe::findNearest()` of its own, which means **Dolibarr 18 and 19** — the core owns the method from 20 onwards.

### How it was tested

On a bench, with a copy of the file whose two raw queries are deliberately invalid, so that the two changed branches are the ones that run:

| instance | Dolibarr | result | log lines carrying the reason |
|---|---|---|---|
| dd18 | 18.0.10 | `-3` / `-3` | 2, distinct from the 4 lines of `DoliDBMysqli::query` |
| dd19 | 19.0.4 | `-3` / `-3` | 2, distinct from the 4 lines of `DoliDBMysqli::query` |
| dd20 | 20.0.4 | not applicable, the core owns `findNearest()` | — |

```
2026-08-25 13:28:20 ERR ???@www-data Table 'dolibarr_dd18.llx_benchb_isolated' doesn't exist
2026-08-25 13:28:37 ERR ???@www-data Table 'dolibarr_dd19.llx_benchb_isolated' doesn't exist
```

Without the change, those two lines do not exist and the caller only gets `-3`.

`php -l`, `phpcs` with the repository ruleset, and phan with the CI configuration are all clean on the branch.
