### PR TITLE
[ci] Update actions/checkout to v6 in the phpcs workflow

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -23,7 +23,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
          fetch-depth: '0'
       - name: Setup PHP


### PR DESCRIPTION
Every `phpcs` run is currently annotated with:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4

`phpcs.yml` is the last workflow still pinned to `actions/checkout@v4`, which bundles the deprecated Node.js 20 runtime. The others already moved on: `phan.yml` uses `checkout@v6`, `ci-pr-autoassign.yml` uses `v7`. This aligns `phpcs.yml` on `v6`.

The action inputs are unchanged between v4 and v6, so `fetch-depth: 0` keeps behaving as before — nothing else in the workflow needs touching.

`run-script-on-merge.yml.disabled` also pins `checkout@v4`, but since it is disabled it emits no warning; left untouched to keep this change to one line.

### Test

Dispatched the modified workflow on my fork: https://github.com/daGrumpf-bxp/dolibarr-community-modules/actions/runs/32956348922

- job `build`: success (PHPCS, VarDump Check and Parallel Lint all ran as before)
- checkout resolved to `actions/checkout@v6` with `fetch-depth: 0` honoured
- zero annotations on the run: the Node.js 20 deprecation warning is gone