### PR TITLE
fix: use EINVOICING_FLOWS_SYNC_CALL_SIZE in cronSyncFlows

### DIFF
--- a/einvoicing/class/document.class.php
+++ b/einvoicing/class/document.class.php
@@ -1225,7 +1225,7 @@ class Document extends CommonObject
 
 		if (isset($provider)) {
 			$syncFromDate = $provider->getLastSyncDate();
-			$maxflows = (int) getDolGlobalString('EINVOICING_MAX_SYNC_FLOWS', 0);
+			$maxflows = getDolGlobalInt('EINVOICING_FLOWS_SYNC_CALL_SIZE', 100);
 
 			// Sync all flows
 			$sync_result = $provider->syncFlows($syncFromDate, $maxflows);


### PR DESCRIPTION
EINVOICING_MAX_SYNC_FLOWS is never initialized by the module and therefore doesn't exist in llx_const. As a result, getDolGlobalString('EINVOICING_MAX_SYNC_FLOWS', 0) always returns 0, which forces syncFlows() into its count-first code path. That path relies on a total field in the API response that some providers no longer return (ESALINK), causing cron jobs to always exit early with "No flows to synchronize." — even when flows are pending.

Fix: replace with EINVOICING_FLOWS_SYNC_CALL_SIZE (defaulting to 100), which is the constant already used everywhere else in the module for this purpose.