### PR TITLE
FIX: #661 [einvoicing] The vendor default product combo obeys the product select settings

### DIFF
--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -2092,12 +2092,15 @@ class EInvoicing
 			$resprints .= '</tr>';
 
 			// Add a line for the Default product for thirdparty (to use when importing vendor invoice and no product found)
-			$resprints .= '<tr class="treinvoicing_collapseseparator trrouting_product_id '.($expand_display ? '' : 'hidden').'">';
-			$resprints .= '<td>' . $form->textwithpicto($langs->trans("DefaultProductEBilling"), $langs->trans("DefaultProductEBillingHelp")) . '</td>';
-			$resprints .= '<td'.(empty($parameters['colspanvalue']) ? '' : ' colspan="'.(((int) $parameters['colspanvalue']) - 1).'"').'>';
-			$resprints .= $this->selectVendorProduct($form, $object->id, $product_id, 'routing_product_id');
-			$resprints .= '</td>';
-			$resprints .= '</tr>';
+			// Vendors only, like in edit mode: the core sets fournisseur when the creation starts from the vendor area
+			if ($object->fournisseur > 0) {
+				$resprints .= '<tr class="treinvoicing_collapseseparator trrouting_product_id '.($expand_display ? '' : 'hidden').'">';
+				$resprints .= '<td>' . $form->textwithpicto($langs->trans("DefaultProductEBilling"), $langs->trans("DefaultProductEBillingHelp")) . '</td>';
+				$resprints .= '<td'.(empty($parameters['colspanvalue']) ? '' : ' colspan="'.(((int) $parameters['colspanvalue']) - 1).'"').'>';
+				$resprints .= $this->selectVendorProduct($form, $object->id, $product_id, 'routing_product_id');
+				$resprints .= '</td>';
+				$resprints .= '</tr>';
+			}
 
 			return $resprints;
 		}

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -2228,6 +2228,10 @@ class EInvoicing
 	 * free to have set to anything: force it here, and give it back, so the combo cannot silently come
 	 * back empty.
 	 *
+	 * The field also follows the two setup options the core uses for its own product combos:
+	 * PRODUIT_USE_SEARCH_TO_SELECT (search form instead of a combo, with its minimum number of
+	 * characters) and PRODUIT_LIMIT_SIZE (number of products shown in a select).
+	 *
 	 * @param	Form	$form		Form handler
 	 * @param	int		$socid		Vendor id
 	 * @param	string	$selected	Product currently selected
@@ -2236,18 +2240,26 @@ class EInvoicing
 	 */
 	private function selectVendorProduct($form, $socid, $selected, $htmlname)
 	{
-		global $status;
+		global $conf, $status;
 
 		$savstatus = isset($status) ? $status : null;
 		$status = 1; // Products to buy
 
-		if (version_compare(DOL_VERSION, '22.0.0', '<')) {
-			// Before v22, select_produits_fournisseurs() uses print instead of return
-			ob_start();
-			$form->select_produits_fournisseurs($socid, $selected, $htmlname, '', '', array(), 0, 1, 'maxwidth300');
-			$out = ob_get_clean();
+		if (!empty($conf->use_javascript_ajax) && getDolGlobalString('PRODUIT_USE_SEARCH_TO_SELECT')) {
+			// Search form: product/ajax/products.php answers with PRODUIT_LIMIT_SIZE products at most
+			if (version_compare(DOL_VERSION, '22.0.0', '<')) {
+				// Before v22, select_produits_fournisseurs() uses print instead of return
+				ob_start();
+				$form->select_produits_fournisseurs($socid, $selected, $htmlname, '', '', array(), 0, 1, 'maxwidth300');
+				$out = ob_get_clean();
+			} else {
+				$out = $form->select_produits_fournisseurs($socid, $selected, $htmlname, '', '', array(), 0, 1, 'maxwidth300', '', 1);
+			}
 		} else {
-			$out = $form->select_produits_fournisseurs($socid, $selected, $htmlname, '', '', array(), 0, 1, 'maxwidth300', '', 1);
+			// Combo: select_produits_fournisseurs() asks the list without any limit, so it loads every
+			// product of the database. Call the list the way the core calls it for its own combos, with
+			// the number of products the user allowed in a select.
+			$out = $form->select_produits_fournisseurs_list($socid, $selected, $htmlname, '', '', '', $status, 0, getDolGlobalInt('PRODUIT_LIMIT_SIZE', 1000), 1, 'maxwidth300', getDolGlobalInt('SUPPLIER_SHOW_STOCK_IN_PRODUCTS_COMBO'));
 		}
 
 		$status = $savstatus;


### PR DESCRIPTION
Fixes #661

### The problem

On the third party card, the module offers a `Default product` for the import of vendor invoices.
It is built by `Form::select_produits_fournisseurs()`, which calls its list **without any limit**
(`$limit = 0`) and with `alsoproductwithnosupplierprice = 1`, so the query is a `LEFT JOIN` on
`product_fournisseur_price`: **every product flagged "to buy" ends up as an `<option>`**, whether it
has a price for that vendor or not. The reporter has 17 000 products.

Measured on a base seeded with 17 000 products (Dolibarr 23, third party edit card):

| | page weight | render | options |
|---|---|---|---|
| before | 9.8 MB | 4.1 s | 17 134 |
| after | 731 KB | 0.6 s | 1 001 |
| after, with `PRODUIT_USE_SEARCH_TO_SELECT` | 158 KB | 0.25 s | search form |

### The fix

Nothing new, no new setup option: the field now follows the very same path the core follows for its
own product combos, driven by the two options the user already sets in `Setup > Products`:

- `PRODUIT_USE_SEARCH_TO_SELECT` (*Use a search form to choose a product*) → the core autocompleter,
  which searches after the number of characters that option holds, and whose endpoint
  (`product/ajax/products.php`, mode 2) already answers with `PRODUIT_LIMIT_SIZE` products at most;
- otherwise the combo, but built by calling `select_produits_fournisseurs_list()` with
  `PRODUIT_LIMIT_SIZE` (*Number of products shown in a select*, 1000 by default), the way
  `product/ajax/products.php` and `core/tpl/objectline_create.tpl.php` call it.

A base large enough to reach the limit is exactly the base where `PRODUIT_USE_SEARCH_TO_SELECT`
should be on, and the field then has no limit to hit. When the combo is truncated and the product
already stored is not among the ones shown, **the stored value is not lost**: the field posts `-1`
and the trigger leaves the existing routing untouched (checked, see below).

### Second commit

The same field was added to **every third party creation**, whatever the nature of the third party,
where edit mode shows it for vendors only. It is now behind the same `fournisseur > 0` test — the
core sets that flag when the creation starts from the vendor area (`type=f`, or
`THIRDPARTY_SUPPLIER_BY_DEFAULT`). On creation there is no third party id yet, so the combo could not
even be restricted to the products of that vendor: it listed the whole base, one row per supplier
price. Creating a customer on the seeded base went from 9.8 MB / 3.7 s to 147 KB / 0.2 s.

### Tested

Third party card loaded over HTTP with a real session on **Dolibarr 18, 19, 20, 21, 22, 23 and 24**,
in both modes (combo and search form), on edit, on creation from the vendor area and on creation from
the customer area: no error, no warning, field present or absent where it should be.

Round trip of the value on 18 and 23, in both modes: pick a product, save the card, the routing row
holds the expected `idprod_<id>`. And with a stored product left out of the truncated combo, saving
the card again keeps it.
