### PR TITLE
FIX [einvoicing] The compat shims stop redeclaring a name that is already taken (#630)

### DIFF
--- a/einvoicing/compat/commonhookactions.class.php
+++ b/einvoicing/compat/commonhookactions.class.php
@@ -24,18 +24,25 @@
 
 // @phan-suppress-file PhanRedefineClass
 
-/**
- *	Parent class of all other hook actions classes
- */
-abstract class CommonHookActions
-{
+// Guarded like the other shims of this directory. The class is only missing before Dolibarr 19, and
+// every module that has to run on both sides of that line carries the same copy of it: whoever gets
+// loaded second declares a name that is already taken, which is a fatal error and not a recoverable
+// one. It cost the activation of the module on the second entity of a multicompany setup (issue
+// #630), where the other module happened to bring its own copy in first.
+if (!class_exists('CommonHookActions', false)) {
 	/**
-	 * @var string	String of results.
+	 *	Parent class of all other hook actions classes
 	 */
-	public $resprints;
+	abstract class CommonHookActions
+	{
+		/**
+		 * @var string	String of results.
+		 */
+		public $resprints;
 
-	/**
-	 * @var array 	Array of results.
-	 */
-	public $results = array();
+		/**
+		 * @var array 	Array of results.
+		 */
+		public $results = array();
+	}
 }

--- a/einvoicing/compat/profid.lib.php
+++ b/einvoicing/compat/profid.lib.php
@@ -25,225 +25,239 @@
 
 // @phan-file-suppress PhanRedefineFunction
 
-/**
- *  Check if a string passes the Luhn algorithm test.
- *  @param		string|int		$str		string to check
- *  @return		bool						True if the string passes the Luhn algorithm check, False otherwise
- *  @since		Dolibarr V20
- */
-function isValidLuhn($str)
-{
-	$str = (string) $str;
-	$len = dol_strlen($str);
-	$parity = $len % 2;
-	$sum = 0;
-	for ($i = $len - 1; $i >= 0; $i--) {
-		$d = (int) $str[$i];
-		if ($i % 2 == $parity) {
-			if (($d *= 2) > 9) {
-				$d -= 9;
+if (!function_exists('isValidLuhn')) {
+	/**
+	 *  Check if a string passes the Luhn algorithm test.
+	 *  @param		string|int		$str		string to check
+	 *  @return		bool						True if the string passes the Luhn algorithm check, False otherwise
+	 *  @since		Dolibarr V20
+	 */
+	function isValidLuhn($str)
+	{
+		$str = (string) $str;
+		$len = dol_strlen($str);
+		$parity = $len % 2;
+		$sum = 0;
+		for ($i = $len - 1; $i >= 0; $i--) {
+			$d = (int) $str[$i];
+			if ($i % 2 == $parity) {
+				if (($d *= 2) > 9) {
+					$d -= 9;
+				}
+			}
+			$sum += $d;
+		}
+		return $sum % 10 == 0;
+	}
+}
+
+
+if (!function_exists('isValidSiren')) {
+	/**
+	 *  Check the syntax validity of a SIREN.
+	 *
+	 *  @param		string		$siren		SIREN to check
+	 *  @return		boolean					True if valid, False otherwise
+	 *  @since		Dolibarr V20
+	 */
+	function isValidSiren($siren)
+	{
+		$siren = trim($siren);
+		$siren = preg_replace('/(\s)/', '', $siren);
+
+		if (!is_numeric($siren) || dol_strlen($siren) != 9) {
+			return false;
+		}
+
+		return isValidLuhn($siren);
+	}
+}
+
+
+if (!function_exists('isValidSiret')) {
+	/**
+	 *  Check the syntax validity of a SIRET.
+	 *
+	 *  @param		string		$siret		SIRET to check
+	 *  @return		boolean					True if valid, False otherwise
+	 *  @since		Dolibarr V20
+	 */
+	function isValidSiret($siret)
+	{
+		$siret = trim($siret);
+		$siret = preg_replace('/(\s)/', '', $siret);
+
+		if (!is_numeric($siret) || dol_strlen($siret) != 14) {
+			return false;
+		}
+
+		if (isValidLuhn($siret)) {
+			return true;
+		} elseif ((substr($siret, 0, 9) == "356000000") && (array_sum(str_split($siret)) % 5 == 0)) {
+			/**
+			 *  Specific case of "La Poste" businesses (SIRET such as "356 000 000 XXXXX"),
+			 *  for which the rule becomes: the sum of the 14 digits must be a multiple of 5.
+			 *  See https://fr.wikipedia.org/wiki/SIRET for details.
+			 */
+			return true;
+		} else {
+			return false;
+		}
+	}
+}
+
+
+if (!function_exists('isValidTinForPT')) {
+	/**
+	 *  Check the syntax validity of a Portuguese (PT) Tax Identification Number (TIN).
+	 *  (NIF = Número de Identificação Fiscal)
+	 *
+	 *  @param		string		$str		NIF to check
+	 *  @return		boolean					True if valid, False otherwise
+	 *  @since		Dolibarr V20
+	 */
+	function isValidTinForPT($str)
+	{
+		$str = trim($str);
+		$str = preg_replace('/(\s)/', '', $str);
+
+		if (preg_match('/(^[0-9]{9}$)/', $str)) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+}
+
+
+if (!function_exists('isValidTinForDZ')) {
+	/**
+	 *  Check the syntax validity of an Algerian (DZ) Tax Identification Number (TIN).
+	 *  (NIF = Numéro d'Identification Fiscale)
+	 *
+	 *  @param		string		$str		TIN to check
+	 *  @return		boolean					True if valid, False otherwise
+	 *  @since		Dolibarr V20
+	 */
+	function isValidTinForDZ($str)
+	{
+		$str = trim($str);
+		$str = preg_replace('/(\s)/', '', $str);
+
+		if (preg_match('/(^[0-9]{15}$)/', $str)) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+}
+
+
+if (!function_exists('isValidTinForBE')) {
+	/**
+	 *  Check the syntax validity of a Belgium (BE) Tax Identification Number (TIN).
+	 *  (NN = Numéro National)
+	 *
+	 *  @param		string		$str		NN to check
+	 *  @return		boolean					True if valid, False otherwise
+	 *  @since		Dolibarr V20
+	 */
+	function isValidTinForBE($str)
+	{
+		// https://economie.fgov.be/fr/themes/entreprises/banque-carrefour-des/actualites/structure-du-numero
+		$str = trim($str);
+		$str = preg_replace('/(\s)/', '', $str);
+
+		if (preg_match('/(^[0-1]{1}[0-9]{3}\.[0-9]{3}\.[0-9]{3}$)/', $str)) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+}
+
+
+if (!function_exists('isValidTinForES')) {
+	/**
+	 *  Check the syntax validity of a Spanish (ES) Tax Identification Number (TIN), where:
+	 *  - NIF = Número de Identificación Fiscal (used for residents only before 2008. Used for both residents and companies since 2008.)
+	 *  - CIF = Código de Identificación Fiscal (used for companies only before 2008. Replaced by NIF since 2008.)
+	 *  - NIE = Número de Identidad de Extranjero
+	 *
+	 *  @param		string		$str		TIN to check
+	 *  @return		int<-4,3>				1 if NIF ok, 2 if CIF ok, 3 if NIE ok, -1 if NIF bad, -2 if CIF bad, -3 if NIE bad, -4 if unexpected bad
+	 *  @since		Dolibarr V20
+	 */
+	function isValidTinForES($str)
+	{
+		$str = trim($str);
+		$str = preg_replace('/(\s)/', '', $str);
+		$str = strtoupper($str);
+
+		//Check format
+		if (!preg_match('/((^[A-Z]{1}[0-9]{7}[A-Z0-9]{1}$|^[T]{1}[A-Z0-9]{8}$)|^[0-9]{8}[A-Z]{1}$)/', $str)) {
+			return 0;
+		}
+
+		$num = array();
+		for ($i = 0; $i < 9; $i++) {
+			$num[$i] = substr($str, $i, 1);
+		}
+		'@phan-var-force array<int<0,8>,string> $num';
+
+		//Check NIF
+		if (preg_match('/(^[0-9]{8}[A-Z]{1}$)/', $str)) {
+			if ($num[8] == substr('TRWAGMYFPDXBNJZSQVHLCKE', (int) substr($str, 0, 8) % 23, 1)) {
+				return 1;
+			} else {
+				return -1;
 			}
 		}
-		$sum += $d;
-	}
-	return $sum % 10 == 0;
-}
 
-
-/**
- *  Check the syntax validity of a SIREN.
- *
- *  @param		string		$siren		SIREN to check
- *  @return		boolean					True if valid, False otherwise
- *  @since		Dolibarr V20
- */
-function isValidSiren($siren)
-{
-	$siren = trim($siren);
-	$siren = preg_replace('/(\s)/', '', $siren);
-
-	if (!is_numeric($siren) || dol_strlen($siren) != 9) {
-		return false;
-	}
-
-	return isValidLuhn($siren);
-}
-
-
-/**
- *  Check the syntax validity of a SIRET.
- *
- *  @param		string		$siret		SIRET to check
- *  @return		boolean					True if valid, False otherwise
- *  @since		Dolibarr V20
- */
-function isValidSiret($siret)
-{
-	$siret = trim($siret);
-	$siret = preg_replace('/(\s)/', '', $siret);
-
-	if (!is_numeric($siret) || dol_strlen($siret) != 14) {
-		return false;
-	}
-
-	if (isValidLuhn($siret)) {
-		return true;
-	} elseif ((substr($siret, 0, 9) == "356000000") && (array_sum(str_split($siret)) % 5 == 0)) {
-		/**
-		 *  Specific case of "La Poste" businesses (SIRET such as "356 000 000 XXXXX"),
-		 *  for which the rule becomes: the sum of the 14 digits must be a multiple of 5.
-		 *  See https://fr.wikipedia.org/wiki/SIRET for details.
-		 */
-		return true;
-	} else {
-		return false;
-	}
-}
-
-
-/**
- *  Check the syntax validity of a Portuguese (PT) Tax Identification Number (TIN).
- *  (NIF = Número de Identificação Fiscal)
- *
- *  @param		string		$str		NIF to check
- *  @return		boolean					True if valid, False otherwise
- *  @since		Dolibarr V20
- */
-function isValidTinForPT($str)
-{
-	$str = trim($str);
-	$str = preg_replace('/(\s)/', '', $str);
-
-	if (preg_match('/(^[0-9]{9}$)/', $str)) {
-		return true;
-	} else {
-		return false;
-	}
-}
-
-
-/**
- *  Check the syntax validity of an Algerian (DZ) Tax Identification Number (TIN).
- *  (NIF = Numéro d'Identification Fiscale)
- *
- *  @param		string		$str		TIN to check
- *  @return		boolean					True if valid, False otherwise
- *  @since		Dolibarr V20
- */
-function isValidTinForDZ($str)
-{
-	$str = trim($str);
-	$str = preg_replace('/(\s)/', '', $str);
-
-	if (preg_match('/(^[0-9]{15}$)/', $str)) {
-		return true;
-	} else {
-		return false;
-	}
-}
-
-
-/**
- *  Check the syntax validity of a Belgium (BE) Tax Identification Number (TIN).
- *  (NN = Numéro National)
- *
- *  @param		string		$str		NN to check
- *  @return		boolean					True if valid, False otherwise
- *  @since		Dolibarr V20
- */
-function isValidTinForBE($str)
-{
-	// https://economie.fgov.be/fr/themes/entreprises/banque-carrefour-des/actualites/structure-du-numero
-	$str = trim($str);
-	$str = preg_replace('/(\s)/', '', $str);
-
-	if (preg_match('/(^[0-1]{1}[0-9]{3}\.[0-9]{3}\.[0-9]{3}$)/', $str)) {
-		return true;
-	} else {
-		return false;
-	}
-}
-
-
-/**
- *  Check the syntax validity of a Spanish (ES) Tax Identification Number (TIN), where:
- *  - NIF = Número de Identificación Fiscal (used for residents only before 2008. Used for both residents and companies since 2008.)
- *  - CIF = Código de Identificación Fiscal (used for companies only before 2008. Replaced by NIF since 2008.)
- *  - NIE = Número de Identidad de Extranjero
- *
- *  @param		string		$str		TIN to check
- *  @return		int<-4,3>				1 if NIF ok, 2 if CIF ok, 3 if NIE ok, -1 if NIF bad, -2 if CIF bad, -3 if NIE bad, -4 if unexpected bad
- *  @since		Dolibarr V20
- */
-function isValidTinForES($str)
-{
-	$str = trim($str);
-	$str = preg_replace('/(\s)/', '', $str);
-	$str = strtoupper($str);
-
-	//Check format
-	if (!preg_match('/((^[A-Z]{1}[0-9]{7}[A-Z0-9]{1}$|^[T]{1}[A-Z0-9]{8}$)|^[0-9]{8}[A-Z]{1}$)/', $str)) {
-		return 0;
-	}
-
-	$num = array();
-	for ($i = 0; $i < 9; $i++) {
-		$num[$i] = substr($str, $i, 1);
-	}
-	'@phan-var-force array<int<0,8>,string> $num';
-
-	//Check NIF
-	if (preg_match('/(^[0-9]{8}[A-Z]{1}$)/', $str)) {
-		if ($num[8] == substr('TRWAGMYFPDXBNJZSQVHLCKE', (int) substr($str, 0, 8) % 23, 1)) {
-			return 1;
-		} else {
-			return -1;
+		//algorithm checking type code CIF
+		$sum = (int) $num[2] + (int) $num[4] + (int) $num[6];
+		for ($i = 1; $i < 8; $i += 2) {
+			$sum += intval(substr((string) (2 * (int) $num[$i]), 0, 1)) + intval(substr((string) (2 * (int) $num[$i]), 1, 1));
 		}
-	}
+		$n = 10 - (int) substr((string) $sum, strlen((string) $sum) - 1, 1);
 
-	//algorithm checking type code CIF
-	$sum = (int) $num[2] + (int) $num[4] + (int) $num[6];
-	for ($i = 1; $i < 8; $i += 2) {
-		$sum += intval(substr((string) (2 * (int) $num[$i]), 0, 1)) + intval(substr((string) (2 * (int) $num[$i]), 1, 1));
-	}
-	$n = 10 - (int) substr((string) $sum, strlen((string) $sum) - 1, 1);
-
-	//Check special NIF
-	if (preg_match('/^[KLM]{1}/', $str)) {
-		if ($num[8] == chr(64 + $n) || $num[8] == substr('TRWAGMYFPDXBNJZSQVHLCKE', (int) substr($str, 1, 8) % 23, 1)) {
-			return 1;
-		} else {
-			return -1;
+		//Check special NIF
+		if (preg_match('/^[KLM]{1}/', $str)) {
+			if ($num[8] == chr(64 + $n) || $num[8] == substr('TRWAGMYFPDXBNJZSQVHLCKE', (int) substr($str, 1, 8) % 23, 1)) {
+				return 1;
+			} else {
+				return -1;
+			}
 		}
-	}
 
-	//Check CIF
-	if (preg_match('/^[ABCDEFGHJNPQRSUVW]{1}/', $str)) {
-		if ($num[8] == chr(64 + $n) || $num[8] == substr((string) $n, strlen((string) $n) - 1, 1)) {
-			return 2;
-		} else {
-			return -2;
+		//Check CIF
+		if (preg_match('/^[ABCDEFGHJNPQRSUVW]{1}/', $str)) {
+			if ($num[8] == chr(64 + $n) || $num[8] == substr((string) $n, strlen((string) $n) - 1, 1)) {
+				return 2;
+			} else {
+				return -2;
+			}
 		}
-	}
 
-	//Check NIE T
-	if (preg_match('/^[T]{1}/', $str)) {
-		if ($num[8] == preg_match('/^[T]{1}[A-Z0-9]{8}$/', $str)) {
-			return 3;
-		} else {
-			return -3;
+		//Check NIE T
+		if (preg_match('/^[T]{1}/', $str)) {
+			if ($num[8] == preg_match('/^[T]{1}[A-Z0-9]{8}$/', $str)) {
+				return 3;
+			} else {
+				return -3;
+			}
 		}
-	}
 
-	//Check NIE XYZ
-	if (preg_match('/^[XYZ]{1}/', $str)) {
-		if ($num[8] == substr('TRWAGMYFPDXBNJZSQVHLCKE', (int) substr(str_replace(array('X', 'Y', 'Z'), array('0', '1', '2'), $str), 0, 8) % 23, 1)) {
-			return 3;
-		} else {
-			return -3;
+		//Check NIE XYZ
+		if (preg_match('/^[XYZ]{1}/', $str)) {
+			if ($num[8] == substr('TRWAGMYFPDXBNJZSQVHLCKE', (int) substr(str_replace(array('X', 'Y', 'Z'), array('0', '1', '2'), $str), 0, 8) % 23, 1)) {
+				return 3;
+			} else {
+				return -3;
+			}
 		}
-	}
 
-	//Can not be verified
-	return -4;
+		//Can not be verified
+		return -4;
+	}
 }

--- a/einvoicing/test/phpunit/AllTests.php
+++ b/einvoicing/test/phpunit/AllTests.php
@@ -113,6 +113,8 @@ class AllTests
 		$suite->addTestSuite('CIIProfileShapeTest');
 		require_once dirname(__FILE__).'/CIIProtocolTest.php';
 		$suite->addTestSuite('CIIProtocolTest');
+		require_once dirname(__FILE__).'/CompatShimReloadTest.php';
+		$suite->addTestSuite('CompatShimReloadTest');
 		require_once dirname(__FILE__).'/EInvoicingSamplesTest.php';
 		$suite->addTestSuite('EInvoicingSamplesTest');
 		require_once dirname(__FILE__).'/InvoicingPeriodTest.php';

--- a/einvoicing/test/phpunit/CompatShimReloadTest.php
+++ b/einvoicing/test/phpunit/CompatShimReloadTest.php
@@ -1,0 +1,158 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/CompatShimReloadTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for the polyfills of compat/: they must be inert when the symbol
+ *                  they backport is already there.
+ *      \remarks    The module runs from Dolibarr 17 and carries copies of core symbols that only
+ *                  appeared later. It is not the only module in that situation: any other module of
+ *                  the instance that also has to run on both sides of the line carries the same
+ *                  copies, and on a name that is already taken PHP does not warn, it fatals. That is
+ *                  how activating the module on the second entity of a multicompany setup died on
+ *                  "Cannot declare class CommonHookActions, because the name is already in use"
+ *                  (issue #630) - the hook of the module could no longer be loaded at all.
+ *
+ *                  Each shim is therefore checked in a subprocess, since a redeclaration cannot be
+ *                  caught in the running one: first with the symbol already declared (the shim must
+ *                  do nothing), then on its own (the shim must still deliver what it backports).
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+// This module is deployed by symlinking this repository into htdocs/custom/einvoicing of one or
+// several Dolibarr instances. Some test runners resolve the real (non-symlinked) path of this
+// file before including it, which breaks a fixed "../../htdocs/master.inc.php" relative path.
+// DOLIBARR_HTDOCS let's the developer/CI point explicitly at the Dolibarr instance to test
+// against; otherwise we fall back to the standard relative path (valid when this file is reached
+// through the htdocs/custom/einvoicing/test/phpunit symlink without realpath resolution).
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class CompatShimReloadTest extends CommonClassTest
+{
+	/**
+	 * The shims, and what has to be in place for each of them to become a no-op.
+	 *
+	 * @return array<string,string[]>	name => shim file, prior declaration, check
+	 */
+	public function shimProvider()
+	{
+		return array(
+			'commonhookactions' => array(
+				'compat/commonhookactions.class.php',
+				'abstract class CommonHookActions { public $resprints; public $results = array(); }',
+				'class_exists("CommonHookActions")',
+			),
+			'profid' => array(
+				'compat/profid.lib.php',
+				'function isValidLuhn($str) { return true; } function isValidSiren($siren) { return true; } function isValidSiret($siret) { return true; } function isValidTinForPT($str) { return true; } function isValidTinForDZ($str) { return true; } function isValidTinForBE($str) { return true; } function isValidTinForES($str) { return 1; }',
+				'function_exists("isValidLuhn") && function_exists("isValidTinForES")',
+			),
+			'files' => array(
+				'compat/files.lib.php',
+				'function dolChmod($filepath, $newmask = "") { }',
+				'function_exists("dolChmod")',
+			),
+			'functions' => array(
+				'compat/functions.lib.php',
+				'function GETPOSTDATE($prefix, $hourTime = "", $gm = "auto") { return ""; } function GETPOSTFLOAT($paramname, $rounding = "") { return 0.0; } function dolPrintHTMLForAttribute($s) { return ""; }',
+				'function_exists("GETPOSTDATE") && function_exists("dolPrintHTMLForAttribute")',
+			),
+		);
+	}
+
+	/**
+	 * A shim loaded after something else already brought the symbol in must be a no-op, not a fatal.
+	 *
+	 * @param	string	$shim		Path of the shim, relative to the module root
+	 * @param	string	$declared	What another module (or a backporting core) declared first
+	 * @param	string	$check		Expression that must still hold once the shim is loaded
+	 * @return	void
+	 *
+	 * @dataProvider shimProvider
+	 */
+	public function testShimIsInertWhenTheSymbolIsAlreadyDeclared($shim, $declared, $check)
+	{
+		$result = $this->runPhp($declared . ' require ' . var_export($this->shimPath($shim), true) . '; echo (' . $check . ') ? "OK" : "MISSING";');
+
+		$this->assertSame('OK', $result, $shim . ' must not redeclare what is already there: ' . $result);
+	}
+
+	/**
+	 * And it must still be the polyfill it claims to be when nothing declared the symbol.
+	 *
+	 * @param	string	$shim		Path of the shim, relative to the module root
+	 * @param	string	$declared	Unused here
+	 * @param	string	$check		Expression that must hold once the shim is loaded
+	 * @return	void
+	 *
+	 * @dataProvider shimProvider
+	 */
+	public function testShimStillDeclaresWhatItBackports($shim, $declared, $check)
+	{
+		$result = $this->runPhp('require ' . var_export($this->shimPath($shim), true) . '; echo (' . $check . ') ? "OK" : "MISSING";');
+
+		$this->assertSame('OK', $result, $shim . ' no longer provides its polyfill: ' . $result);
+	}
+
+	/**
+	 * Absolute path of a file of the module.
+	 *
+	 * @param	string	$relative	Path relative to the module root
+	 * @return	string				Absolute path
+	 */
+	private function shimPath($relative)
+	{
+		return dirname(__DIR__, 2) . '/' . $relative;
+	}
+
+	/**
+	 * Run a snippet in a subprocess, because a redeclaration is fatal and cannot be caught here.
+	 *
+	 * @param	string	$code	PHP code to run, without the opening tag
+	 * @return	string			Trimmed output, stderr included
+	 */
+	private function runPhp($code)
+	{
+		$output = array();
+		$status = 0;
+		exec(escapeshellarg(PHP_BINARY) . ' -d error_reporting=E_ALL -r ' . escapeshellarg($code) . ' 2>&1', $output, $status);
+
+		$text = trim(implode("\n", $output));
+
+		return $status === 0 ? $text : 'exit ' . $status . ' - ' . $text;
+	}
+}


### PR DESCRIPTION
Fixes #630.

## What happens

`einvoicing/compat/` backports four sets of core symbols so the module can run from Dolibarr 17. Two of them are guarded, two are not:

| shim | backports | guarded |
|---|---|---|
| `files.lib.php` | `dolChmod()` | ✅ `function_exists()` |
| `functions.lib.php` | `GETPOSTDATE()`, `GETPOSTFLOAT()`, `dolPrintHTMLForAttribute()` | ✅ `function_exists()` |
| `commonhookactions.class.php` | `CommonHookActions` | ❌ declared outright |
| `profid.lib.php` | `isValidLuhn()` and 6 others | ❌ declared outright |

We are not the only module in that situation: any other module of the instance that also has to run on both sides of Dolibarr 19 carries its own copy of `CommonHookActions`. PHP does not warn on a name that is already taken, it fatals — so whichever of the two hooks `HookManager::initHooks()` loads second kills the request, and the hook of this module can then never be loaded at all:

```
Fatal error: Cannot declare class CommonHookActions, because the name is already in use
in .../custom/einvoicing/compat/commonhookactions.class.php on line 30
```

`initHooks()` walks `$conf->modules_parts['hooks']`, which is built from the `MAIN_MODULE_*_HOOKS` constants **of the current entity** — which is why the reporter sees the same two modules living together on the first entity and fatalling on the second. Their way out was setting `MAIN_MODULE_EINVOICING_HOOKS` to 0, i.e. giving up the hooks of the module.

## Reproduction

Dolibarr 18.0.10, a second entity, and a second module carrying its own copy of the class:

```
entity     : 2
core class : absent (this is a pre-19 Dolibarr)
other mod  : nbmodules=1 errors=(none)
einvoicing : nbmodules=1 errors=(none)
hooks decl : ["mchook","einvoicing"]
PHP Fatal error:  Cannot redeclare class CommonHookActions
  (previously declared in .../custom/mchook/compat/commonhookactions.class.php:7)
  in .../einvoicing/compat/commonhookactions.class.php on line 30
```

With the branch, on the same instance and the same entity:

```
hooks decl : ["mchook","einvoicing"]
initHooks  : ["modulesadmin","invoicecard"]
OK - no fatal
```

## The change

Guard the two remaining shims the way the two others already are — `class_exists()` for the class, `function_exists()` per function, no behaviour change when nothing else declared the symbol.

`profid.lib.php` is the same defect one file away, on the versions below 20. It has not been reported yet only because nothing else has shipped `isValidLuhn()` next to us so far; it is fixed here rather than waited for.

The `profid.lib.php` diff is large but it is only the indentation: `git diff -w` on it shows nothing but the 7 added `if (!function_exists(...)) {` lines.

## Test

`test/phpunit/CompatShimReloadTest.php` loads each of the four shims in a subprocess (a redeclaration is fatal and cannot be caught in the running process): once with the symbol already declared, where the shim must do nothing, and once on its own, where it must still deliver the backport. It covers the four, so the next shim added to the directory has a place to be checked too.

Against the unguarded shims it fails exactly where expected:

```
compat/commonhookactions.class.php must not redeclare what is already there:
  exit 255 - PHP Fatal error: Cannot redeclare class CommonHookActions ...
compat/profid.lib.php must not redeclare what is already there:
  exit 255 - PHP Fatal error: Cannot redeclare function isValidLuhn() ...
Tests: 8, Assertions: 8, Failures: 2.
```

With the branch: `OK (8 tests, 8 assertions)`.

Full suite run file by file on Dolibarr **17, 18, 19 and 22**: no change (17/17 on 18, 19 and 22; on 17 the single pre-existing `EInvoicingSamplesTest` failure is unrelated and fails identically without this branch).
