### PR TITLE
FIX #683 [einvoicing] The deliver-to party names the company, and an address keeps its lines

### DIFF
--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -3700,6 +3700,33 @@ class EInvoicing
 	}
 
 	/**
+	 * Split a Dolibarr postal address into the three lines EN 16931 has for it.
+	 *
+	 * Dolibarr keeps a postal address as one free text field where the user separates the lines with
+	 * newlines, while the norm gives an address three separate terms - BT-35/36/162 for the seller,
+	 * BT-50/51/163 for the buyer, BT-75/76/165 for the deliver-to party. Handing the whole field to
+	 * the first of them puts raw newlines inside a single element, which the receiving side renders
+	 * as one run-on line (issue #683).
+	 *
+	 * Nothing is dropped: the norm stops at three lines, so a fourth and beyond join the third,
+	 * separated by a comma, rather than disappearing from the document.
+	 *
+	 * @param	string	$address	Address as Dolibarr stores it, lines separated by newlines
+	 * @return	string[]			Exactly three lines, empty strings when the address has fewer
+	 */
+	public function splitAddressLines($address)
+	{
+		$lines = preg_split('/\R/', (string) $address);
+		$lines = array_values(array_filter(array_map('trim', $lines), 'strlen'));
+
+		if (count($lines) > 3) {
+			$lines = array_merge(array_slice($lines, 0, 2), array(implode(', ', array_slice($lines, 2))));
+		}
+
+		return $lines + array('', '', '');
+	}
+
+	/**
 	 * Generates the deposit, standard and credit note CII sample-invoice chain and returns the normalized XML of each.
 	 *
 	 * Generates three sample invoices (deposit, standard, and credit note) using fixed specimen

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -3723,7 +3723,7 @@ class EInvoicing
 			$lines = array_merge(array_slice($lines, 0, 2), array(implode(', ', array_slice($lines, 2))));
 		}
 
-		return $lines + array('', '', '');
+		return array_pad($lines, 3, '');
 	}
 
 	/**

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -2675,8 +2675,17 @@ class CIIProtocol extends AbstractProtocol
 		// TradeAddressType is reduced to the country code by the MINIMUM schema
 		if (!$this->isMinimumProfile($profile)) {
 			$addr->appendChild($doc->createElement('ram:PostcodeCode', $data[$prefix . 'postcode']));
+			// The three address lines the norm has: BT-35/36/162 for the seller, BT-50/51/163 for the
+			// buyer. XSD order inside TradeAddressType is PostcodeCode, LineOne, LineTwo, LineThree,
+			// CityName, CountryID - the elements are written in that order and nowhere else.
 			if (!empty($data[$prefix . 'lineone'])) {
 				$addr->appendChild($doc->createElement('ram:LineOne', htmlspecialchars($data[$prefix . 'lineone'])));
+			}
+			if (!empty($data[$prefix . 'linetwo'])) {
+				$addr->appendChild($doc->createElement('ram:LineTwo', htmlspecialchars($data[$prefix . 'linetwo'])));
+			}
+			if (!empty($data[$prefix . 'linethree'])) {
+				$addr->appendChild($doc->createElement('ram:LineThree', htmlspecialchars($data[$prefix . 'linethree'])));
 			}
 			$addr->appendChild($doc->createElement('ram:CityName', htmlspecialchars($data[$prefix . 'city'])));
 		}
@@ -2769,8 +2778,17 @@ class CIIProtocol extends AbstractProtocol
 		if (!empty($ship['zip'])) {
 			$addr->appendChild($doc->createElement('ram:PostcodeCode', $ship['zip']));
 		}
-		if (!empty($ship['address'])) {
-			$addr->appendChild($doc->createElement('ram:LineOne', htmlspecialchars($ship['address'])));
+		// BT-75/76/165: the deliver-to address has three lines too. The caller splits the free text
+		// field Dolibarr stores; a single-line address keeps landing on LineOne alone.
+		$shiplines = array(
+			$ship['lineone'] ?? $ship['address'] ?? '',
+			$ship['linetwo'] ?? '',
+			$ship['linethree'] ?? '',
+		);
+		foreach (array('ram:LineOne', 'ram:LineTwo', 'ram:LineThree') as $rank => $element) {
+			if (!empty($shiplines[$rank])) {
+				$addr->appendChild($doc->createElement($element, htmlspecialchars($shiplines[$rank])));
+			}
 		}
 		if (!empty($ship['town'])) {
 			$addr->appendChild($doc->createElement('ram:CityName', htmlspecialchars($ship['town'])));

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -806,6 +806,12 @@ $deliveryDate = !empty($deliveryDateList)
 $vatOnDebits      = einvoicingVatOnDebits();
 $vatPointDateCode = einvoicingVatPointDateCode($hasProductLine, $hasServiceLine, $object->type == $object::TYPE_DEPOSIT);
 
+// A postal address is one free text field in Dolibarr and three terms in EN 16931 (BT-35/36/162 for
+// the seller, BT-50/51/163 for the buyer). Handing the whole field to the first of them puts raw
+// newlines inside a single element, which the receiving side renders as one run-on line (issue #683).
+$sellerAddressLines = $einvoicing->splitAddressLines($mysoc->address ?? '');
+$buyerAddressLines  = $einvoicing->splitAddressLines($buyerAddress);
+
 // Filling $invoiceData (based on $invoiceTemplate)
 $invoiceData = [
 	// Document part
@@ -847,9 +853,9 @@ $invoiceData = [
 	'sellername'                => $mysoc->name,
 	'sellerids'                 => $myidprof,
 
-	'sellerlineone'             => $mysoc->address      ?? 'ADDRESS EMPTY',
-	'sellerlinetwo'             => "",
-	'sellerlinethree'           => "",
+	'sellerlineone'             => $sellerAddressLines[0] !== '' ? $sellerAddressLines[0] : 'ADDRESS EMPTY',
+	'sellerlinetwo'             => $sellerAddressLines[1],
+	'sellerlinethree'           => $sellerAddressLines[2],
 	'sellerpostcode'            => $mysoc->zip          ?? 'ZIP EMPTY',
 	'sellercity'                => $mysoc->town         ?? 'NO TOWN',
 	'sellercountry'             => $mysoc->country_code ?? 'COUNTRY NOT SET',
@@ -879,9 +885,9 @@ $invoiceData = [
 	'buyername'                 =>  $buyerName ?: 'CUSTOMER',
 	'buyerids'                  => $idprof ?: 'IDPROF',
 
-	'buyerlineone'              => $buyerAddress     ?: 'ADDRESS',
-	'buyerlinetwo'              => "",
-	'buyerlinethree'            => "",
+	'buyerlineone'              => $buyerAddressLines[0] !== '' ? $buyerAddressLines[0] : 'ADDRESS',
+	'buyerlinetwo'              => $buyerAddressLines[1],
+	'buyerlinethree'            => $buyerAddressLines[2],
 	'buyerpostcode'             => $buyerZip         ?: 'ZIP',
 	'buyercity'                 => $buyerTown        ?: 'TOWN',
 	'buyercountry'              => $buyerCountryCode ?: 'COUNTRY',
@@ -962,7 +968,16 @@ if ($object->mode_reglement_code) {
 // buildShipToTradePartyBuilder function only emits the node when the resolved address
 // actually differs from the buyer (bill-to) address and carries a country code; otherwise it falls
 // back to the buyer party. Nothing resolved => keys stay unset => ship-to = buyer is preserved.
+//
+// A shipping contact is a person, and BT-70 is the name of a party: what the document has to name is
+// the company the delivery is made to. The core says the same, and says it in the shipping frame of
+// the invoice PDF - pdfBuildThirdpartyName() given a Contact returns the name of its thirdparty, and
+// pdf_build_address() reads the address of the contact when it carries one, else the address of the
+// company the contact belongs to (core/lib/pdf.lib.php). einvoicingShipToFromContact() below builds
+// BG-15 the same way, so the XML and the PDF of one invoice no longer name two different things
+// (issue #683).
 $shipAddress = null;
+
 if (method_exists($object, 'liste_contact')) {
 	$shipContacts = $object->liste_contact(-1, 'external', 0, 'SHIPPING');
 	if (is_array($shipContacts) && count($shipContacts) > 0) {
@@ -972,17 +987,7 @@ if (method_exists($object, 'liste_contact')) {
 		require_once DOL_DOCUMENT_ROOT . '/contact/class/contact.class.php';
 		$shipContact = new Contact($db);
 		if ($shipContact->fetch($shipContacts[0]['id']) > 0) {
-			$shipName = trim($shipContact->getFullName($outputlangs));
-			if ($shipName === '') {
-				$shipName = $object->thirdparty->name;
-			}
-			$shipAddress = array(
-				'name'    => $shipName,
-				'address' => $shipContact->address,
-				'zip'     => $shipContact->zip,
-				'town'    => $shipContact->town,
-				'country' => $shipContact->country_code,
-			);
+			$shipAddress = einvoicingShipToFromContact($shipContact, $object->thirdparty, $outputlangs, $db);
 		}
 	}
 }
@@ -996,17 +1001,7 @@ if ($shipAddress === null && !empty($object->linkedObjectsIds['shipping']) && is
 		if ($tmpexpedition->fetch($expeditionId) > 0 && !empty($tmpexpedition->fk_delivery_address)) {
 			$shipContact = new Contact($db);
 			if ($shipContact->fetch((int) $tmpexpedition->fk_delivery_address) > 0) {
-				$shipName = trim($shipContact->getFullName($outputlangs));
-				if ($shipName === '') {
-					$shipName = $object->thirdparty->name;
-				}
-				$shipAddress = array(
-					'name'    => $shipName,
-					'address' => $shipContact->address,
-					'zip'     => $shipContact->zip,
-					'town'    => $shipContact->town,
-					'country' => $shipContact->country_code,
-				);
+				$shipAddress = einvoicingShipToFromContact($shipContact, $object->thirdparty, $outputlangs, $db);
 				break;
 			}
 		}
@@ -1020,6 +1015,12 @@ if ($shipAddress !== null) {
 		'town'    => $object->thirdparty->town,
 		'country' => $object->thirdparty->country_code,
 	);
+	// Split here rather than in the writer, so the three address terms of a party are decided in one
+	// place for the seller, the buyer and the deliver-to party alike.
+	$shipAddressLines = $einvoicing->splitAddressLines($shipAddress['address']);
+	$shipAddress['lineone']   = $shipAddressLines[0];
+	$shipAddress['linetwo']   = $shipAddressLines[1];
+	$shipAddress['linethree'] = $shipAddressLines[2];
 	$invoiceData['_shipFromContactShip'] = $shipAddress;
 }
 

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -731,7 +731,7 @@ function einvoicingSellerVatRegime($seller)
  * @param	Societe		$buyer			Thirdparty being invoiced, last resort for the name
  * @param	Translate	$outputlangs	Language the name is built in
  * @param	DoliDB		$db				Database handler
- * @return	array						Keys name, address, zip, town, country
+ * @return	array{name:string,address:string,zip:string,town:string,country:string}
  */
 function einvoicingShipToFromContact($shipContact, $buyer, $outputlangs, $db)
 {
@@ -759,11 +759,11 @@ function einvoicingShipToFromContact($shipContact, $buyer, $outputlangs, $db)
 	$source = !empty($shipContact->address) ? $shipContact : ($shipSoc !== null ? $shipSoc : $shipContact);
 
 	return array(
-		'name'    => $name,
-		'address' => $source->address,
-		'zip'     => $source->zip,
-		'town'    => $source->town,
-		'country' => $shipContact->country_code ?: ($shipSoc !== null ? $shipSoc->country_code : ''),
+		'name'    => (string) $name,
+		'address' => (string) $source->address,
+		'zip'     => (string) $source->zip,
+		'town'    => (string) $source->town,
+		'country' => (string) ($shipContact->country_code ?: ($shipSoc !== null ? $shipSoc->country_code : '')),
 	);
 }
 

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -725,6 +725,49 @@ function einvoicingSellerVatRegime($seller)
 }
 
 /**
+ * Build the deliver-to address of a shipping contact, the way the core builds the shipping frame.
+ *
+ * @param	Contact		$shipContact	Contact designated as the delivery point
+ * @param	Societe		$buyer			Thirdparty being invoiced, last resort for the name
+ * @param	Translate	$outputlangs	Language the name is built in
+ * @param	DoliDB		$db				Database handler
+ * @return	array						Keys name, address, zip, town, country
+ */
+function einvoicingShipToFromContact($shipContact, $buyer, $outputlangs, $db)
+{
+	require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
+
+	$shipSoc = null;
+	$shipSocId = (int) (!empty($shipContact->socid) ? $shipContact->socid : ($shipContact->fk_soc ?? 0));
+	if ($shipSocId > 0) {
+		$tmpsoc = new Societe($db);
+		if ($tmpsoc->fetch($shipSocId) > 0) {
+			$shipSoc = $tmpsoc;
+		}
+	}
+
+	// BT-70 names a party. The person keeps no place of its own in BG-15, which also spares the
+	// document a personal name it does not need.
+	$name = ($shipSoc !== null && !empty($shipSoc->name)) ? $shipSoc->name : trim($shipContact->getFullName($outputlangs));
+	if ($name === '') {
+		$name = $buyer->name;
+	}
+
+	// The contact wins when it carries an address of its own - that is a delivery site the user
+	// entered deliberately. With none, the address of its company is the one that means something;
+	// the contact's own empty fields would emit a deliver-to party with no address at all.
+	$source = !empty($shipContact->address) ? $shipContact : ($shipSoc !== null ? $shipSoc : $shipContact);
+
+	return array(
+		'name'    => $name,
+		'address' => $source->address,
+		'zip'     => $source->zip,
+		'town'    => $source->town,
+		'country' => $shipContact->country_code ?: ($shipSoc !== null ? $shipSoc->country_code : ''),
+	);
+}
+
+/**
  * Tax registrations (BT-31 / BT-32) the seller declares, in the shape the two writers consume.
  *
  * One entry, because the two identifiers answer the same question and a document that carried both

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -746,16 +746,27 @@ function einvoicingShipToFromContact($shipContact, $buyer, $outputlangs, $db)
 		}
 	}
 
-	// BT-70 names a party. The person keeps no place of its own in BG-15, which also spares the
-	// document a personal name it does not need.
-	$name = ($shipSoc !== null && !empty($shipSoc->name)) ? $shipSoc->name : trim($shipContact->getFullName($outputlangs));
+	// The core makes the distinction here and this follows it: pdf_build_address() switches to the
+	// company of the contact only when that company is not the one being invoiced
+	// ($targetcontact->socid != $targetcompany->id).
+	$anothercompany = ($shipSoc !== null && $shipSoc->id != $buyer->id);
+
+	// BT-70 names a party. When the contact belongs to another company, that company is the party the
+	// goods go to, and naming it also spares the document a personal name it has no use for. When the
+	// contact belongs to the company being invoiced, its name is already the BuyerTradeParty name and
+	// would say nothing here, while the label the user gave the contact is what names the delivery
+	// point - so that one is kept.
+	$name = ($anothercompany && !empty($shipSoc->name)) ? $shipSoc->name : trim($shipContact->getFullName($outputlangs));
 	if ($name === '') {
-		$name = $buyer->name;
+		$name = ($shipSoc !== null && !empty($shipSoc->name)) ? $shipSoc->name : $buyer->name;
 	}
 
 	// The contact wins when it carries an address of its own - that is a delivery site the user
 	// entered deliberately. With none, the address of its company is the one that means something;
-	// the contact's own empty fields would emit a deliver-to party with no address at all.
+	// the contact's own empty fields would emit a deliver-to party with no address at all. This is
+	// again what pdf_build_address() does, and a contact of the invoiced company with no address of
+	// its own falls back on that same company, so the deliver-to party then equals the buyer and no
+	// distinct BG-15 is emitted at all.
 	$source = !empty($shipContact->address) ? $shipContact : ($shipSoc !== null ? $shipSoc : $shipContact);
 
 	return array(


### PR DESCRIPTION
Fixes #683

A delivery address entered as a `SHIPPING` contact came out of the CII as the name of the contact
*person*, with an address made of the two or three lines of the field run together inside one
`LineOne`. Reproduced exactly as reported, on a parent/child pair with the invoice issued to the
parent, on Dolibarr 22.0.5 and current `main`:

```xml
<ram:ShipToTradeParty>
  <ram:Name>Jean DELIVRANCE</ram:Name>
  <ram:PostalTradeAddress>
    <ram:PostcodeCode>95520</ram:PostcodeCode>
    <ram:LineOne>5 avenue de la Fille
Batiment C
Zone des Bruyeres</ram:LineOne>
```

While reproducing, a third symptom of the same cause showed up, and it is the more common one: a
shipping contact that carries **no address of its own** — the ordinary case, since the address is
normally on the company — produces a deliver-to party with no address at all.

```xml
<ram:ShipToTradeParty>
  <ram:Name>Jean DELIVRANCE</ram:Name>
  <ram:PostalTradeAddress>
    <ram:CountryID>FR</ram:CountryID>       <!-- and nothing else -->
```

## What was wrong

BG-15 was built from the contact person instead of from the company the contact belongs to, and a
postal address was handed whole to the first of the three terms the norm has for it.

The core answers both questions, and answers them in the shipping frame of the invoice PDF
(`core/lib/pdf.lib.php`, identical from 18 to 24):

- `pdfBuildThirdpartyName()` given a `Contact` returns **the name of its thirdparty**, never the
  person — BT-70 names a party;
- `pdf_build_address()` with `$usecontact = 1` reads the address of the contact when it carries one,
  and otherwise `$targetcontact->thirdparty`.

BG-15 is now built the same way, so the XML and the PDF of one invoice stop naming two different
things. It also answers the reporter's last point: the document no longer carries a personal name it
has no use for.

The address split is not specific to the deliver-to party — a **seller** or a **buyer** whose address
holds two lines had them run together in `LineOne` just the same (`sellerlinetwo`/`sellerlinethree`
and their buyer twins were hardcoded to `""`, and `buildParty()` emitted `LineOne` only). EN 16931
gives an address three terms — BT-35/36/162, BT-50/51/163, BT-75/76/165 — and they are now filled in
the XSD order of `TradeAddressType` (`PostcodeCode, LineOne, LineTwo, LineThree, CityName,
CountryID`). Nothing is lost when an address holds more than three lines: the surplus joins the
third. **A single-line address, which is the ordinary case, produces exactly the document it produced
before.**

## After

```xml
<ram:ShipToTradeParty>
  <ram:Name>Fille 683 SAS</ram:Name>
  <ram:PostalTradeAddress>
    <ram:PostcodeCode>95520</ram:PostcodeCode>
    <ram:LineOne>5 avenue de la Fille</ram:LineOne>
    <ram:LineTwo>Batiment C</ram:LineTwo>
    <ram:LineThree>Zone des Bruyeres</ram:LineThree>
    <ram:CityName>OSNY</ram:CityName>
    <ram:CountryID>FR</ram:CountryID>
```

and the contact with no address of its own now gets the full address of the company it belongs to,
instead of a lone country code.

## Tested

Bench: `scw-exciting-tu`, 8 Dolibarr instances, on the tree actually deployed (this branch at
`07d20da6`), never on a worktree.

- **Reproduced first on the unpatched tree**, all three symptoms, then shown gone.
- **The three shapes**, on Dolibarr **18.0.10, 20.0.4, 22.0.5, 23.0.3 and 24.0.0** — identical output
  on all five: contact with a three-line address, contact with no address, contact with a one-line
  address (byte-identical to before the patch on that last one).
- **PHPUnit, file by file, on 18 → 24**: 16/16 OK on each. `EInvoicingSamplesTest` compares generated
  XML against the fixtures, so the specimen chain is unchanged.
- **Generation matrix on 22.0.5, CII and Factur-X**: standard, deposit, credit note, replacement and
  a three-invoice situation cycle — 14 documents, all generated, all with the buyer address now
  spread over the three lines.
- **Validation**: the 7 CII of that matrix are **VALID** against the FNFE chain
  (XSD `CrossIndustryInvoice_100pD22B` + `FACTUR-X_EN16931.xslt` + `BR-FR-Flux2-Schematron-CII`),
  0 failure. The before/after pair of the reported case validates on both sides, which is the point:
  the old document was conformant and wrong, not invalid.
- `phpcs` (dolibarr ruleset) clean on the four files touched.
