### PR TITLE
FIX #685 [einvoicing] A deleted e-invoice stops being announced as ready to send

### DIFF
--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -2441,7 +2441,10 @@ class EInvoicing
 			}
 
 			if (!empty($tmpstatus)) {
-				$status = $tmpstatus;
+				// Merged, not replaced: the row read from the table does not carry every key of the default
+				// answer - 'file' in particular is set further down - and a caller reading a key the row does
+				// not define would get an "Undefined array key" warning.
+				$status = array_merge($status, $tmpstatus);
 			}
 
 			if (empty($foundforanotherprovider) && empty($foundforcurrentprovider)) {
@@ -2478,6 +2481,15 @@ class EInvoicing
 				$status['code'] = self::STATUS_GENERATED;
 				$status['status'] = $this->getStatusLabel(self::STATUS_GENERATED);
 			}
+		} elseif (!empty($einvoicefilepath) && $status['code'] == self::STATUS_GENERATED && empty($status['everTransmitted'])) {
+			// Symmetrical to the promotion above. "Generated (ready to send)" is written in the table when the
+			// invoice carried no status row at generation time - an invoice that predates the module on the
+			// base - and nothing ever cleared it, so deleting the e-invoice file left the card announcing a
+			// document that does not exist any more. An invoice that already reached the Access Point keeps
+			// its status: the document it announces exists there, whatever is left on disk.
+			$status['code'] = self::STATUS_NOT_GENERATED;
+			$status['status'] = $this->getStatusLabel(self::STATUS_NOT_GENERATED);
+			$status['info'] = '';	// The stored comment explains the status we just stopped reporting
 		}
 
 		return $status;


### PR DESCRIPTION
Fixes #685.

The invoice card kept reading *Generated (ready to send)* after the operator deleted the XML it announces.

The status shown is normally derived from the file: when a status row exists at *To generate*, the presence of the e-invoice on disk is what promotes the display to *Generated*, so removing the file already put the card back to *To generate*. But an invoice that carried **no status row when the e-invoice was generated** — one that predates the module on the base — takes another path: `generateInvoice()` reads the status back after writing the file, gets *Unknown*, and persists *Generated* in `einvoicing_extlinks`. Nothing ever cleared it, so the card announced a document that no longer existed. That is the reporter's case, and his screenshot confirms it: the `Invoice status set to Generated by generateInvoice()` subtitle is written on that branch only.

The demotion is now symmetrical to the promotion, which covers both paths. An invoice that already reached the Access Point is left alone: the document it announces exists there whatever is left on disk.

Sending was never possible in that state — the send button and the `send_to_pdp` action both require the file — so what is fixed is a status that lied, not an invoice leaving without its document.

A second defect surfaced while reproducing: `fetchLastknownInvoiceStatus()` replaced its default answer wholesale with the row read from the table. That row does not define every key, `file` in particular, so the three callers reading `$currentStatusDetails['file']` without a guard raised `Undefined array key "file"` on any invoice with a status row and no file on disk. The row is merged into the default answer instead.

## Tested

Bench: Dolibarr 22.0.5, module on this branch.

| case | before | after |
|---|---|---|
| status row at *To generate*, XML deleted | *Non généré* | *Non généré* (unchanged) |
| no status row at generation, XML deleted | *Généré (prêt à envoyer)* | *Non généré* |
| send allowed once the XML is gone | no | no (unchanged) |
| `$status['file']` when a row exists and no file | key absent → PHP warning | `'0'` |

PHPUnit: 16/16 green on two Dolibarr 22.0.5 instances.
