### PR TITLE
FIX CDAR: add schemeID="0002" to buyer-side IssuerTradeParty (205/210/211)

### DIFF
--- a/einvoicing/class/utils/CdarHandler.class.php
+++ b/einvoicing/class/utils/CdarHandler.class.php
@@ -379,8 +379,9 @@ class CdarHandler
 		} else {
 			// We issue the status as the BUYER of a supplier invoice, and it goes back to the vendor
 			$CdarIssuerTradeParty = [
-				'GlobalID' => $mysocGlobalID, // GlobalID of CDAR SENDER
-				'RoleCode' => CdarHandler::ROLE_BY
+				'GlobalID'  => $mysocGlobalID, // GlobalID of CDAR SENDER
+				'SchemeID'  => CdarHandler::SCHEME_SIREN_0002,
+				'RoleCode'  => CdarHandler::ROLE_BY
 			];
 
 			$CdarRecipientTradeParty = [


### PR DESCRIPTION
schemeID="0002" was added to the seller-side IssuerTradeParty in 56a7063 (status 212) but was never added to the buyer-side block covering statuses 205, 210 and 211. This aligns the two branches and makes the attribute consistent across all lifecycle statuses.

One-line change, no behaviour change on platforms that accept the attribute absent — as they currently do.