### PR TITLE
FIX [einvoicing] The call log is lost on installations that predate the request_id column

### DIFF
--- a/einvoicing/core/modules/modEInvoicing.class.php
+++ b/einvoicing/core/modules/modEInvoicing.class.php
@@ -668,6 +668,16 @@ class modEInvoicing extends DolibarrModules
 			$this->db->query($sqltmp);
 		}
 
+		// The call log carries the Request-Id sent to the Access Point, and llx_einvoicing_call.sql
+		// declares the column for a fresh installation. _load_tables() only creates the tables it does
+		// not find, so an installation that already carried that table never receives the column: the
+		// insert of every API call then fails on an unknown column, and it fails silently because the
+		// trace is written on its own connection (see AbstractPDPProvider::logCall()).
+		$resql = $this->db->DDLDescTable(MAIN_DB_PREFIX . 'einvoicing_call', 'request_id');
+		if (!$resql || !$this->db->fetch_object($resql)) {
+			$this->db->DDLAddField(MAIN_DB_PREFIX . 'einvoicing_call', 'request_id', array('type' => 'varchar', 'value' => '36'), 'AFTER endpoint');
+		}
+
 		return $this->_init($sql, $options);
 	}
 


### PR DESCRIPTION
### The problem

`request_id` was added to `llx_einvoicing_call.sql` in #639, which covers a fresh installation. `_load_tables()` only creates the tables it does not find, so an installation that **already carried** `llx_einvoicing_call` never receives the column — and `Call::create()` lists it among the fields it inserts.

Every API call log then fails on an unknown column. Silently: the trace is written on its own connection (issue #291) and its error only reaches `dol_syslog()`, which is off on most installations.

Measured on an instance whose table predates the column, on current `main`:

```
http=200  call log rows before=805 after=805  => LOST
```

The call itself is fine. Only its trace disappears — the invoice is sent, and nothing records that it was.

### The repair

In `init()`, right before `_init()`, read the table and add the column only if it is missing:

```php
$resql = $this->db->DDLDescTable(MAIN_DB_PREFIX . 'einvoicing_call', 'request_id');
if (!$resql || !$this->db->fetch_object($resql)) {
    $this->db->DDLAddField(MAIN_DB_PREFIX . 'einvoicing_call', 'request_id', array('type' => 'varchar', 'value' => '36'), 'AFTER endpoint');
}
```

`DDLDescTable()` returns an empty set for a column that does not exist, so the test costs one query and the whole thing is a no-op on an installation that is already up to date. Going through the database layer rather than a raw `ALTER` keeps it portable — MySQL has no `ADD COLUMN IF NOT EXISTS`.

It sits next to the other repairs `init()` already carries for old installations (the extrafield conditions), and it needs no new file: the `sql/update_v1.1.1.sql` that came with #639 was dropped before the merge, so the repair has to live in PHP.

### Tested

On an instance whose table lacked the column:

```
avant     : ABSENTE
passage 1 : colonne ajoutee (DDLAddField=1)
passage 2 : rien a faire
apres     : presente
```

and the call log works again right after:

```
http=200  call log rows before=805 after=806  => LOGGED
```

`php -l`, `phpcs` with the repository ruleset and phan with the CI configuration are clean.
