### PR TITLE
FIX Phan red on main: $obj possibly undeclared in the e-invoice status row

### DIFF
--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -1928,6 +1928,8 @@ class EInvoicing
 		if ($provider) {
 			// Get current status
 			$currentStatus = '-';
+			$currentStatusCode = 0;
+			$currentReasonCode = '';
 			$sql = "SELECT lc_status, lc_reason_code FROM " . $this->db->prefix() . "einvoicing_lifecycle_msg";
 			$sql .= " WHERE element_type = '" . $this->db->escape($object->element) . "'";
 			$sql .= " AND element_id = " . (int) $object->id;
@@ -1936,21 +1938,23 @@ class EInvoicing
 			$resql = $this->db->query($sql);
 			if ($resql && $this->db->num_rows($resql) > 0) {
 				$obj = $this->db->fetch_object($resql);
-				$currentStatus = $this->getStatusLabel($obj->lc_status);
+				$currentStatusCode = (int) $obj->lc_status;
+				$currentReasonCode = $obj->lc_reason_code;
+				$currentStatus = $this->getStatusLabel($currentStatusCode);
 			}
 			$this->db->free($resql);
 			// Current status
 			$resprints .= '<tr class="treinvoicing_collapseseparator">';
 			$resprints .= '<td class="">' . $langs->trans("einvoicingInvoiceStatus") . '</td>';
-			$resprints .= '<td><span id="einvoice-status" title="'.$obj->lc_status.'">' . $currentStatus;
-			$resprints .= ($obj->lc_status > 200 ? ' <span class="opacitymedium small">('.$langs->trans("EInvoiceCodeShort").' '.$obj->lc_status.')</span>' : '');
+			$resprints .= '<td><span id="einvoice-status"' . ($currentStatusCode ? ' title="' . $currentStatusCode . '"' : '') . '>' . $currentStatus;
+			$resprints .= ($currentStatusCode > 200 ? ' <span class="opacitymedium small">(' . $langs->trans("EInvoiceCodeShort") . ' ' . $currentStatusCode . ')</span>' : '');
 			$resprints .= '</span>';
 
 			// If current status requires a reason, display it
 			$reasonLabel = '';
 			$displayReasonLabel = 'style="display:none;"';
-			if (!empty($obj->lc_reason_code)) {
-				$reasonLabel = $langs->trans($this->getReasonsByStatus($obj->lc_status)[$obj->lc_reason_code]['label'] ?? $obj->lc_reason_code);
+			if (!empty($currentReasonCode)) {
+				$reasonLabel = $langs->trans($this->getReasonsByStatus($currentStatusCode)[$currentReasonCode]['label'] ?? $currentReasonCode);
 				$displayReasonLabel = '';
 			}
 


### PR DESCRIPTION
`main` is red on phan since 9e1edd0 (*Show code*), and still red on 3adff8b (*Trans code*). The phan artifact of the run on 3adff8b contains exactly two errors, both on the new "Current status" row of `supplierInvoiceCardBlock()`:

```
einvoicing/class/einvoicing.class.php:1945 PhanPossiblyUndeclaredVariable Variable $obj is possibly undeclared
einvoicing/class/einvoicing.class.php:1946 PhanPossiblyUndeclaredVariable Variable $obj is possibly undeclared
```

## Why

`$obj` is assigned inside the `if ($resql && num_rows > 0)` of the lifecycle query, but the new lines read `$obj->lc_status` after it, outside any guard.

This is not only a static analysis complaint. A hundred lines above, the same `$obj` name already received the row of the `einvoicing_extlinks` query, so when the invoice has no lifecycle message yet, the code does not read an undefined variable, it reads a property of **the wrong object** — the extlinks row.

Reproduced on the bench (Dolibarr 23, PHP 8.4), on a supplier invoice imported from a PDP that has no lifecycle message yet:

```
--- id=25 ref=(PROV25)
  !! PHP notice/warning: Undefined property: stdClass::$lc_status (einvoicing.class.php:1945)
  !! PHP notice/warning: Undefined property: stdClass::$lc_status (einvoicing.class.php:1946)
  <span id="einvoice-status" title="">-</span>
```

## Fix

The status code and the reason code are carried by their own variables, initialized before the query, so they are always defined whatever the query returns. The `title` attribute is only emitted when a code is known, instead of an empty `title=""`.

## Tests

Bench dd23 (Dolibarr 23.0, PHP 8.4), `supplierInvoiceCardBlock()` rendered on four real supplier invoices, before (3adff8b) and after:

| invoice | lifecycle | before | after |
|---|---|---|---|
| id 2732 | `212` | `title="212"` … `(Code 212)` | identical |
| id 256 | `210` + reason `MONTANTTOTAL_ERR` | `title="210"` … `(Code 210)`, reason `Montant total incorrect` | identical |
| id 2 | none | 2 PHP warnings, `title=""` | no warning, no `title` |
| id 25 | none | 2 PHP warnings, `title=""` | no warning, no `title` |

Rendering is byte for byte unchanged when a lifecycle message exists.

Static analysis, replayed locally with the CI configuration (`phan 5.5.2`, `--analyze-twice`, repo config + baseline): the two `PhanPossiblyUndeclaredVariable` are gone, only the two pre-existing polyfill-parser-only `helloasso` notices remain (they are absent from the CI artifact). `phpcs` with `dev/setup/codesniffer/ruleset.xml` is clean on the file.
