### PR TITLE
FIX [einvoicing] The Esalink synchronization counts its postponed flows from zero

### DIFF
--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -994,6 +994,7 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 		$error = 0;
 		$alreadyExist = 0;
 		$syncedFlows = 0;
+		$postponedFlows = 0;	// Flows left unread on purpose, retried on the next run (see 'postponeflow')
 
 		// Call ID for logging purposes
 		$call_id = $response['call_id'] ?? null;


### PR DESCRIPTION
The postponed flow counter was ported from `SuperPDPProvider` to `EsalinkPDPProvider` in 511901e3
without the line that declares it. `syncFlows()` increments it on a postponed flow and reads it on
its closing test, so every Esalink synchronization emits a warning, and one more per postponed flow.

`SuperPDPProvider` declares it at line 1806, next to `$alreadyExist` and `$syncedFlows`; the Esalink
copy starts at its line 995 with those two only.

### Reproduced

On the sandbox bench, on `main` at 511901e3, `EsalinkPDPProvider::syncFlows()` run against a stub
access point that answers `flows/search` with `{"limit":5,"total":0,"results":[]}` — a page holding
no flow, which is enough to walk the method to its final report:

```
PHP Warning:  Undefined variable $postponedFlows in .../EsalinkPDPProvider.class.php on line 1145
```

### What changes

The declaration goes next to the two counters it belongs with, worded as in `SuperPDPProvider` so
both providers read the same.

### Tested

Sandbox bench, on this branch: the same synchronization, with `error_reporting=E_ALL`, on Dolibarr
19.0.4 — no warning left, and the run still reports what it did:

```
Synchronization completed with success (Maximum number of new flows to process per run: 5)
Total of flows available to synchronize: 0
Total of flows skipped (existing or already processed): 0 - Total of new flows synchronized: 0
```

Whole PHPUnit suite of the module, file by file, on Dolibarr 18 → 24: 16/16 OK on each.
