### PR TITLE
FIX #680 [einvoicing] The lists of Dolibarr stop paying for the joins of the module

### DIFF
--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -1245,7 +1245,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 */
 	public function completeArrayFields($parameters, $object, &$action, $hookmanager)
 	{
-		if (in_array('invoicelist', explode(':', $parameters['context'])) && !getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP')) {
+		if (self::isListCompletedByModule($parameters['context'], 'invoicelist')) {
 			// Add fields to invoice list
 			$parameters['arrayfields']['einvoicegenerated'] = array(
 				'label' => 'EInvoiceFile',
@@ -1263,8 +1263,8 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 			);
 		}
 
-		if (in_array('thirdpartylist', explode(':', $parameters['context'])) && (!getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP') || !getDolGlobalString('EINVOICING_DISABLE_SYNC_AP_TO_DOLI'))) {
-			// Add fields to invoice list
+		if (self::isListCompletedByModule($parameters['context'], 'thirdpartylist')) {
+			// Add fields to thirdparty list
 			$parameters['arrayfields']['routing_id'] = array(
 				'label' => 'RoutingIdField',
 				'help' => 'SpecificRoutingFieldHelp',
@@ -1286,6 +1286,94 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	}
 
 
+
+	/**
+	 * Tell whether the module completes a given list of the core with its own columns.
+	 *
+	 * The SELECT, the FROM, the WHERE and the GROUP BY must all answer the same thing: a column read
+	 * from, or a filter set on, a table that the FROM did not join turns the page of the core into an
+	 * SQL error. Same conditions as the ones printFieldListTitle() and printFieldListValue() use to
+	 * decide whether they display something.
+	 *
+	 * @param 	string	$context	Value of $parameters['context'] as the hook manager builds it
+	 * @param 	string	$list		List to test ('invoicelist', 'supplierinvoicelist' or 'thirdpartylist')
+	 * @return 	bool				True if the module adds its columns and its joins to that list
+	 */
+	protected static function isListCompletedByModule($context, $list)
+	{
+		if (!in_array($list, explode(':', $context), true)) {
+			return false;
+		}
+
+		if ($list == 'invoicelist') {
+			return !getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP');
+		}
+
+		if ($list == 'supplierinvoicelist') {
+			return !getDolGlobalString('EINVOICING_DISABLE_SYNC_AP_TO_DOLI');
+		}
+
+		return !getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP') || !getDolGlobalString('EINVOICING_DISABLE_SYNC_AP_TO_DOLI');
+	}
+
+	/**
+	 * Build the condition restricting the join on einvoicing_extlinks (aliased 'ext') to a single row.
+	 *
+	 * An element can carry several links: one per provider, and a provider can be registered both
+	 * directly and through a partner. Without this condition every extra link adds a line to the list
+	 * and, because the core builds its record count on the same FROM clause, an invoice is counted as
+	 * many times as it has links. The row kept here is the one EInvoicing::fetchLastknownInvoiceStatus()
+	 * would keep, so the list and the card never disagree.
+	 *
+	 * @param 	'facture'|'invoice_supplier'|'societe'	$elementtype	Value of einvoicing_extlinks.element_type, which also tells which list of the core is being built
+	 * @return 	string									Condition to append to the ON clause of the join
+	 */
+	protected static function getExtLinkJoinCondition($elementtype)
+	{
+		global $db;
+
+		// The 'ViaPartner' suffix tells how the provider is reached, not which provider it is.
+		$providershort = preg_replace('/ViaPartner$/', '', getDolGlobalString('EINVOICING_PDP'));
+		$sqlcurrentprovider = "sub.provider IN ('" . $db->escape($providershort) . "', '" . $db->escape($providershort . 'ViaPartner') . "')";
+
+		$sql = ' AND ext.rowid = (SELECT sub.rowid FROM ' . $db->prefix() . 'einvoicing_extlinks as sub';
+		$sql .= " WHERE sub.element_type = '" . $db->escape($elementtype) . "'";
+		if ($elementtype == 'societe') {
+			$sql .= ' AND sub.element_id = s.rowid';	// Alias of the thirdparty in the thirdparty list of the core
+		} else {
+			$sql .= ' AND sub.element_id = f.rowid';	// Alias of the invoice in both invoice lists of the core
+		}
+		$sql .= ' ORDER BY CASE WHEN ' . $sqlcurrentprovider . ' THEN 0 ELSE 1 END,';
+		// fetchLastknownInvoiceStatus() keeps the LAST link read for the configured provider, but the
+		// FIRST one read for another provider, so the two cases do not order the rowid the same way.
+		$sql .= ' CASE WHEN ' . $sqlcurrentprovider . ' THEN -sub.rowid ELSE sub.rowid END';
+		$sql .= ' LIMIT 1)';
+
+		return $sql;
+	}
+
+	/**
+	 * Build the condition restricting the join on einvoicing_routing (aliased 'rt') to a single row.
+	 *
+	 * A thirdparty can hold several routing identifiers, and a routing row for its default product on
+	 * top of them, so the join repeats the thirdparty in the list as many times. The row kept here is
+	 * the one EInvoicing::fetchDefaultRouting() and EInvoicing::fetchAllRoutings() put first.
+	 *
+	 * @return 	string				Condition to append to the ON clause of the join, correlated on s.rowid
+	 */
+	protected static function getRoutingJoinCondition()
+	{
+		global $db;
+
+		$sql = ' AND rt.rowid = (SELECT sub.rowid FROM ' . $db->prefix() . 'einvoicing_routing as sub';
+		$sql .= ' WHERE sub.fk_soc = s.rowid';	// Alias of the thirdparty in the thirdparty list of the core
+		$sql .= " AND sub.routing_type = 'thirdparty'";
+		$sql .= ' AND sub.active = 1';
+		$sql .= ' ORDER BY sub.is_default DESC, sub.rowid ASC';
+		$sql .= ' LIMIT 1)';
+
+		return $sql;
+	}
 
 	/**
 	 * Build the sub query returning the last lifecycle status validated by the Access Point for a supplier invoice.
@@ -1315,24 +1403,20 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	public function printFieldListSelect($parameters, $object, &$action, $hookmanager)
 	{
 		// Invoice list
-		if (in_array('invoicelist', explode(':', $parameters['context']))) {
+		if (self::isListCompletedByModule($parameters['context'], 'invoicelist')) {
 			$this->resprints .= ', ext.rowid AS pdplink_id, ext.provider AS pdp_provider';
 			$this->resprints .= ', ext.syncstatus AS pdp_syncstatus';
 		}
 
-		// Supplier invoice list, Product list, Soc list
-		if (in_array('supplierinvoicelist', explode(':', $parameters['context']))) {
+		// Supplier invoice list
+		if (self::isListCompletedByModule($parameters['context'], 'supplierinvoicelist')) {
 			$this->resprints .= ', ext.rowid AS pdplink_id, ext.provider AS pdp_provider';
 			// Last known lifecycle status accepted by the Access Point, same source as the one shown on the invoice card
 			$this->resprints .= ', (' . self::getSupplierLifecycleStatusSubQuery() . ') AS pdp_lcstatus';
 		}
 
-		if (in_array('thirdpartylist', explode(':', $parameters['context']))) {
-			$this->resprints .= ', ext.rowid AS pdplink_id, ext.provider AS pdp_provider';
-			$this->resprints .= ', rt.routing_id AS routing_id';
-		}
-
-		if (in_array('societelist', explode(':', $parameters['context']))) {
+		// Thirdparty list
+		if (self::isListCompletedByModule($parameters['context'], 'thirdpartylist')) {
 			$this->resprints .= ', ext.rowid AS pdplink_id, ext.provider AS pdp_provider';
 			$this->resprints .= ', rt.routing_id AS routing_id';
 		}
@@ -1353,26 +1437,24 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	{
 		global $db;
 
-		// Supplier invoice list, Product list, Soc list
-		$contexts = explode(':', $parameters['context']);
+		// Thirdparty list
+		if (self::isListCompletedByModule($parameters['context'], 'thirdpartylist')) {
+			$this->resprints .= ' LEFT JOIN ' . $db->prefix() . "einvoicing_extlinks as ext ON ext.element_id = s.rowid AND ext.element_type = 'societe'";
+			$this->resprints .= self::getExtLinkJoinCondition('societe');
+			$this->resprints .= ' LEFT JOIN ' . $db->prefix() . 'einvoicing_routing rt ON rt.fk_soc = s.rowid';
+			$this->resprints .= self::getRoutingJoinCondition();
+		}
 
-		if (array_intersect($contexts, ['invoicelist', 'supplierinvoicelist', 'thirdpartylist', 'productservicelist', 'societelist'])) {
-			if (in_array('thirdpartylist', $contexts, true)) {
-				$this->resprints .= ' LEFT JOIN ' . $db->prefix() . "einvoicing_extlinks as ext ON ext.element_id = s.rowid AND ext.element_type = 'societe'";
-				$this->resprints .= ' LEFT JOIN ' . $db->prefix() . "einvoicing_routing rt ON rt.fk_soc = s.rowid";
-			}
+		// Invoice list
+		if (self::isListCompletedByModule($parameters['context'], 'invoicelist')) {
+			$this->resprints .= ' LEFT JOIN ' . $db->prefix() . "einvoicing_extlinks as ext ON ext.element_id = f.rowid AND ext.element_type = 'facture'";
+			$this->resprints .= self::getExtLinkJoinCondition('facture');
+		}
 
-			if (in_array('invoicelist', explode(':', $parameters['context']))) {
-				$this->resprints .= " LEFT JOIN " . $db->prefix() . "einvoicing_extlinks as ext ON ext.element_id = f.rowid AND ext.element_type = 'facture'";
-			}
-
-			if (in_array('supplierinvoicelist', $contexts, true)) {
-				$this->resprints .= ' LEFT JOIN ' . $db->prefix() . "einvoicing_extlinks as ext ON ext.element_id = f.rowid AND ext.element_type = 'invoice_supplier'";
-			}
-
-			if (in_array('productservicelist', $contexts, true)) {
-				$this->resprints .= ' LEFT JOIN ' . $db->prefix() . "einvoicing_extlinks as ext ON ext.element_id = p.rowid AND ext.element_type = 'product'";
-			}
+		// Supplier invoice list
+		if (self::isListCompletedByModule($parameters['context'], 'supplierinvoicelist')) {
+			$this->resprints .= ' LEFT JOIN ' . $db->prefix() . "einvoicing_extlinks as ext ON ext.element_id = f.rowid AND ext.element_type = 'invoice_supplier'";
+			$this->resprints .= self::getExtLinkJoinCondition('invoice_supplier');
 		}
 
 		return 0;
@@ -1393,23 +1475,27 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 
 		$contexts = explode(':', $parameters['context']);
 
-		if (array_intersect($contexts, ['invoicelist', 'supplierinvoicelist', 'thirdpartylist', 'productservicelist', 'societelist'])) {
-			if (GETPOST('search_pdplinked', 'alpha') !== '' && GETPOST('search_pdplinked', 'alpha') == getDolGlobalString('EINVOICING_PDP')) {
-				$this->resprints .= " AND ext.provider = '" . $db->escape(getDolGlobalString('EINVOICING_PDP')) . "'";
-			}
+		// Only the lists the module joined its tables to: a filter on a table left out of the FROM is an SQL error
+		$hasextlink = self::isListCompletedByModule($parameters['context'], 'invoicelist')
+			|| self::isListCompletedByModule($parameters['context'], 'supplierinvoicelist')
+			|| self::isListCompletedByModule($parameters['context'], 'thirdpartylist');
 
-			if (GETPOST('search_routing_id', 'alpha') !== '' && GETPOST('search_routing_id', 'alpha') != "") {
-				$this->resprints .= " AND ext.routing_id = '" . $db->escape(GETPOST('search_routing_id', 'alpha')) . "'";
-			}
+		if ($hasextlink && GETPOST('search_pdplinked', 'alpha') !== '' && GETPOST('search_pdplinked', 'alpha') == getDolGlobalString('EINVOICING_PDP')) {
+			$this->resprints .= " AND ext.provider = '" . $db->escape(getDolGlobalString('EINVOICING_PDP')) . "'";
 		}
 
-		if (in_array('invoicelist', $contexts) && !getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP')) {
+		// The routing identifier is a column of einvoicing_routing, joined as 'rt' on the thirdparty list only
+		if (self::isListCompletedByModule($parameters['context'], 'thirdpartylist') && GETPOST('search_routing_id', 'alpha') !== '') {
+			$this->resprints .= " AND rt.routing_id = '" . $db->escape(GETPOST('search_routing_id', 'alpha')) . "'";
+		}
+
+		if (self::isListCompletedByModule($parameters['context'], 'invoicelist')) {
 			if (GETPOST('search_pdp_syncstatus', 'alpha') !== '' && GETPOST('search_pdp_syncstatus', 'alpha') != -2) {
 				$this->resprints .= ' AND ext.syncstatus = ' . ((int) GETPOST('search_pdp_syncstatus'));
 			}
 		}
 
-		if (in_array('supplierinvoicelist', $contexts) && !getDolGlobalString('EINVOICING_DISABLE_SYNC_AP_TO_DOLI') && GETPOST('search_pdp_lcstatus', 'alpha') !== '' && GETPOST('search_pdp_lcstatus', 'alpha') != -2) {
+		if (self::isListCompletedByModule($parameters['context'], 'supplierinvoicelist') && GETPOST('search_pdp_lcstatus', 'alpha') !== '' && GETPOST('search_pdp_lcstatus', 'alpha') != -2) {
 			$this->resprints .= ' AND (' . self::getSupplierLifecycleStatusSubQuery() . ') = ' . GETPOSTINT('search_pdp_lcstatus');
 		}
 
@@ -1432,8 +1518,8 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 * Add GROUP BY fields
 	 * Mandatory for the fields added by printFieldListSelect() on lists that build a GROUP BY clause,
 	 * otherwise MySQL rejects the query with sql_mode=only_full_group_by (error 1055).
-	 * Only supplierinvoicelist is concerned: thirdpartylist/societelist call the hook without any
-	 * GROUP BY clause, and productservicelist selects no column from the joined table.
+	 * Only supplierinvoicelist is concerned: the thirdparty list and the invoice list call the hook
+	 * without any GROUP BY clause.
 	 *
 	 * @param array<string,mixed> 	$parameters		Array of parameters
 	 * @param CommonObject			$object			Object invoice
@@ -1443,7 +1529,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 */
 	public function printFieldListGroupBy($parameters, $object, &$action, $hookmanager)
 	{
-		if (in_array('supplierinvoicelist', explode(':', $parameters['context']), true)) {
+		if (self::isListCompletedByModule($parameters['context'], 'supplierinvoicelist')) {
 			$this->resprints .= ', ext.rowid, ext.provider';
 		}
 
@@ -1463,7 +1549,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	{
 		global $form, $db;
 
-		if (in_array('invoicelist', explode(':', $parameters['context'])) && !getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP')) {
+		if (self::isListCompletedByModule($parameters['context'], 'invoicelist')) {
 			$einvoicing = new EInvoicing($db);
 			$checkConfig = $einvoicing->checkModulePrerequisites();
 			if ($checkConfig < 0) {
@@ -1527,8 +1613,8 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 			}
 		}
 
-		// Supplier invoice list, Product list, Soc list
-		if (in_array('supplierinvoicelist', explode(':', $parameters['context'])) && !getDolGlobalString('EINVOICING_DISABLE_SYNC_AP_TO_DOLI')) {
+		// Supplier invoice list
+		if (self::isListCompletedByModule($parameters['context'], 'supplierinvoicelist')) {
 			$tmpeinvoicingpartner = preg_replace('/ViaPartner/i', '', getDolGlobalString('EINVOICING_PDP'));
 			$listofoptions = array(
 				$tmpeinvoicingpartner => $tmpeinvoicingpartner,
@@ -1573,8 +1659,9 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 		}
 
 
-		if (in_array('thirdpartylist', explode(':', $parameters['context'])) && (!getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP') || !getDolGlobalString('EINVOICING_DISABLE_SYNC_AP_TO_DOLI'))) {
-			if (!empty($parameters['arrayfields']['einvoicegenerated']['checked'])) {
+		if (self::isListCompletedByModule($parameters['context'], 'thirdpartylist')) {
+			// 'routing_id' is the field completeArrayFields() declares for that list
+			if (!empty($parameters['arrayfields']['routing_id']['checked'])) {
 				print '<td class="liste_titre">';
 				print '<input type="text" name="search_routing_id" value="' . dolPrintHTMLForAttribute(GETPOST('search_routing_id', 'alpha')) . '" class="minwidth50 maxwidth100">';
 				print '</td>';
@@ -1605,7 +1692,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 
 		$contexts = explode(':', $parameters['context']);
 
-		if (in_array('invoicelist', $contexts) && !getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP')) {
+		if (self::isListCompletedByModule($parameters['context'], 'invoicelist')) {
 			$einvoicing = new EInvoicing($db);
 			$checkConfig = $einvoicing->checkModulePrerequisites();
 			if ($checkConfig < 0) {
@@ -1626,14 +1713,14 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 			}
 		}
 
-		// Supplier invoice list, Product list, Soc list
-		if (in_array('supplierinvoicelist', $contexts) && !getDolGlobalString('EINVOICING_DISABLE_SYNC_AP_TO_DOLI')) {
+		// Supplier invoice list
+		if (self::isListCompletedByModule($parameters['context'], 'supplierinvoicelist')) {
 			print_liste_field_titre($langs->transnoentitiesnoconv('einvoicingSourceTitle'));
 			print_liste_field_titre($langs->transnoentitiesnoconv('einvoicingInvoiceStatus'), '', '', '', $parameters['param'] ?? '', '', '', '', 'center ');
 		}
 
-		if (in_array('thirdpartylist', $contexts) && (!getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP') || !getDolGlobalString('EINVOICING_DISABLE_SYNC_AP_TO_DOLI'))) {
-			if (!empty($parameters['arrayfields']['einvoicegenerated']['checked'])) {
+		if (self::isListCompletedByModule($parameters['context'], 'thirdpartylist')) {
+			if (!empty($parameters['arrayfields']['routing_id']['checked'])) {
 				print_liste_field_titre($langs->transnoentitiesnoconv('einvoicingThirdPartyRoutingTitle'));
 			}
 		}
@@ -1660,8 +1747,6 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	{
 		global $db, $langs;
 
-		$contexts = explode(':', $parameters['context']);
-
 		// Every block below counts the cells it prints into the caller's column counter, which sizes the
 		// footer of the list. A hook is not guaranteed to receive that counter already built, so make sure
 		// of it once, before the first increment rather than after it. Only create the key when it is
@@ -1674,7 +1759,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 			$parameters['totalarray']['nbfield'] = 0;
 		}
 
-		if (in_array('invoicelist', $contexts) && !getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP')) {
+		if (self::isListCompletedByModule($parameters['context'], 'invoicelist')) {
 			$einvoicing = new EInvoicing($db);
 			$checkConfig = $einvoicing->checkModulePrerequisites();
 			if ($checkConfig < 0) {
@@ -1719,8 +1804,8 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 			}
 		}
 
-		// Supplier invoice list, Product list, Soc list
-		if (in_array('supplierinvoicelist', $contexts) && !getDolGlobalString('EINVOICING_DISABLE_SYNC_AP_TO_DOLI')) {
+		// Supplier invoice list
+		if (self::isListCompletedByModule($parameters['context'], 'supplierinvoicelist')) {
 			$obj = $parameters['obj'];
 
 			print '<td class="tdoverflowmax100">';
@@ -1743,12 +1828,13 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 			}
 		}
 
-		if (in_array('thirdpartylist', explode(':', $parameters['context']), true)) {
-			if (!empty($parameters['arrayfields']['einvoicegenerated']['checked'])) {
+		if (self::isListCompletedByModule($parameters['context'], 'thirdpartylist')) {
+			if (!empty($parameters['arrayfields']['routing_id']['checked'])) {
 				$obj = $parameters['obj'];
 
 				print '<td class="tdoverflowmax125">';
-				if ($obj->pdplink_id) {
+				// A thirdparty holds a routing identifier whether or not it also carries a link to the Access Point
+				if (!empty($obj->routing_id)) {
 					print dolPrintHTML($obj->routing_id);
 				}
 				print '</td>';

--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -525,6 +525,13 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	{
 		global $db, $langs, $user;
 
+		// Before anything else, and before the early return below: on a list the core builds its
+		// $arrayfields before it knows any action, and the older versions offer no other hook to
+		// complete it. See addFieldsToList().
+		if (isset($parameters['arrayfields'])) {
+			self::addFieldsToList($parameters['arrayfields'], $parameters['context']);
+		}
+
 		if (empty($action)) {
 			return 0;
 		}
@@ -1245,16 +1252,39 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 */
 	public function completeArrayFields($parameters, $object, &$action, $hookmanager)
 	{
-		if (self::isListCompletedByModule($parameters['context'], 'invoicelist')) {
+		if (isset($parameters['arrayfields'])) {
+			self::addFieldsToList($parameters['arrayfields'], $parameters['context']);
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Declare the columns of the module in the list of fields a list of the core offers to display.
+	 *
+	 * Called from two hooks on purpose. 'completeArrayFields' is the hook meant for this, but the core
+	 * only runs it from Dolibarr 22 (customer invoice list) and 23 (the four lists); 'doActions', on the
+	 * other hand, receives the same array by reference from Dolibarr 17 on the customer invoice list,
+	 * 19 on the supplier invoice list and 20 on the thirdparty and product lists. Declaring from both
+	 * is what makes the columns reachable on the versions still supported. Writing the same keys twice
+	 * where both hooks run changes nothing.
+	 *
+	 * @param 	array<string,mixed>	$arrayfields	Fields of the list, as the core passes them by reference
+	 * @param 	string				$context		Value of $parameters['context'] as the hook manager builds it
+	 * @return 	void
+	 */
+	protected static function addFieldsToList(&$arrayfields, $context)
+	{
+		if (self::isListCompletedByModule($context, 'invoicelist')) {
 			// Add fields to invoice list
-			$parameters['arrayfields']['einvoicegenerated'] = array(
+			$arrayfields['einvoicegenerated'] = array(
 				'label' => 'EInvoiceFile',
 				'checked' => -1,
 				'position' => 900,
 				'enabled' => 1,
 				'perms' => '1'
 			);
-			$parameters['arrayfields']['pdp_syncstatus'] = array(
+			$arrayfields['pdp_syncstatus'] = array(
 				'label' => 'PDPSyncStatus',
 				'checked' => 1,
 				'position' => 901,
@@ -1263,9 +1293,9 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 			);
 		}
 
-		if (self::isListCompletedByModule($parameters['context'], 'thirdpartylist')) {
+		if (self::isListCompletedByModule($context, 'thirdpartylist')) {
 			// Add fields to thirdparty list
-			$parameters['arrayfields']['routing_id'] = array(
+			$arrayfields['routing_id'] = array(
 				'label' => 'RoutingIdField',
 				'help' => 'SpecificRoutingFieldHelp',
 				'checked' => -1,
@@ -1273,7 +1303,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 				'enabled' => 1,
 				'perms' => '1'
 			);
-			$parameters['arrayfields']['routing_product_id'] = array(
+			$arrayfields['routing_product_id'] = array(
 				'label' => 'DefaultProductEBilling',
 				'checked' => -1,
 				'position' => 901,
@@ -1281,8 +1311,6 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 				'perms' => '1'
 			);
 		}
-
-		return 0;
 	}
 
 

--- a/einvoicing/sql/dolibarr_allversions.sql
+++ b/einvoicing/sql/dolibarr_allversions.sql
@@ -49,3 +49,15 @@ ALTER TABLE llx_einvoicing_call ADD COLUMN call_id_num integer AFTER call_id;
 ALTER TABLE llx_einvoicing_call ADD COLUMN call_id_num integer AFTER call_id;
 
 ALTER TABLE llx_einvoicing_call ADD COLUMN request_id varchar(36) AFTER endpoint;
+
+ALTER TABLE llx_einvoicing_extlinks ADD INDEX idx_einvoicing_extlinks_element (element_type, element_id);
+
+ALTER TABLE llx_einvoicing_extlinks ADD INDEX idx_einvoicing_extlinks_syncref (element_type, syncref);
+
+ALTER TABLE llx_einvoicing_extlinks ADD INDEX idx_einvoicing_extlinks_flowid (flow_id);
+
+ALTER TABLE llx_einvoicing_lifecycle_msg ADD INDEX idx_einvoicing_lifecycle_msg_element (element_type, element_id, lc_validation_status);
+
+ALTER TABLE llx_einvoicing_lifecycle_msg ADD INDEX idx_einvoicing_lifecycle_msg_flowid (flow_id);
+
+ALTER TABLE llx_einvoicing_routing ADD INDEX idx_einvoicing_routing_soc (fk_soc, routing_type, active);

--- a/einvoicing/sql/llx_einvoicing_extlinks.key.sql
+++ b/einvoicing/sql/llx_einvoicing_extlinks.key.sql
@@ -1,0 +1,25 @@
+-- Copyright (C) 2026		Pierre Grasswill			<da.grumpf@gmail.com>
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see https://www.gnu.org/licenses/.
+
+-- The table is read by (element_type, element_id) on every card and, above all, it is joined to the
+-- invoice, supplier invoice and thirdparty lists of Dolibarr: without this index the whole table is
+-- re-scanned for each block of rows of the list, including for the record count of the page.
+ALTER TABLE llx_einvoicing_extlinks ADD INDEX idx_einvoicing_extlinks_element (element_type, element_id);
+
+-- Lookup by reference, used when the id of the element is not known (EInvoicing::fetchLastknownInvoiceStatus)
+ALTER TABLE llx_einvoicing_extlinks ADD INDEX idx_einvoicing_extlinks_syncref (element_type, syncref);
+
+-- Lookup by flow, used when a message of the Access Point carries only the flow identifier
+ALTER TABLE llx_einvoicing_extlinks ADD INDEX idx_einvoicing_extlinks_flowid (flow_id);

--- a/einvoicing/sql/llx_einvoicing_lifecycle_msg.key.sql
+++ b/einvoicing/sql/llx_einvoicing_lifecycle_msg.key.sql
@@ -1,0 +1,21 @@
+-- Copyright (C) 2026		Pierre Grasswill			<da.grumpf@gmail.com>
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see https://www.gnu.org/licenses/.
+
+-- The table is read by (element_type, element_id) on every card, and the supplier invoice list runs
+-- that same read as a correlated sub query, once per row displayed.
+ALTER TABLE llx_einvoicing_lifecycle_msg ADD INDEX idx_einvoicing_lifecycle_msg_element (element_type, element_id, lc_validation_status);
+
+-- Lookup by flow, used to gather the messages of a flow (EInvoicing::fetchStatusMessages)
+ALTER TABLE llx_einvoicing_lifecycle_msg ADD INDEX idx_einvoicing_lifecycle_msg_flowid (flow_id);

--- a/einvoicing/sql/llx_einvoicing_routing.key.sql
+++ b/einvoicing/sql/llx_einvoicing_routing.key.sql
@@ -1,0 +1,19 @@
+-- Copyright (C) 2026		Pierre Grasswill			<da.grumpf@gmail.com>
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see https://www.gnu.org/licenses/.
+
+-- Every read of the table selects the routing of one thirdparty, of one type, active or not
+-- (EInvoicing::fetchDefaultRouting, EInvoicing::fetchAllRoutings), and the thirdparty list of
+-- Dolibarr runs that read as a correlated sub query, once per row displayed.
+ALTER TABLE llx_einvoicing_routing ADD INDEX idx_einvoicing_routing_soc (fk_soc, routing_type, active);


### PR DESCRIPTION
Fixes #680.

The module joins `llx_einvoicing_extlinks` and `llx_einvoicing_routing` into the invoice, supplier
invoice and thirdparty lists of the core. Neither table carried an index, neither join was restricted
to a single row, and the search filter on the routing identifier read a column that does not exist.

Everything below was measured on a bench of eight instances, Dolibarr 17.0.4 to 24.0.0-beta, sharing
one checkout of the module, PHP 8.4 / MariaDB 11.4.

## 1. The missing indexes

Three new `.key.sql` files, and the same statements in `dolibarr_allversions.sql` for installations
that upgrade the core rather than reactivate the module. Every index answers a read the module
already performs: `(element_type, element_id)` on every card, `(element_type, syncref)` for
`fetchLastknownInvoiceStatus()` when the id is unknown, `flow_id` for the messages of the Access
Point, `(fk_soc, routing_type, active)` for `fetchDefaultRouting()`.

The record count of a list is the query that hurts, because `list.php` builds it on the same `FROM`
clause and gives it no `LIMIT`. Measured on 20 100 invoices carrying 30 101 links:

| state | `COUNT(*)` returns | time |
|---|---|---|
| as shipped, no index | 30 100 | **32.9 s** |
| as shipped, with the index | 30 100 | 0.046 s |
| deduplicated join, with the index | **20 100** | **0.024 s** |

The user-visible effect on the same data set, on Dolibarr 22.0.5: `/compta/facture/list.php?limit=25`
answered **HTTP 504 after 60 s**, three times in a row. With this branch it answers in **0.036 s**.
`EXPLAIN` goes from `type: ALL, key: NULL, rows: 496, Using join buffer (flat, BNL join)` on `ext`
to `type: eq_ref, key: PRIMARY, rows: 1`; on the count query MariaDB now eliminates the join
altogether, since it is provably at most one row and no column of it is read.

## 2. The join repeated rows and inflated the count

An element can carry several links: one per provider, and a provider registered both directly and
through a partner. The row kept is now the one `fetchLastknownInvoiceStatus()` would keep, so a list
and a card never disagree; same idea on the routing side with `fetchDefaultRouting()`.

On the bench, before → after, without touching the data:

- customer invoice list, Dolibarr 24: `COUNT(*)` 137 for 118 invoices → **118**; first page 100 row
  links for 90 distinct invoices → **100 / 100**.
- thirdparty list, Dolibarr 23 and 24: 13 links for 12 thirdparties → **12 / 12** (one thirdparty
  holding two routing identifiers).
- supplier invoice list: a second link added on one invoice made it appear twice (200 rows for 199
  invoices) → **200 / 200**, and the kept row is the one of the configured provider.

## 3. `ext.routing_id` does not exist

`printFieldListWhere()` filtered on `ext.routing_id`, a column of `llx_einvoicing_routing` (aliased
`rt`), not of `llx_einvoicing_extlinks`. Any URL carrying `&search_routing_id=` answered
`Unknown column 'ext.routing_id' in 'WHERE'` — reproduced on **all eight versions**, on the invoice,
supplier invoice, thirdparty and product lists. The filter now reads `rt.routing_id`, and only on the
thirdparty list where `rt` is joined.

Note that it therefore matches the routing identifier the list displays — the default one. Searching
a secondary identifier of a thirdparty returns nothing. An `EXISTS` on the whole table would answer
"which thirdparty holds this identifier" instead, at the price of a filter that no longer agrees with
the column; I kept the agreement, and I will gladly switch if you prefer the other reading.

## 4. The columns of the module were unreachable on the older cores

`completeArrayFields()` is the hook meant to declare a column, but the core only calls it from
Dolibarr 22 — and there only on the customer invoice list; the four lists get it from 23. Below that,
the declared fields were never registered, so the "E-invoice File" column could not be displayed at
all, and `arrayfields['einvoicegenerated']` — a key the thirdparty list never declares — gated its
routing column, which therefore never appeared on any version.

The core has passed that same `$arrayfields` **by reference** in the parameters of `doActions` for
much longer: since 17 on the customer invoice list, 19 on the supplier invoice list, 20 on the
thirdparty and product lists. The declaration moved to a method both hooks call, and the thirdparty
column is gated on the field name that list actually declares.

Column offered in the "select columns" menu, before → after:

| list | before | after |
|---|---|---|
| customer invoice, "E-invoice File" | 22, 23, 24 | **18 → 24** |
| thirdparty, "E-invoicing address" | declared on 23/24 but never rendered | **20 → 24**, rendered |

## 5. Consistency between the clauses

The `SELECT`, the `FROM`, the `WHERE` and the `GROUP BY` now answer the same question as the columns
they feed — a single `isListCompletedByModule()`. Consequences:

- the product list no longer joins `llx_einvoicing_extlinks`: nothing was ever selected from it there;
- with `EINVOICING_DISABLE_SYNC_DOLI_TO_AP` set, the invoice list now runs **zero** query touching
  `einvoicing_extlinks`, where the join used to be added regardless;
- the `societelist` branches are gone. `societe/list.php` calls
  `initHooks(array($contextpage, 'thirdpartylist'))`, so `thirdpartylist` is always present even with
  `?contextpage=societelist`: that branch only made the query select `pdplink_id` twice. Removing it
  is the one deletion here that is not strictly a bug fix — say the word and I put it back.

## Test batch

- Four lists × eight instances (17 → 24), with and without the search filters: 200 everywhere, no SQL
  error, and as many distinct rows as rows. On `main` the same sweep answers `DB_ERROR_NOSUCHFIELD`
  on both filter URLs of every version, and repeats rows on 22, 23 and 24.
- Both lists checked under `sql_mode=ONLY_FULL_GROUP_BY`.
- Both `EINVOICING_DISABLE_SYNC_*` options set, with the filters passed in the URL: no error.
- Module deactivated and reactivated on the seven instances 18 → 24: the six indexes are created, and
  replaying it a second time is a no-op.
- PHPUnit, every test file on every instance: 128 runs, 127 OK. The single failure
  (`EInvoicingSamplesTest` on the 17.0.4 instance, where the module is not enabled) fails identically
  on `main`.
- `phpcs` with the ruleset of the repository: clean.
