### PR TITLE
FIX [einvoicing] The buyer-side CDAR issuer identifier carries no scheme

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -94,6 +94,15 @@ tolerated without losing the boundary it forms. Several candidates are reported 
 instead of being guessed, and a database failure is no longer reported to the user as a missing
 document.
 
+FIX: A lifecycle status sent as the buyer of a supplier invoice now qualifies the identifier of its
+issuer. The GlobalID of the IssuerTradeParty - our own SIREN, the party the status comes from - went out
+with no schemeID attribute on the statuses 205, 210 and 211, while every other identifier of the same
+document carries schemeID="0002": the recipient of the status, the issuer of the invoice it refers to,
+and the issuer of the cash-in (212), which was given the attribute when the seller branch was written and
+the buyer one was left without it. An identifier with no scheme is not qualified - nothing in the document
+says those nine digits are a SIREN rather than any other registration number - and the platforms accepted
+it anyway, which is why it went unnoticed since the module started answering its vendors.
+
 FIX: The log of the API calls to the Approved Platform no longer loses rows. Call::getNextCallId()
 read the highest call number through the global $db, while logCall() builds and inserts its record on
 the independent $dbhistory - the connection it deliberately uses so the trace survives a rollback of

--- a/einvoicing/class/utils/CdarHandler.class.php
+++ b/einvoicing/class/utils/CdarHandler.class.php
@@ -380,6 +380,7 @@ class CdarHandler
 			// We issue the status as the BUYER of a supplier invoice, and it goes back to the vendor
 			$CdarIssuerTradeParty = [
 				'GlobalID' => $mysocGlobalID, // GlobalID of CDAR SENDER
+				'SchemeID' => CdarHandler::SCHEME_SIREN_0002,
 				'RoleCode' => CdarHandler::ROLE_BY
 			];
 


### PR DESCRIPTION
The `GlobalID` of the `IssuerTradeParty` of a lifecycle status sent as the **buyer** of a supplier invoice — our own SIREN, the party the status comes from — goes out with no `schemeID` attribute on the statuses **205, 210 and 211**.

56a7063c added the attribute to the seller branch (212) and left the buyer one without it. Every other identifier of the same document already carries it: the recipient of the status, and the issuer of the invoice it refers to. So that one identifier is unqualified — nothing in the document says those nine digits are a SIREN rather than any other registration number. The platforms accept it anyway, which is why it has gone unnoticed since the module started answering its vendors.

One line, the same constant used in the four other places.

Spotted by @lelex86 while reviewing #615; split out on its own as offered there, so it does not wait on the identifier discussion still open on that PR.

### Tested live

Full sandbox cycle on the deployed branch: an invoice emitted by one instance, routed by the Access Point, received as a supplier invoice by another, then a real **205** sent back from the buyer side and accepted by the platform (`res: 1`, `validation=Ok`).

Before — a 211 generated before the fix:

```xml
<ram:IssuerTradeParty>
  <ram:GlobalID>000000002</ram:GlobalID>
  <ram:RoleCode>BY</ram:RoleCode>
</ram:IssuerTradeParty>
<ram:RecipientTradeParty>
  <ram:GlobalID schemeID="0002">000000001</ram:GlobalID>
```

After — the 205 sent on the branch:

```xml
<ram:IssuerTradeParty>
  <ram:GlobalID schemeID="0002">000000002</ram:GlobalID>
  <ram:RoleCode>BY</ram:RoleCode>
</ram:IssuerTradeParty>
<ram:RecipientTradeParty>
  <ram:GlobalID schemeID="0002">000000001</ram:GlobalID>
```
