### PR TITLE
FIX #681 [einvoicing] Generating a Factur-X no longer breaks the next PDF of the request

### DIFF
--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -267,14 +267,29 @@ class FacturXProtocol extends CIIProtocol
 			$creator = (string) pdfExtractMetadata($orig_pdf, 'Creator');
 		}
 
+		// The choice below reads the global class FPDF, and must not depend on whether the request
+		// happened to render a PDF before reaching here. Below Dolibarr 24 the core declares its own
+		// "class FPDF extends TCPDF {}" in htdocs/includes/tcpdi/tcpdi.php, but only once its PDF stack
+		// is loaded: a generation that finds the source PDF already on disk - the mass generation of the
+		// invoice list, typically - never renders one, so the shim is absent and the branch below picks
+		// the horstoeko/setasign writer, which autoloads the real FPDF of the module. Both classes are
+		// named FPDF and only the first one of the request survives, so the next core PDF of that same
+		// request dies on "Cannot redeclare class FPDF ... in includes/tcpdi/tcpdi.php". Load the PDF
+		// stack of the core now, so the question is settled by the Dolibarr version alone. The instance
+		// is discarded: pdf_getInstance() is called for what it loads and for the K_* constants TCPDF
+		// needs, which no PDF render defined yet in this request.
+		if (!class_exists('FPDF', false)) {
+			require_once DOL_DOCUMENT_ROOT . '/core/lib/pdf.lib.php';
+			pdf_getInstance();
+		}
+
 		try {
 			if (class_exists('FPDF', false) && is_subclass_of('FPDF', 'TCPDF')) {
-				// Below Dolibarr 24, htdocs/includes/tcpdi/tcpdi.php declares "class FPDF extends TCPDF {}"
-				// as soon as any PDF is rendered in the request - the invoice PDF produced at validation,
-				// right before this hook runs. The horstoeko/zugferd writer then inherits from TCPDF instead
-				// of the real FPDF and dies on ZugferdPdfWriter::_getpagesize(). Merge with TCPDF itself,
-				// which needs no FPDF at all and supports PDF/A-3 natively. Reaching this branch means
-				// the core has loaded TCPDF, which is what the merger descends from.
+				// Below Dolibarr 24, htdocs/includes/tcpdi/tcpdi.php declares "class FPDF extends TCPDF {}".
+				// The horstoeko/zugferd writer then inherits from TCPDF instead of the real FPDF and dies on
+				// ZugferdPdfWriter::_getpagesize(). Merge with TCPDF itself, which needs no FPDF at all and
+				// supports PDF/A-3 natively. Reaching this branch means the core has loaded TCPDF, which is
+				// what the merger descends from.
 				dol_include_once('einvoicing/class/utils/FacturxTcpdfMerger.class.php');
 				$merger = new FacturxTcpdfMerger($xmlfile, $orig_pdf);
 			} else {


### PR DESCRIPTION
Found while checking #681 against the current `main`. The fatal reported there is fixed, but the FPDF collision it comes from has a second direction, still open, which answers a blank 500.

### The problem

Below Dolibarr 24 the core declares its own shim, `class FPDF extends TCPDF {}` in `htdocs/includes/tcpdi/tcpdi.php`, and the module carries the real `setasign/fpdf` in its vendor folder. Only one of the two can exist in a PHP request, and until now which one it was depended on the order of that request rather than on the version of Dolibarr.

`FacturXProtocol` chooses between the TCPDF merger and the horstoeko/setasign one by asking whether the shim is already declared. It is declared only once the core has loaded its PDF stack - which a generation that finds the source PDF already on disk never does, because it does not render one. The module then takes the setasign branch and autoloads its own FPDF, and the next PDF the core renders in that same request dies on:

```
PHP Fatal error: Cannot redeclare class FPDF
(previously declared in einvoicing/vendor/setasign/fpdf/fpdf.php:10)
in htdocs/includes/tcpdi/tcpdi.php on line 22
```

Reached by the mass generation of the invoice list: the first invoice still has its PDF, so the setasign branch runs and loads the real FPDF; a later invoice of the same batch has lost its PDF, `generateInvoice()` rebuilds it, and the request dies. The page answers a 500 and none of the remaining invoices of the batch gets its e-invoice.

### The fix

The PDF stack of the core is loaded before the choice is made, so the branch is settled by the Dolibarr version alone: below 24 the container is always built with TCPDF, from 24 on - where the core no longer declares the shim - always with the horstoeko writer. The discarded instance of `pdf_getInstance()` is also what defines the `K_*` constants TCPDF reads, which no PDF render had defined yet in that request.

### Tested

On the bench, Dolibarr 18.0.10, 20.0.4, 22.0.5 and 24.0.0, PHP 8.4:

- the two-invoice mass generation above: 500 before, both e-invoices generated after;
- validation with automatic generation, CII and Factur-X, on the four versions: unchanged;
- standalone generation of the e-invoice of an invoice that keeps its PDF: below 24 it now goes through the TCPDF merger, on 24 it still goes through the horstoeko writer;
- the container produced below 24 is unchanged - PDF/A-3 output intent, `factur-x.xml` as an embedded file, `/AFRelationship`, Factur-X XMP.
