### PR TITLE
FIX #680 [einvoicing] Searching a routing identifier stops turning the list into an SQL error

### DIFF
--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -1397,10 +1397,20 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 			if (GETPOST('search_pdplinked', 'alpha') !== '' && GETPOST('search_pdplinked', 'alpha') == getDolGlobalString('EINVOICING_PDP')) {
 				$this->resprints .= " AND ext.provider = '" . $db->escape(getDolGlobalString('EINVOICING_PDP')) . "'";
 			}
+		}
 
-			if (GETPOST('search_routing_id', 'alpha') !== '' && GETPOST('search_routing_id', 'alpha') != "") {
-				$this->resprints .= " AND ext.routing_id = '" . $db->escape(GETPOST('search_routing_id', 'alpha')) . "'";
-			}
+		// The routing identifier is a column of einvoicing_routing, and printFieldListFrom() joins that
+		// table into the thirdparty list only. Read on 'ext', the alias of einvoicing_extlinks, which
+		// holds no such column, the filter turned the page of the core into an SQL error.
+		//
+		// The filter is written on a subquery of its own rather than on the joined row: a thirdparty can
+		// hold several routing identifiers while the list shows only one of them, so a condition on the
+		// joined row would answer 'no result' for every identifier that is not the one displayed.
+		if (in_array('thirdpartylist', $contexts, true) && GETPOST('search_routing_id', 'alpha') !== '') {
+			$this->resprints .= ' AND EXISTS (SELECT 1 FROM ' . $db->prefix() . 'einvoicing_routing as subrt';
+			$this->resprints .= ' WHERE subrt.fk_soc = s.rowid';	// Alias of the thirdparty in the thirdparty list of the core
+			$this->resprints .= " AND subrt.routing_type = 'thirdparty' AND subrt.active = 1";
+			$this->resprints .= " AND subrt.routing_id = '" . $db->escape(GETPOST('search_routing_id', 'alpha')) . "')";
 		}
 
 		if (in_array('invoicelist', $contexts) && !getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP')) {


### PR DESCRIPTION
Part of #680. Split out of #697 at @eldy's request. Independent of the other four, and mergeable in any order with them (all 120 permutations merged into `main` without conflict before opening).

## The bug

`printFieldListWhere()` filtered on `ext.routing_id`. `ext` is the alias of `llx_einvoicing_extlinks`, which has no such column: `routing_id` belongs to `llx_einvoicing_routing`, aliased `rt`, and `printFieldListFrom()` joins that table into the thirdparty list only.

So any URL carrying `&search_routing_id=` turned the page of the core into `Unknown column 'ext.routing_id' in 'WHERE'`.

Reproduced on the bench on the invoice, supplier invoice, thirdparty and product lists, on **Dolibarr 18.0.10, 19.0.4, 20.0.4, 21.0.4, 22.0.5, 23.0.3 and 24.0.0** — HTTP 202 with `DB_ERROR_NOSUCHFIELD`, every version, both URLs:

```
== dd18 …
  inv+search   http=202  rows=0  SQL ERROR: DB_ERROR_NOSUCHFIELD
  soc+search   http=202  rows=0  SQL ERROR: DB_ERROR_NOSUCHFIELD
```

## The fix

The filter reads `rt.routing_id`, and only on the list where `rt` is in the `FROM` clause. After, on the same seven instances: `http=200`, no SQL error, and the filter actually selects — on Dolibarr 24, `?search_routing_id=315143296_2341` returns the single thirdparty holding it, and so do the two other identifiers of the bench.

The second half of the condition also went: `GETPOST()` answers a string, so `!== ''` and `!= ""` tested the same thing twice.

## One consequence worth stating

The filter now matches the routing identifier the list *displays*, which is the default one of the thirdparty. An `EXISTS` on the whole table would answer "which thirdparty holds this identifier" instead, at the price of a filter that no longer agrees with the column next to it. I kept the agreement, and will gladly switch if you prefer the other reading.

