### PR TITLE
[ci] Prove the PDF/A gate on the documents it just validated, not on one of them

### DIFF
--- a/.github/workflows/module_einvoicing_pdfa.yml
+++ b/.github/workflows/module_einvoicing_pdfa.yml
@@ -97,33 +97,64 @@ jobs:
       - name: Validate the same documents with veraPDF
         run: ./verapdf/verapdf -f 3b --format text out/*.pdf
 
-      - name: A document veraPDF has to refuse
-        # A green validation says something only if a document that is not conformant comes back red.
-        # This takes one of the documents just validated and moves the namespace its extension schema
-        # declares by one letter - the same number of bytes, so the file stays whole and the offsets
-        # keep pointing where they did - which leaves the Factur-X properties declared by no schema
-        # at all: ISO 19005-3, 6.6.2.3.1. That is the clause which separates a Factur-X file from a
-        # PDF with something attached to it, and the half of the format nothing here used to check.
-        # If veraPDF still answered PASS, the step above would not be looking at what it says it is.
+      - name: The same documents, damaged, veraPDF has to refuse
+        # A green validation says something only if a document that is not conformant comes back red,
+        # and the documents to prove it on are the ones just validated: every one of them is damaged
+        # in place, once per defect below - a replacement of the same number of bytes, so the file
+        # stays whole and the offsets keep pointing where they did - and each result has to come back
+        # FAIL. One that still passes means the step above is not looking at what it says it is. Both
+        # mergers are covered because all of the documents are damaged, not the first one.
+        #
+        # The defects, and the clause of ISO 19005-3 each of them lands on:
+        #   no-extension-schema     the Factur-X properties are declared by no extension schema -
+        #                           6.6.2.3.1, the clause that separates a Factur-X file from a PDF
+        #                           with something attached to it, and the half of the format nothing
+        #                           here used to check.
+        #   unreadable-xmp          the XMP packet no longer parses - 6.6.2.1, with 6.6.4 in cascade:
+        #                           the shape the first of the two shipped defects had.
+        #   wrong-part              the document identifies itself as another part of PDF/A - 6.6.4.
+        #   wrong-conformance       and as another conformance level - 6.6.4.
+        #   no-pdfa-output-intent   the output intent is no longer the PDF/A one - 6.2.4.3 and 6.2.10.
         run: |
           php -r '
+            $mutations = array(
+              "no-extension-schema" => array("<pdfaSchema:namespaceURI>urn:factur-x:", "<pdfaSchema:namespaceURI>urn:factur-y:"),
+              "unreadable-xmp" => array("<rdf:RDF ", "<rdf/RDF "),
+              "wrong-part" => array("<pdfaid:part>3", "<pdfaid:part>2"),
+              "wrong-conformance" => array("<pdfaid:conformance>B", "<pdfaid:conformance>X"),
+              "no-pdfa-output-intent" => array("GTS_PDFA1", "GTS_PDFB1"),
+            );
             $files = glob("out/*.pdf");
             sort($files);
-            if (!$files) { fwrite(STDERR, "no document to build the control from\n"); exit(2); }
-            $carrier = file_get_contents($files[0]);
-            $declaration = "<pdfaSchema:namespaceURI>urn:factur-x:";
-            if (substr_count($carrier, $declaration) !== 1) {
-              fwrite(STDERR, "the control cannot be built: " . substr_count($carrier, $declaration) . " extension schema declarations in " . $files[0] . "\n");
-              exit(2);
+            if (!$files) { fwrite(STDERR, "no document to build the controls from\n"); exit(2); }
+            if (!is_dir("control") && !mkdir("control")) { fwrite(STDERR, "cannot create the control directory\n"); exit(2); }
+            foreach ($files as $file) {
+              $document = file_get_contents($file);
+              foreach ($mutations as $name => $mutation) {
+                list($from, $to) = $mutation;
+                if (substr_count($document, $from) !== 1) {
+                  fwrite(STDERR, "the " . $name . " control cannot be built from " . basename($file) . ": " . substr_count($document, $from) . " occurrences of " . $from . "\n");
+                  exit(2);
+                }
+                $damaged = str_replace($from, $to, $document);
+                if ($damaged === $document || strlen($damaged) !== strlen($document)) {
+                  fwrite(STDERR, "the " . $name . " control does not damage " . basename($file) . " in place\n");
+                  exit(2);
+                }
+                file_put_contents("control/" . basename($file, ".pdf") . "__" . $name . ".pdf", $damaged);
+              }
             }
-            file_put_contents("control.pdf", str_replace($declaration, "<pdfaSchema:namespaceURI>urn:factur-y:", $carrier));
-            echo "control built from ", basename($files[0]), "\n";
+            echo count($files) * count($mutations), " damaged documents built from the ", count($files), " validated above\n";
           '
-          if ./verapdf/verapdf -f 3b --format text control.pdf; then
-            echo "::error::veraPDF accepted a document whose Factur-X properties are declared by no extension schema - the validation of the six documents is not checking what it says it checks"
+          built=$(find control -name '*.pdf' | wc -l)
+          ./verapdf/verapdf -f 3b --format text control/*.pdf > verapdf-control-report.txt 2>/dev/null || true
+          refused=$(grep -c '^FAIL ' verapdf-control-report.txt || true)
+          if [ "$refused" -ne "$built" ]; then
+            echo "::error::veraPDF refused $refused of the $built damaged documents - the validation of the documents above is not checking what it says it checks"
+            grep -v '^FAIL ' verapdf-control-report.txt || true
             exit 1
           fi
-          echo "veraPDF refuses the control document, as it has to."
+          echo "veraPDF refuses the $built damaged documents, as it has to."
 
       - name: Provide the validation report as artifact
         if: ${{ always() }}
@@ -135,5 +166,6 @@ jobs:
           name: verapdf-report
           path: |
             verapdf-report.xml
+            verapdf-control-report.txt
             out/
           retention-days: 2


### PR DESCRIPTION
The `pdfa` job ends on a negative control: a document veraPDF has to refuse, because a green validation says something only if a document that is not conformant comes back red.

That control took the first document of the run - one merger out of two - and moved the namespace of its extension schema by one letter. It proved veraPDF was running. It proved nothing about the other merger, nor about any other clause.

**What changes.** Every document of the previous step is now damaged in place, once per defect, and all of the results have to come back FAIL. The five defects land on five different clauses of ISO 19005-3:

| defect | clause |
| --- | --- |
| the Factur-X properties are declared by no extension schema | 6.6.2.3.1 |
| the XMP packet no longer parses - the shape the first shipped defect had | 6.6.2.1, 6.6.4 in cascade |
| the document identifies itself as another part of PDF/A | 6.6.4 |
| ... and as another conformance level | 6.6.4 |
| the output intent is no longer the PDF/A one | 6.2.4.3, 6.2.10 |

Each replacement is the same number of bytes, so the file stays whole and the offsets keep pointing where they did: what the validator answers is about the clause, not about a broken file. A defect the documents no longer carry stops the job with its own message rather than passing silently, and the report of the control run is uploaded next to the other one.

Ten documents by five defects is fifty validations, in a single veraPDF run: five seconds on the runner.

**Checked on a runner, not only locally.**

- Green run: the ten documents PASS, then `veraPDF refuses the 50 damaged documents, as it has to.`
- A real regression the PHPUnit test can see (the Factur-X namespace changed in the XMP template): red at the build step, as before.
- A real regression the PHPUnit test cannot see (the `/OutputIntents` reference dropped from the catalog - `GTS_PDFA1` is still in the file, so every assertion of the test still holds): PHPUnit green, veraPDF red on the five documents of the merger concerned, the five others PASS. That is the half of the job this control is here to keep honest.
- The control itself: an intact document slipped into the control set turns the step red, and a defect that cannot be built stops the job with exit 2.

No change outside the workflow file.