### PR TITLE
FIX [einvoicing] Converting a deposit no longer raises six PHP warnings per VAT rate

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -3293,6 +3293,19 @@ class CIIProtocol extends AbstractProtocol
 			if ($line->product_type < 9 && $line->total_ht != 0) { // Remove lines with product_type greater than or equal to 9 and no need to create discount if amount is null
 				$keyforvatrate = $line->tva_tx . ($line->vat_src_code ? ' (' . $line->vat_src_code . ')' : '');
 
+				// Open the accumulators for a rate met for the first time. Adding to a key that does not
+				// exist yet is what the core does here, and it costs six "Undefined array key" warnings
+				// per deposit converted - silent on a web page, but they are real and they pile up in the
+				// PHP log of every synchronization that imports an invoice linked to a deposit.
+				if (!isset($amount_ht[$keyforvatrate])) {
+					$amount_ht[$keyforvatrate] = 0;
+					$amount_tva[$keyforvatrate] = 0;
+					$amount_ttc[$keyforvatrate] = 0;
+					$multicurrency_amount_ht[$keyforvatrate] = 0;
+					$multicurrency_amount_tva[$keyforvatrate] = 0;
+					$multicurrency_amount_ttc[$keyforvatrate] = 0;
+				}
+
 				$amount_ht[$keyforvatrate] += $line->total_ht;
 				$amount_tva[$keyforvatrate] += $line->total_tva;
 				$amount_ttc[$keyforvatrate] += $line->total_ttc;


### PR DESCRIPTION
## Problem

`CIIProtocol::getOrCreateDepositDiscount()` totals the lines of a deposit invoice per VAT rate by
adding straight into the accumulator arrays:

```php
$amount_ht = $amount_tva = $amount_ttc = array();
...
$amount_ht[$keyforvatrate] += $line->total_ht;
```

The key does not exist on the first line of a rate, so each rate met for the first time raises six
`PHP Warning: Undefined array key` - one per accumulator. Nothing is visible on a web page, but they
are real warnings and they land in the PHP log of every synchronization that imports an invoice
linked to a deposit, which is the ordinary deposit-then-balance chain.

Seen while running an import from the command line, where the warnings are not swallowed:

```
PHP Warning:  Undefined array key "20.0000" in .../CIIProtocol.class.php on line 3296
... (six times, then six more for the next rate)
```

## Fix

The accumulators for a rate are opened before anything is added to them. The accumulation lines
themselves are untouched, so they still read exactly like the ones in the core they come from
(`fourn/facture/card.php`, which has the same pattern - worth a look there too, it is unchanged from
18 to 24).

No behaviour and no amount changes: the sums were already correct, PHP treats the missing key as
null and warns about it.

## Tested

Live on the bench, Dolibarr 23.0.3, on a deposit invoice carrying three lines over two VAT rates
(300 + 150 at 20 %, 100 at 5.5 %), running the function the import runs, before and after:

| | warnings raised | discount 20 % | discount 5.5 % |
|---|---|---|---|
| before | **12** | 450.00 / 90.00 / 540.00 | 100.00 / 5.50 / 105.50 |
| after | **0** | 450.00 / 90.00 / 540.00 | 100.00 / 5.50 / 105.50 |

Same rows, same amounts, no warning. Also checked on a real incoming invoice referencing a deposit
(the balance invoice of a deposit chain, imported through `syncFlows()`): the deposit discount is
created and the `(DEPOSIT)` line of -300.00 HT is placed on the imported invoice, 1000.00 - 300.00 =
700.00 HT as on the original.

phpcs clean, `php -l` clean.

PHPUnit, every test file one by one on Dolibarr 18 to 24: 16 OK / 0 KO on each of the seven
versions.
