### PR TITLE
FIX #680 [einvoicing] The tables joined into the lists of Dolibarr carry an index

### DIFF
--- a/einvoicing/sql/dolibarr_allversions.sql
+++ b/einvoicing/sql/dolibarr_allversions.sql
@@ -49,3 +49,15 @@ ALTER TABLE llx_einvoicing_call ADD COLUMN call_id_num integer AFTER call_id;
 ALTER TABLE llx_einvoicing_call ADD COLUMN call_id_num integer AFTER call_id;
 
 ALTER TABLE llx_einvoicing_call ADD COLUMN request_id varchar(36) AFTER endpoint;
+
+ALTER TABLE llx_einvoicing_extlinks ADD INDEX idx_einvoicing_extlinks_element (element_type, element_id);
+
+ALTER TABLE llx_einvoicing_extlinks ADD INDEX idx_einvoicing_extlinks_syncref (element_type, syncref);
+
+ALTER TABLE llx_einvoicing_extlinks ADD INDEX idx_einvoicing_extlinks_flowid (flow_id);
+
+ALTER TABLE llx_einvoicing_lifecycle_msg ADD INDEX idx_einvoicing_lifecycle_msg_element (element_type, element_id, lc_validation_status);
+
+ALTER TABLE llx_einvoicing_lifecycle_msg ADD INDEX idx_einvoicing_lifecycle_msg_flowid (flow_id);
+
+ALTER TABLE llx_einvoicing_routing ADD INDEX idx_einvoicing_routing_soc (fk_soc, routing_type, active);

--- a/einvoicing/sql/llx_einvoicing_extlinks.key.sql
+++ b/einvoicing/sql/llx_einvoicing_extlinks.key.sql
@@ -1,0 +1,25 @@
+-- Copyright (C) 2026		Pierre Grasswill			<da.grumpf@gmail.com>
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see https://www.gnu.org/licenses/.
+
+-- The table is read by (element_type, element_id) on every card and, above all, it is joined to the
+-- invoice, supplier invoice and thirdparty lists of Dolibarr: without this index the whole table is
+-- re-scanned for each block of rows of the list, including for the record count of the page.
+ALTER TABLE llx_einvoicing_extlinks ADD INDEX idx_einvoicing_extlinks_element (element_type, element_id);
+
+-- Lookup by reference, used when the id of the element is not known (EInvoicing::fetchLastknownInvoiceStatus)
+ALTER TABLE llx_einvoicing_extlinks ADD INDEX idx_einvoicing_extlinks_syncref (element_type, syncref);
+
+-- Lookup by flow, used when a message of the Access Point carries only the flow identifier
+ALTER TABLE llx_einvoicing_extlinks ADD INDEX idx_einvoicing_extlinks_flowid (flow_id);

--- a/einvoicing/sql/llx_einvoicing_lifecycle_msg.key.sql
+++ b/einvoicing/sql/llx_einvoicing_lifecycle_msg.key.sql
@@ -1,0 +1,21 @@
+-- Copyright (C) 2026		Pierre Grasswill			<da.grumpf@gmail.com>
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see https://www.gnu.org/licenses/.
+
+-- The table is read by (element_type, element_id) on every card, and the supplier invoice list runs
+-- that same read as a correlated sub query, once per row displayed.
+ALTER TABLE llx_einvoicing_lifecycle_msg ADD INDEX idx_einvoicing_lifecycle_msg_element (element_type, element_id, lc_validation_status);
+
+-- Lookup by flow, used to gather the messages of a flow (EInvoicing::fetchStatusMessages)
+ALTER TABLE llx_einvoicing_lifecycle_msg ADD INDEX idx_einvoicing_lifecycle_msg_flowid (flow_id);

--- a/einvoicing/sql/llx_einvoicing_routing.key.sql
+++ b/einvoicing/sql/llx_einvoicing_routing.key.sql
@@ -1,0 +1,19 @@
+-- Copyright (C) 2026		Pierre Grasswill			<da.grumpf@gmail.com>
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see https://www.gnu.org/licenses/.
+
+-- Every read of the table selects the routing of one thirdparty, of one type, active or not
+-- (EInvoicing::fetchDefaultRouting, EInvoicing::fetchAllRoutings), and the thirdparty list of
+-- Dolibarr runs that read as a correlated sub query, once per row displayed.
+ALTER TABLE llx_einvoicing_routing ADD INDEX idx_einvoicing_routing_soc (fk_soc, routing_type, active);


### PR DESCRIPTION
Part of #680. Split out of #697 at @eldy's request — that PR carried five separate concerns, this is the database structure one and it stands alone.

**The five, all opened on `main` and mergeable in any order** (I merged them into `main` in all 120 permutations before opening: no conflict, and the result parses in every one):
- **this one** — the indexes
- the `ext.routing_id` filter that is an SQL error
- the `einvoicing_extlinks` join returning several rows
- the `einvoicing_routing` join returning several rows
- the columns unreachable on the cores that have no `completeArrayFields` hook

## What is missing

The module joins `llx_einvoicing_extlinks` and `llx_einvoicing_routing` into the invoice, supplier invoice and thirdparty lists of the core, and reads `llx_einvoicing_lifecycle_msg` as a correlated sub query on the supplier invoice list. None of the three tables carries an index, so every list re-scans them in full — including for the record count, which `list.php` builds on the same `FROM` clause and gives no `LIMIT`.

Every index added answers a read the module already performs:

| index | read it answers |
|---|---|
| `einvoicing_extlinks (element_type, element_id)` | every card, and every list join |
| `einvoicing_extlinks (element_type, syncref)` | `fetchLastknownInvoiceStatus()` when the id is unknown |
| `einvoicing_extlinks (flow_id)` | a message of the Access Point carrying only the flow id |
| `einvoicing_lifecycle_msg (element_type, element_id, lc_validation_status)` | every card, and the sub query of the supplier invoice list, once per row |
| `einvoicing_lifecycle_msg (flow_id)` | `fetchStatusMessages()` |
| `einvoicing_routing (fk_soc, routing_type, active)` | `fetchDefaultRouting()` / `fetchAllRoutings()`, and the thirdparty list |

## Measured

Bench of seven instances, Dolibarr 18.0.10 to 24.0.0 sharing one checkout of the module, PHP 8.4 / MariaDB 11.4. Data set: 20 100 invoices carrying 30 101 links.

| state | `COUNT(*)` of the customer invoice list |
|---|---|
| as shipped, no index | **32.9 s** |
| with the index | 0.046 s |

User-visible, same data, Dolibarr 22.0.5: `/compta/facture/list.php?limit=25` answered **HTTP 504 after 60 s**, three times in a row; 0.036 s with the index. `EXPLAIN` goes from `type: ALL, key: NULL, rows: 496, Using join buffer (flat, BNL join)` on `ext` to `type: eq_ref, key: PRIMARY, rows: 1`.

## Where the statements live

Three new `.key.sql` files, played on activation, and the same statements repeated in `dolibarr_allversions.sql` for installations that upgrade the core rather than reactivate the module.

Verified on the bench, Dolibarr 21.0.4: the six indexes dropped by hand, module deactivated and reactivated, the six are back.

