### PR TITLE
FIX: #701 [einvoicing] A received e-invoice is written where the supplier invoice card reads it

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -3063,7 +3063,12 @@ class CIIProtocol extends AbstractProtocol
 		global $conf;
 
 		// Ensure upload directory exists
-		$folder_part = get_exdir(0, 0, 0, 0, $supplierInvoice);
+		// The arguments are the ones the card of the core passes (fourn/facture/card.php), and they are
+		// passed in full on purpose: get_exdir(0, 0, ...) answers the same thing only since Dolibarr 20,
+		// where an empty level defaults to 2 for a supplier invoice. On 18 and 19 that default does not
+		// exist, the path falls back to the reference of the invoice, and the document is written into a
+		// directory the card never reads - so a received e-invoice was shown nowhere.
+		$folder_part = get_exdir($supplierInvoice->id, 2, 0, 0, $supplierInvoice, 'invoice_supplier');
 		$relative_path = 'fournisseur/facture/' . $folder_part . dol_sanitizeFileName($supplierInvoice->ref);
 		$upload_dir = $conf->fournisseur->dir_output . '/facture/' . $folder_part . dol_sanitizeFileName($supplierInvoice->ref);
 


### PR DESCRIPTION
Fixes #701.

`CIIProtocol::saveEInvoiceFileToSupplierInvoiceAttachment()` built the directory of a received document with `get_exdir(0, 0, 0, 0, $supplierInvoice)`, while `fourn/facture/card.php` reads it with `get_exdir($object->id, 2, 0, 0, $object, 'invoice_supplier')`. The two answer the same thing only from Dolibarr 20 on, where `get_exdir()` defaults `level` to 2 for a supplier invoice when it is not given. On 18 and 19 that default does not exist, the path falls back to the reference of the invoice, and the document lands in a directory the card never reads — so a received e-invoice was shown nowhere on the two oldest supported cores.

The fix passes the arguments in full, exactly as the card does. The explicit form answers the same thing on every version, so nothing changes on 20 and later.

### Tested

On 18.0.10, 20.0.4, 23.0.3 and 24.0.0, by importing a CII through `createSupplierInvoiceFromSource()` as the web user and then loading the card of the invoice it creates:

| core | before | after |
|---|---|---|
| 18.0.10 | `(PROV4727)/(PROV4727)/` — **card lists nothing** | `6/2/(PROV4726)/` — card lists the document |
| 20.0.4 | `4/4/(PROV3944)/` — card lists it | unchanged |
| 23.0.3 | `6/2/(PROV4926)/` — card lists it | unchanged |
| 24.0.0 | `2/6/(PROV3962)/` — card lists it | unchanged |

The before line of 18 is a real run of the current `main` on the same instance with the same document, not a reconstruction.

Module PHPUnit: 16 files x 7 cores (18 to 24), 0 failure.

### Not done here

Documents received before this fix stay where they were written, and the ECM index keeps the path it was given. Moving them is a migration of its own, and it only concerns installations that received on 18 or 19.
