### PR TITLE
FIX: do not forget $db in your object

### DIFF
--- a/einvoicing/class/providers/PDPProviderManager.class.php
+++ b/einvoicing/class/providers/PDPProviderManager.class.php
@@ -50,6 +50,8 @@ class PDPProviderManager
 		global $langs, $mysoc;
 		global $dolibarr_main_url_root;
 
+		$this->db = $db;
+
 		// Define $urlwithroot
 		$urlwithouturlroot = preg_replace('/'.preg_quote(DOL_URL_ROOT, '/').'$/i', '', trim($dolibarr_main_url_root));
 		$urlwithroot = $urlwithouturlroot.DOL_URL_ROOT; // This is to use external domain name found into config file


### PR DESCRIPTION
FIX: do not forget $db in your object

$db property is defined but not set in PDPProvider::__construct().

So, when we call for a new HookManager in addProviderFromHooks() method, $this->db is null, and therefore an error 500 will occur if any module pretends to interact with this Hook !