### PR TITLE
FIX [einvoicing] phan is green again on main

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -866,7 +866,7 @@ class CIIProtocol extends AbstractProtocol
 
 		if ($supplierInvoiceId == -3) {
 			$langs->load("bills");
-			$action = $langs->trans('FixTheAmountOrModifySupplierRef', $langs->transnoentitiesnoconv("RefSupplierBill"), $parsedHeader['documentno'], $langs->trans("Duplicate"));
+			$action = $langs->trans('FixTheAmountOrModifySupplierRef', $langs->transnoentitiesnoconv("RefSupplierBill"), $parsedHeader['documentno'] ?? '', $langs->trans("Duplicate"));
 			$action .= ' <a class="butAction small smallpaddingimp nomarginleft" href="' . DOL_URL_ROOT.'/fourn/facture/list.php?search_refsupplier='.urlencode($parsedHeader['documentno'] ?? '').'&socid=' . (int) $socId. '" target="_blank">';
 			$action .= '<i class="fas fa-plus-circle"></i> ';
 			$action .= $langs->trans('ModifySupplierInvoice');

--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -1179,6 +1179,7 @@ trait CommonProtocol
 
 			$errorDetails = [];
 			$createParams = [];
+			$allactiondata = [];
 
 			if (!empty($prodRef)) {
 				$errorDetails[] = 'Ref: '.$prodRef;

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -669,7 +669,7 @@ class FacturXProtocol extends CIIProtocol
 
 		if ($supplierInvoiceId == -3) {
 			$langs->load("bills");
-			$action = $langs->trans('FixTheAmountOrModifySupplierRef', $langs->transnoentitiesnoconv("RefSupplierBill"), $parsedHeader['documentno'], $langs->trans("Duplicate"));
+			$action = $langs->trans('FixTheAmountOrModifySupplierRef', $langs->transnoentitiesnoconv("RefSupplierBill"), $parsedHeader['documentno'] ?? '', $langs->trans("Duplicate"));
 			$action .= ' <a class="butAction small smallpaddingimp nomarginleft" href="' . DOL_URL_ROOT.'/fourn/facture/list.php?search_refsupplier='.urlencode($parsedHeader['documentno'] ?? '').'&socid=' . (int) $socId. '" target="_blank">';
 			$action .= '<i class="fas fa-plus-circle"></i> ';
 			$action .= $langs->trans('ModifySupplierInvoice');

--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -994,6 +994,7 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 		$error = 0;
 		$alreadyExist = 0;
 		$syncedFlows = 0;
+		$postponedFlows = 0;	// Flows left unread on purpose, retried on the next run (see 'postponeflow')
 
 		// Call ID for logging purposes
 		$call_id = $response['call_id'] ?? null;

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -1930,7 +1930,7 @@ class SuperPDPProvider extends AbstractPDPProvider
 
 							// Complete the $actions array with the Business error message
 							if ($rescode == 'SUPPLIER_INVOICE_FOUND_WITH_BAD_AMOUNT') {
-								$actions[$rescode]['businessmessage'] = $langs->trans("SupplierInvoiceFoundButWithdifferentAmount", $res['actiondata']['supplierref'], $res['actiondata']['expectedamount']);
+								$actions[$rescode]['businessmessage'] = $langs->trans("SupplierInvoiceFoundButWithdifferentAmount", $res['actiondata']['supplierref'] ?? '', $res['actiondata']['expectedamount'] ?? '');
 							}
 							if ($rescode == 'THIRDPARTY_NOT_FOUND') {
 								$infostring = '';
@@ -2137,7 +2137,7 @@ class SuperPDPProvider extends AbstractPDPProvider
 	 *
 	 * @param string 		$flowId        	FlowId
 	 * @param string|null 	$call_id  		Call ID for logging purposes
-	 * @return array{res:int<-1,1>, message:string, postponeflow?:int, actioncode?:string|null, actionurl?:string|null, action?:string|null} Returns array with 'res' (1 on success, 0 if exists or already processed, -1 on failure) with a 'message' and for business errors an optional 'actioncode', 'actionurl' and 'action'. 'postponeflow' marks a failure that stored nothing, so the batch may go on and the flow be retried later.
+	 * @return array{res:int<-1,1>, message:string, postponeflow?:int, actioncode?:string|null, actionurl?:string|null, action?:string|null, actiondata?:array<string,mixed>|null} Returns array with 'res' (1 on success, 0 if exists or already processed, -1 on failure) with a 'message' and for business errors an optional 'actioncode', 'actionurl' and 'action'. 'postponeflow' marks a failure that stored nothing, so the batch may go on and the flow be retried later.
 	 */
 	public function syncFlow($flowId, $call_id = null)
 	{

--- a/einvoicing/class/utils/SupplierInvoiceHelper.class.php
+++ b/einvoicing/class/utils/SupplierInvoiceHelper.class.php
@@ -722,10 +722,10 @@ class SupplierInvoiceHelper
 	 *
 	 * @param	string|null	$ref		Reference to look for (ExchangedDocument/ID or IssuerAssignedID of the XML)
 	 * @param	int			$socId		Id of the supplier thirdparty
-	 * @param	float		$total_ttc	If set, check that total amount of the invoicewe is ok.
-	 * @return	int						Invoice id (>0) on a single certain match, 0 when not found, -1 on database error, -2 when several invoices match, -3 found the ref butnot with the expected amount
+	 * @param	float		$total_ttc	If set, check that the total amount of the invoice is the expected one. 0 to look the reference up without checking any amount.
+	 * @return	int						Invoice id (>0) on a single certain match, 0 when not found, -1 on database error, -2 when several invoices match, -3 when the reference matches but not with the expected amount
 	 */
-	public static function findIdByRef($ref, int $socId, float $total_ttc): int
+	public static function findIdByRef($ref, int $socId, float $total_ttc = 0): int
 	{
 		global $db;
 


### PR DESCRIPTION
`phan` has been failing on every commit of `main` since ba1fb494, and it analyses the whole
repository, so every pull request opened against `main` inherits the red. Its 18 findings all come
from that lot, and this clears every one of them.

Two are more than static analysis noise: `findIdByRef()` gained a required third parameter that seven
call sites do not pass, which is a fatal `ArgumentCountError` on any invoice referencing another
document, and the undeclared `$postponedFlows` makes every Esalink synchronization emit a warning.
The rest are a missing declaration, a nullable passed to `trans()`, and a documented return shape
that omits a key the code really returns.

Tested on the sandbox bench: a real credit note import that was fatal before and now links to its
source invoice on Dolibarr 22, an Esalink synchronization run against a stub access point with no
warning left, the `-3` refusal and the `PRODUCT_NOT_FOUND` branch both rendering their actions, and
the module PHPUnit suite at 16/16 on Dolibarr 18 to 24 (`SupplierInvoiceHelperTest` alone went from
8 errors to 39 tests OK).
