### PR TITLE
FIX: #658 [einvoicing] A Factur-X no longer embeds its own file name instead of the XML

### DIFF
--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -730,6 +730,16 @@ class FacturXProtocol extends CIIProtocol
 				return -1;
 			}
 			$orig_pdf = $filedir . '/' . $filename . '.' . self::INVOICE_FILE_EXTENSION;				// generateDocument writes <ref>.pdf
+
+			// That rebuild fired the afterPDFCreation hook, which generates the e-invoice on its own and
+			// deletes this very temporary XML once it has embedded it. Write it again rather than merge
+			// against a path that points at nothing: the mergers take the XML as content and fall back to
+			// treating the string as content when the file is gone, so what would be embedded is the path
+			// itself - 61 bytes of file name announced as a Factur-X (issue #658).
+			if (!file_exists($xmlfile)) {
+				dol_syslog(get_class($this) . "::generateInvoice temporary XML consumed by the PDF rebuild, generating it again");
+				$xmlfile = $this->generateXML($invoice, $outputlangs);
+			}
 		}
 
 		// Make a copy of the original PDF file
@@ -770,7 +780,10 @@ class FacturXProtocol extends CIIProtocol
 
 		// TODO A third method can be tried using the atgp/factur-x library.
 
-		if (!file_exists($orig_pdf)) {
+		// The mergers below take the XML as content, and treat the string as content when it is not the
+		// path of an existing file. A missing XML therefore does not fail, it gets embedded: check it here
+		// rather than hand over a PDF carrying its own file name (issue #658).
+		if (!file_exists($orig_pdf) || empty($xmlfile) || !file_exists($xmlfile)) {
 			throw new \Exception("XML and/or PDF does not exist");
 		}
 


### PR DESCRIPTION
Fixes #658.

## Problem

`FacturXProtocol::generateInvoice()` writes the XML to `documents/facture/temp/<ref>/factur-x.xml`, **then** looks for the source PDF. When the invoice has none it rebuilds it with `generateDocument()` — and that fires the `afterPDFCreation` hook, which generates the e-invoice on its own, embeds it, and cleans up that very temporary XML when it is done. The outer call then merges against a path that no longer points at anything.

The two mergers take the XML *as content*, and fall back to treating the string as content when it is not the path of an existing file. So what got embedded was the path:

```
FA2608-0044_facturx.pdf -> [/var/www/dd18/documents/facture/temp/FA2608-0044/factur-x.xml]
```

61 bytes of file name where 8 kB of CII should be, in a file the module announces as generated, and offers for transmission. On Dolibarr 24 the merger validates the syntax first, so the generation failed outright instead — and its error path then deleted the correct Factur-X the nested generation had produced a moment earlier.

The guard right before the merge only tested the PDF, although its message already mentioned the XML.

## Fix

Two lines of substance:

- when the PDF rebuild consumed the temporary XML, write it again — the same `generateXML()` call as at the top of the method, so the same CII builder, not a second path;
- test the XML in the guard, so a missing one can never be embedded again.

## Why this path is reached in real life

The module put that PDF rebuild there on purpose — its own comment says *"Source PDF deleted or never generated: regenerate it with the default PDF model before embedding"*. Invoices reach it: those validated before the module was installed, those whose documents were purged, those validated with `MAIN_DISABLE_PDF_AUTOUPDATE` on, and every invoice of a mass generation (#657) that never had its document built.

## Tests

- **Reproduced and fixed on four cores.** On a clean invoice with no PDF, generating the Factur-X from the invoice card:

| Dolibarr | before | after |
|---|---|---|
| 18.0.10 | "generated", embedded XML = 61 bytes, the path | 8358 bytes, document `DD18-FA-2608-0018` |
| 22.0.5 | "generated", the path | 8004 bytes, document `DD22-FA-2608-0010` |
| 23.0.3 | "generated", 67 bytes, the path | 8112 bytes, document `DD23-FA-2608-0025` |
| 24.0.0-beta | generation fails, no file | 8115 bytes, document `DD24-FA-2608-0011` |

- **Nothing else moved.** Full generation matrix on 8 instances (17.0.4 → 24.0.0-beta), every validated invoice of each through the 6 profiles and both protocols — **7902 generations per run**, payload hashed for each artefact (the XML, or the XML extracted from the Factur-X PDF): **7056 payloads byte-identical between `main` and this branch**, identical generation reports.
- **phpunit** on the 9 instances: 152 tests green, except the 3 pre-existing `EInvoicingSamplesTest` errors on Dolibarr 17.
- **End to end, both directions, dolidev (23.0.3) ↔ dd18 (18.0.10)**, through the SuperPDP sandbox, in CII and in Factur-X: send, sync at the receiver, import, validate, return status 205. Four legs, all acknowledged (202 on import, 205 after validation), and the two Factur-X files transmitted carry their real XML (8443 and 8362 bytes, right invoice numbers).
