### PR TITLE
FIX [einvoicing] The reference lookup keeps answering the callers that ask for no amount

### DIFF
--- a/einvoicing/class/utils/SupplierInvoiceHelper.class.php
+++ b/einvoicing/class/utils/SupplierInvoiceHelper.class.php
@@ -722,10 +722,10 @@ class SupplierInvoiceHelper
 	 *
 	 * @param	string|null	$ref		Reference to look for (ExchangedDocument/ID or IssuerAssignedID of the XML)
 	 * @param	int			$socId		Id of the supplier thirdparty
-	 * @param	float		$total_ttc	If set, check that total amount of the invoicewe is ok.
-	 * @return	int						Invoice id (>0) on a single certain match, 0 when not found, -1 on database error, -2 when several invoices match, -3 found the ref butnot with the expected amount
+	 * @param	float		$total_ttc	If set, check that the total amount of the invoice is the expected one. 0 to look the reference up without checking any amount.
+	 * @return	int						Invoice id (>0) on a single certain match, 0 when not found, -1 on database error, -2 when several invoices match, -3 when the reference matches but not with the expected amount
 	 */
-	public static function findIdByRef($ref, int $socId, float $total_ttc): int
+	public static function findIdByRef($ref, int $socId, float $total_ttc = 0): int
 	{
 		global $db;
 


### PR DESCRIPTION
`SupplierInvoiceHelper::findIdByRef()` gained a third parameter in 511901e3, to check the total amount
of the invoice it finds. That parameter is required, and seven call sites legitimately have no amount
to check still call the two-argument form:

| file | lines | what it looks up |
|---|---|---|
| `CIIProtocol.class.php` | 905, 934, 1022, 1190 | referenced documents (BT-25), source invoice of a credit note or of a replacement, line level references |
| `FacturXProtocol.class.php` | 708, 737, 825 | same three |
| `test/phpunit/SupplierInvoiceHelperTest.php` | 12 calls | — |

Reaching any of them throws `ArgumentCountError`, which is a fatal, not a warning.

### Reproduced

On the sandbox bench, on `main` at 511901e3, importing a **real credit note** whose CII carries
`ram:InvoiceReferencedDocument` (BT-25, mandatory on a credit note per EN 16931):

```
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function
SupplierInvoiceHelper::findIdByRef(), 2 passed in .../CIIProtocol.class.php on line 905 and exactly 3 expected
#0 .../CIIProtocol.class.php(905): SupplierInvoiceHelper::findIdByRef()
#1 .../CIIProtocol.class.php(698): CIIProtocol->doCreateSupplierInvoiceFromSource()
```

Same fatal on Dolibarr 18.0.10 and 22.0.5. `SupplierInvoiceHelperTest` reports 8 errors of the same
kind on both versions.

### What changes

The parameter defaults to `0`, which the body already reads as "do not check any amount", so those
callers get the behaviour they were written for and the new check stays exactly where it was wired:
the duplicate detection at import time. The docblock says what `0` means.

### Tested

Sandbox bench, on this branch:

- `SupplierInvoiceHelperTest`: **OK (39 tests, 272 assertions)** on Dolibarr 18.0.10 and 23.0.3 — 8 errors before.
- Whole PHPUnit suite of the module, file by file, on Dolibarr 18 → 24: **16/16 OK on each**.
- Real import on Dolibarr 22.0.5: the source invoice imports (supplier invoice 1914), then its credit
  note imports and links (1915, TTC -240.00), both read back from a second process. Before, the same
  document was a fatal.
- Credit note whose referenced document is *absent* from the database: the loop reports its business
  message, `Document : DD23-FA-2608-0028 linked to document DD23-AV-2608-0004 not found in Dolibarr`,
  instead of dying.
