### PR TITLE
FIX: #658 [einvoicing] The PDF rebuild of a generation no longer re-enters that generation

### DIFF
--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -104,6 +104,15 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 		if ($invoiceObject instanceof Facture) {
 			/** @var Facture $invoiceObject */
 
+			// This PDF is the one the module is rebuilding to embed the e-invoice into: the caller is
+			// producing the document, this hook must not produce it a second time and must not clean up
+			// the temporary XML the caller still needs (issue #658). Nothing in $parameters says who
+			// called generateDocument(), hence the request-scoped marker.
+			if (EInvoicing::isEInvoiceGenerationInProgress($invoiceObject->id)) {
+				dol_syslog(__METHOD__ . " the module is rebuilding the PDF of invoice id=" . $invoiceObject->id . " itself, nothing to do here");
+				return 0;
+			}
+
 			// Ask the boolean question: needEInvoiceManagement() answers with a status code, and the codes
 			// meaning "out of the e-invoicing scope" are truthy, so testing its answer for truth alone let an
 			// ignored invoice (a B2C one when EINVOICING_SKIP_B2C is on, typically) walk into the checks below

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -70,6 +70,18 @@ class EInvoicing
 	 */
 	private static $validatedinthisrequest = array();
 
+	/**
+	 * Invoices whose source PDF the module is rebuilding right now, to embed their e-invoice into it.
+	 *
+	 * Same idea as $validatedinthisrequest, for the opposite purpose: telling the afterPDFCreation hook
+	 * which PDF creations are its business. A rebuild started by generateInvoice() is not - the caller is
+	 * already producing the document, and a hook that produces it a second time also cleans up the
+	 * temporary XML the caller still needs (issue #658).
+	 *
+	 * @var array<int,bool>
+	 */
+	private static $einvoicegenerationinprogress = array();
+
 
 	// Dolibarr internal statuses
 	public const STATUS_UNKNOWN             = 0;		// By default, before the e-invoice has been generated
@@ -542,6 +554,42 @@ class EInvoicing
 	public static function isInvoiceValidatedInThisRequest($invoiceid)
 	{
 		return in_array((int) $invoiceid, self::$validatedinthisrequest, true);
+	}
+
+	/**
+	 * Record that the module is rebuilding the source PDF of an invoice to embed its e-invoice into it.
+	 *
+	 * That rebuild goes through generateDocument(), which fires the afterPDFCreation hook - whose job is
+	 * to produce the e-invoice, which is exactly what the caller is already doing. Left alone, the hook
+	 * re-enters the generation, produces the document a second time and deletes the temporary XML the
+	 * outer call still holds a path to (issue #658).
+	 *
+	 * @param  int	$invoiceid	Id of the invoice whose source PDF is being rebuilt
+	 * @param  bool	$inprogress	True when the rebuild starts, false when it is over
+	 * @return void
+	 */
+	public static function setEInvoiceGenerationInProgress($invoiceid, $inprogress)
+	{
+		$invoiceid = (int) $invoiceid;
+		if ($invoiceid <= 0) {
+			return;
+		}
+		if ($inprogress) {
+			self::$einvoicegenerationinprogress[$invoiceid] = true;
+		} else {
+			unset(self::$einvoicegenerationinprogress[$invoiceid]);
+		}
+	}
+
+	/**
+	 * Tell whether the module is itself rebuilding the source PDF of this invoice right now.
+	 *
+	 * @param  int	$invoiceid	Id of the invoice
+	 * @return bool				True while generateInvoice() is rebuilding the PDF it needs
+	 */
+	public static function isEInvoiceGenerationInProgress($invoiceid)
+	{
+		return !empty(self::$einvoicegenerationinprogress[(int) $invoiceid]);
 	}
 
 

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -722,7 +722,20 @@ class FacturXProtocol extends CIIProtocol
 			}
 			// Source PDF deleted or never generated: regenerate it with the default PDF model before embedding.
 			$modelname = getDolGlobalString('FACTURE_ADDON_PDF') ?: 'crabe';
-			$resultpdf = $invoice->generateDocument($modelname, $langs);
+
+			// That rebuild fires afterPDFCreation, whose job is to produce the e-invoice - which is exactly
+			// what this call is doing. Tell the hook to stand back for this invoice, or it generates the
+			// document a second time and cleans up the temporary XML this call still needs (issue #658).
+			// try/finally, not two plain assignments: a rebuild that throws must not leave the hook muted
+			// for the rest of the request, which would silently skip the e-invoice of the invoices a mass
+			// generation handles after this one.
+			$resultpdf = -1;
+			EInvoicing::setEInvoiceGenerationInProgress($invoice->id, true);
+			try {
+				$resultpdf = $invoice->generateDocument($modelname, $langs);
+			} finally {
+				EInvoicing::setEInvoiceGenerationInProgress($invoice->id, false);
+			}
 			if ($resultpdf < 0) {
 				dol_syslog(get_class($this) . "::generateInvoice failed to regenerate missing PDF for invoice id=" . $invoice_id, LOG_ERR);
 				$this->error = $langs->trans("ErrorFailedToRegeneratePDF");
@@ -770,7 +783,11 @@ class FacturXProtocol extends CIIProtocol
 
 		// TODO A third method can be tried using the atgp/factur-x library.
 
-		if (!file_exists($orig_pdf)) {
+		// The mergers below take the XML as content, and treat the string as content when it is not the
+		// path of an existing file. A missing XML therefore does not fail, it gets embedded: check it here
+		// rather than hand over a PDF carrying its own file name. Nothing removes that file any more, but
+		// the merge is the last place where the mistake is still catchable (issue #658).
+		if (!file_exists($orig_pdf) || empty($xmlfile) || !file_exists($xmlfile)) {
 			throw new \Exception("XML and/or PDF does not exist");
 		}
 


### PR DESCRIPTION
Fixes #658. Stands alone on `main` — #659 proposed the same fix from the other end and is closed in favour of this one.

## The recursion

`generateInvoice()` rebuilds the source PDF when the invoice has none — its own comment says so — and that rebuild goes through `generateDocument()`, which fires `afterPDFCreation`, whose job is to produce the e-invoice. Which is what the caller is already doing:

```
generateInvoice()                      <- writes temp/<ref>/factur-x.xml
  generateDocument()                   <- no source PDF, rebuild it
    afterPDFCreation()
      generateInvoice()                <- the whole job, a second time
        merge, then clean up temp/<ref>/factur-x.xml
  merge                                <- against a path that no longer exists
```

Two defects out of that one recursion:

- **the Factur-X embedded its own file name.** The mergers take the XML as content and fall back to treating the string as content when the path leads nowhere, so the document carried 61 bytes of path where 8 kB of CII belong — announced as generated, and offered for transmission. On Dolibarr 24 the merger validates the syntax first, so the generation failed outright instead, and its error path deleted the correct file the nested call had just produced.
- **every e-invoice of an invoice without a PDF was produced twice.** Unnoticed, because it succeeded.

## Why a marker

`afterPDFCreation` cannot tell who asked for the PDF. Its `$parameters` carry `file`, `object` and `outputlangs`; its second argument is the PDF model object; and `$action` is whatever the page was doing — `generate_einvoice` from the invoice card, but empty from a CLI script, a cron, the API or a mass action. Nothing identifies the caller.

So the caller says so, which **the module already does for the neighbouring question**: `EInvoicing::$validatedinthisrequest` exists precisely so this same hook can recognise the rebuild that follows a validation, the only one `EINVOICING_AUTO_SEND_ON_GENERATION` is meant to transmit. This adds the marker of the same family, next to it, set around the single call that can start the recursion.

`try/finally` rather than two assignments: a rebuild that throws must not leave the hook muted for the rest of the request, which would silently skip the e-invoice of every invoice a mass generation handles after that one.

And the guard before the merge now tests the XML too — its message already claimed to. Nothing removes that file any more, but the merge is the last place a missing XML is still catchable, whatever removes it in the future.

## Tests

- **The recursion is gone and the output is right.** On a clean invoice with no PDF, Factur-X generated from the invoice card:

| Dolibarr | before | after |
|---|---|---|
| 18.0.10 | "generated", 61 bytes: the path | 8338 bytes, document `DD18-FA-2608-0025` |
| 22.0.5 | "generated", the path | 8008 bytes, document `DD22-FA-2608-0012` |
| 23.0.3 | "generated", 67 bytes: the path | 8116 bytes, document `DD23-FA-2608-0027` |
| 24.0.0-beta | generation fails, no file | 8119 bytes, document `DD24-FA-2608-0014` |

  And the log shows **one** `generateInvoice` where it showed two.

- **Nothing else moved.** Full generation matrix on 8 instances (17.0.4 → 24.0.0-beta), every validated invoice through the 6 profiles and both protocols — **8082 generations per run**, payload hashed for every artefact (the XML, or the XML extracted from the Factur-X PDF): **7236 payloads byte-identical between `main` and this branch**, identical generation reports. That matters more than usual here: the hook is muted only for a rebuild the module started itself, and the matrix builds the PDF of every invoice before its e-invoice, so it exercises the hook on the ordinary path 8082 times.
- **phpunit** on the 9 instances: 152 tests green, except the 3 pre-existing `EInvoicingSamplesTest` errors on Dolibarr 17.
- **End to end, both directions, dolidev (23.0.3) ↔ dd18 (18.0.10)**, SuperPDP sandbox, in CII and in Factur-X: send, sync, import, validate, status 205. Four legs, all acknowledged, and the two Factur-X transmitted carry their real XML (8443 and 8362 bytes, right invoice numbers).