### PR TITLE
FIX: #644 [einvoicing] The option completing third party information from a received e-invoice does complete it

### DIFF
--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -643,100 +643,94 @@ trait CommonProtocol
 
 		// if found, update information
 		if ($thirdpartyId > 0) {
-			// if complete info is disabled, we return directly the thirdpartyId
-			if (getDolGlobalInt('EINVOICING_THIRDPARTIES_COMPLETE_INFO')) {
-				dol_syslog(get_class($this) . '::_syncOrCreateThirdpartyFromEInvoiceSeller Complete info disabled, returning existing thirdparty: ' . $thirdpartyId);
-				return array(
-					'res' => $thirdpartyId,
-					'message' => 'Existing thirdparty used without update: ' . $thirdpartyId . ($nameMismatchWarning !== '' ? ' - ' . $nameMismatchWarning : '')
-				);
-			}
-
 			dol_syslog(get_class($this) . '::_syncOrCreateThirdpartyFromEInvoiceSeller Updating existing thirdparty: ' . $thirdpartyId);
 			// TODO: MAYBE we should call PDP to retrieve more information
 
 			$thirdparty = new Societe($db);
 			$thirdparty->fetch($thirdpartyId);
 
-			// Update thirdparty information based on priority
-			if ($priority === 'pdp') { // Overwrite Dolibarr data with AP data
-				$thirdparty->name = $sellerInfo['sellername'] ?? $thirdparty->name;
-				$thirdparty->address = $sellerInfo['sellerlineone'] ?? $thirdparty->address;
-				if (!empty($sellerInfo['sellerlinetwo'])) {
-					$thirdparty->address .= "\n" . $sellerInfo['sellerlinetwo'];
-				}
-				if (!empty($sellerInfo['sellerlinethree'])) {
-					$thirdparty->address .= "\n" . $sellerInfo['sellerlinethree'];
-				}
-				$thirdparty->zip = $sellerInfo['sellerpostcode'] ?? $thirdparty->zip;
-				$thirdparty->town = $sellerInfo['sellercity'] ?? $thirdparty->town;
-				$thirdparty->country_code = $sellerInfo['sellercountry'] ?? $thirdparty->country_code;
-				$thirdparty->email = $sellerInfo['sellercontactemailaddr'] ?? $thirdparty->email;
-				$thirdparty->phone = $sellerInfo['sellercontactphoneno'] ?? $thirdparty->phone;
-				$thirdparty->fax = $sellerInfo['sellercontactfaxno'] ?? $thirdparty->fax;
-
-				// Set identification numbers
-				if (!empty($sellerInfo['sellerGlobalIds']) && is_array($sellerInfo['sellerGlobalIds'])) {
-					foreach ($sellerInfo['sellerGlobalIds'] as $idScheme => $globalId) {
-						if (!empty($globalId)) {
-							$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode);
-							if (!empty($idprofField)) {
-								$thirdparty->$idprofField = $einvoicing->removeSpaces($globalId);
-							}
-						}
-					}
-				}
-				if (!empty($sellerInfo['sellerTaxRegistations']['VA'])) {
-					$thirdparty->tva_intra = $einvoicing->removeSpaces($sellerInfo['sellerTaxRegistations']['VA']);
-					$thirdparty->tva_assuj = 1;
-				}
-			} elseif ($priority === 'dolibarr') { // Fill only empty fields from pdp data
-				dol_syslog(get_class($this) . '::_syncOrCreateThirdpartyFromEInvoiceSeller Keeping existing thirdparty data and fill only empty fields as priority is dolibarr: ' . $thirdpartyId);
-
-				if (empty($thirdparty->name) && !empty($sellerInfo['sellername'])) {
-					$thirdparty->name = $sellerInfo['sellername'];
-				}
-				if (empty($thirdparty->address) && !empty($sellerInfo['sellerlineone'])) {
-					$thirdparty->address = $sellerInfo['sellerlineone'];
+			// Complete the third party information from the e-invoice only when the option asks for it.
+			if (getDolGlobalInt('EINVOICING_THIRDPARTIES_COMPLETE_INFO')) {
+				// Update thirdparty information based on priority
+				if ($priority === 'pdp') { // Overwrite Dolibarr data with AP data
+					$thirdparty->name = $sellerInfo['sellername'] ?? $thirdparty->name;
+					$thirdparty->address = $sellerInfo['sellerlineone'] ?? $thirdparty->address;
 					if (!empty($sellerInfo['sellerlinetwo'])) {
 						$thirdparty->address .= "\n" . $sellerInfo['sellerlinetwo'];
 					}
 					if (!empty($sellerInfo['sellerlinethree'])) {
 						$thirdparty->address .= "\n" . $sellerInfo['sellerlinethree'];
 					}
-				}
-				if (empty($thirdparty->zip) && !empty($sellerInfo['sellerpostcode'])) {
-					$thirdparty->zip = $sellerInfo['sellerpostcode'];
-				}
-				if (empty($thirdparty->town) && !empty($sellerInfo['sellercity'])) {
-					$thirdparty->town = $sellerInfo['sellercity'];
-				}
-				if (empty($thirdparty->country_code) && !empty($sellerInfo['sellercountry'])) {
-					$thirdparty->country_code = $sellerInfo['sellercountry'];
-				}
-				if (empty($thirdparty->email) && !empty($sellerInfo['sellercontactemailaddr'])) {
-					$thirdparty->email = $sellerInfo['sellercontactemailaddr'];
-				}
-				if (empty($thirdparty->phone) && !empty($sellerInfo['sellercontactphoneno'])) {
-					$thirdparty->phone = $sellerInfo['sellercontactphoneno'];
-				}
-				if (empty($thirdparty->fax) && !empty($sellerInfo['sellercontactfaxno'])) {
-					$thirdparty->fax = $sellerInfo['sellercontactfaxno'];
-				}
-				// Set identification numbers if empty
-				if (!empty($sellerInfo['sellerGlobalIds']) && is_array($sellerInfo['sellerGlobalIds'])) {
-					foreach ($sellerInfo['sellerGlobalIds'] as $idScheme => $globalId) {
-						if (!empty($globalId)) {
-							$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode);
-							if (!empty($idprofField) && empty($thirdparty->$idprofField)) {
-								$thirdparty->$idprofField = $einvoicing->removeSpaces($globalId);
+					$thirdparty->zip = $sellerInfo['sellerpostcode'] ?? $thirdparty->zip;
+					$thirdparty->town = $sellerInfo['sellercity'] ?? $thirdparty->town;
+					$thirdparty->country_code = $sellerInfo['sellercountry'] ?? $thirdparty->country_code;
+					$thirdparty->email = $sellerInfo['sellercontactemailaddr'] ?? $thirdparty->email;
+					$thirdparty->phone = $sellerInfo['sellercontactphoneno'] ?? $thirdparty->phone;
+					$thirdparty->fax = $sellerInfo['sellercontactfaxno'] ?? $thirdparty->fax;
+
+					// Set identification numbers
+					if (!empty($sellerInfo['sellerGlobalIds']) && is_array($sellerInfo['sellerGlobalIds'])) {
+						foreach ($sellerInfo['sellerGlobalIds'] as $idScheme => $globalId) {
+							if (!empty($globalId)) {
+								$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode);
+								if (!empty($idprofField)) {
+									$thirdparty->$idprofField = $einvoicing->removeSpaces($globalId);
+								}
 							}
 						}
 					}
-				}
-				if (!empty($sellerInfo['sellerTaxRegistations']['VA']) && empty($thirdparty->tva_intra)) {
-					$thirdparty->tva_intra = $einvoicing->removeSpaces($sellerInfo['sellerTaxRegistations']['VA']);
-					$thirdparty->tva_assuj = 1;
+					if (!empty($sellerInfo['sellerTaxRegistations']['VA'])) {
+						$thirdparty->tva_intra = $einvoicing->removeSpaces($sellerInfo['sellerTaxRegistations']['VA']);
+						$thirdparty->tva_assuj = 1;
+					}
+				} elseif ($priority === 'dolibarr') { // Fill only empty fields from pdp data
+					dol_syslog(get_class($this) . '::_syncOrCreateThirdpartyFromEInvoiceSeller Keeping existing thirdparty data and fill only empty fields as priority is dolibarr: ' . $thirdpartyId);
+
+					if (empty($thirdparty->name) && !empty($sellerInfo['sellername'])) {
+						$thirdparty->name = $sellerInfo['sellername'];
+					}
+					if (empty($thirdparty->address) && !empty($sellerInfo['sellerlineone'])) {
+						$thirdparty->address = $sellerInfo['sellerlineone'];
+						if (!empty($sellerInfo['sellerlinetwo'])) {
+							$thirdparty->address .= "\n" . $sellerInfo['sellerlinetwo'];
+						}
+						if (!empty($sellerInfo['sellerlinethree'])) {
+							$thirdparty->address .= "\n" . $sellerInfo['sellerlinethree'];
+						}
+					}
+					if (empty($thirdparty->zip) && !empty($sellerInfo['sellerpostcode'])) {
+						$thirdparty->zip = $sellerInfo['sellerpostcode'];
+					}
+					if (empty($thirdparty->town) && !empty($sellerInfo['sellercity'])) {
+						$thirdparty->town = $sellerInfo['sellercity'];
+					}
+					if (empty($thirdparty->country_code) && !empty($sellerInfo['sellercountry'])) {
+						$thirdparty->country_code = $sellerInfo['sellercountry'];
+					}
+					if (empty($thirdparty->email) && !empty($sellerInfo['sellercontactemailaddr'])) {
+						$thirdparty->email = $sellerInfo['sellercontactemailaddr'];
+					}
+					if (empty($thirdparty->phone) && !empty($sellerInfo['sellercontactphoneno'])) {
+						$thirdparty->phone = $sellerInfo['sellercontactphoneno'];
+					}
+					if (empty($thirdparty->fax) && !empty($sellerInfo['sellercontactfaxno'])) {
+						$thirdparty->fax = $sellerInfo['sellercontactfaxno'];
+					}
+					// Set identification numbers if empty
+					if (!empty($sellerInfo['sellerGlobalIds']) && is_array($sellerInfo['sellerGlobalIds'])) {
+						foreach ($sellerInfo['sellerGlobalIds'] as $idScheme => $globalId) {
+							if (!empty($globalId)) {
+								$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode);
+								if (!empty($idprofField) && empty($thirdparty->$idprofField)) {
+									$thirdparty->$idprofField = $einvoicing->removeSpaces($globalId);
+								}
+							}
+						}
+					}
+					if (!empty($sellerInfo['sellerTaxRegistations']['VA']) && empty($thirdparty->tva_intra)) {
+						$thirdparty->tva_intra = $einvoicing->removeSpaces($sellerInfo['sellerTaxRegistations']['VA']);
+						$thirdparty->tva_assuj = 1;
+					}
 				}
 			}
 			// Flag the thirdparty as a vendor if it is not one yet


### PR DESCRIPTION
Fixes #644.

The option `EINVOICING_THIRDPARTIES_COMPLETE_INFO` announces *"Complete missing third-party information when receiving an e-invoice"*, but the code returned the existing third party untouched **when the option was enabled**, so the completion only ever ran on an installation that left it off. The log line said "Complete info disabled" while testing the opposite.

The vendor flag went with it: `fournisseur = 1` is set further down the very block the early return skipped, so a customer receiving its first supplier invoice was not flagged as a vendor either — the symptom reported in the issue.

### What changes

The early return goes away and only the priority chain (`pdp` / `dolibarr`) is wrapped in the option. The `if ($thirdpartyId > 0)` guard is kept, and the vendor flag plus the `update()` stay outside the option, so a customer receiving its first supplier invoice is flagged as a vendor whether the option is on or not. Most of the diff is the re-indentation of the wrapped block.

This is the same fix as #645, which cannot be merged as it stands: it drops the `if ($thirdpartyId > 0) {` line but keeps its closing brace, so `CommonProtocol.class.php` no longer parses (`syntax error, unexpected token "if", expecting "function"`). That is also the source of the phan errors reported there on files the PR does not touch: `CommonProtocol` is a trait, and when it fails to parse every class that uses it loses all of its methods.

### Tested

On the sandbox bench (Dolibarr 18.0.10 → 24.0.0, v17 skipped since the module targets 18):

- **Bug reproduced on `main` first**: a customer-only third party (`fournisseur = 0`, empty contact fields) plus a CII whose seller carries the same SIREN and the missing information. With the option **on**, the import answered "Existing thirdparty used without update", nothing was completed and the third party stayed a non-vendor. With the option **off**, everything was completed — the inversion.
- **After the fix**: option **on** → fields completed and `fournisseur = 1`; option **off** → `fournisseur = 1`, fields untouched. Verified on 18.0.10, 19.0.4, 20.0.4, 21.0.4, 22.0.5, 23.0.3 and 24.0.0, and read back from a separate process each time.
- **Error path**: an `update()` refused by `verify()` (blank name, option off) reports `Thirdparty update error: ErrorBadThirdPartyName` instead of failing quietly.
- **`pdp` priority branch**: no caller passes it today, so it was entered through reflection with the header of a real CII — it still overwrites existing values rather than only filling empty ones.
- **PHPUnit** file by file: 16/16 on 18.0.10, 20.0.4, 23.0.3 and 24.0.0.
- **One full sandbox cycle** with the option on: invoice `TRI-FA-2608-0251` emitted, acknowledged `Ok` by the Access Point, received as a supplier invoice with its line periods, statuses 200 and 201 back on the sender.
- phan (whole repo, `--analyze-twice`) and PHPCS clean.
