### PR TITLE
FIX #680 [einvoicing] The join on einvoicing_extlinks stops repeating the rows of a list

### DIFF
--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -1341,6 +1341,44 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	}
 
 	/**
+	 * Build the condition restricting the join on einvoicing_extlinks (aliased 'ext') to a single row.
+	 *
+	 * An element can carry several links: one per provider, and a provider can be registered both
+	 * directly and through a partner. Without this condition every extra link adds a line to the list
+	 * of the core and, because list.php builds its record count on the same FROM clause, the element
+	 * is counted as many times as it has links. The row kept here is the one
+	 * EInvoicing::fetchLastknownInvoiceStatus() would keep, so a list and a card never disagree.
+	 *
+	 * @param 	'facture'|'invoice_supplier'|'societe'|'product'	$elementtype	Value of einvoicing_extlinks.element_type, which also tells which list of the core is being built
+	 * @return 	string															Condition to append to the ON clause of the join
+	 */
+	protected static function getExtLinkJoinCondition($elementtype)
+	{
+		global $db;
+
+		// The 'ViaPartner' suffix tells how the provider is reached, not which provider it is.
+		$providershort = preg_replace('/ViaPartner$/', '', getDolGlobalString('EINVOICING_PDP'));
+		$sqlcurrentprovider = "sub.provider IN ('" . $db->escape($providershort) . "', '" . $db->escape($providershort . 'ViaPartner') . "')";
+
+		$sql = ' AND ext.rowid = (SELECT sub.rowid FROM ' . $db->prefix() . 'einvoicing_extlinks as sub';
+		$sql .= " WHERE sub.element_type = '" . $db->escape($elementtype) . "'";
+		if ($elementtype == 'societe') {
+			$sql .= ' AND sub.element_id = s.rowid';	// Alias of the thirdparty in the thirdparty list of the core
+		} elseif ($elementtype == 'product') {
+			$sql .= ' AND sub.element_id = p.rowid';	// Alias of the product in the product list of the core
+		} else {
+			$sql .= ' AND sub.element_id = f.rowid';	// Alias of the invoice in both invoice lists of the core
+		}
+		$sql .= ' ORDER BY CASE WHEN ' . $sqlcurrentprovider . ' THEN 0 ELSE 1 END,';
+		// fetchLastknownInvoiceStatus() keeps the LAST link read for the configured provider, but the
+		// FIRST one read for another provider, so the two cases do not order the rowid the same way.
+		$sql .= ' CASE WHEN ' . $sqlcurrentprovider . ' THEN -sub.rowid ELSE sub.rowid END';
+		$sql .= ' LIMIT 1)';
+
+		return $sql;
+	}
+
+	/**
 	 * Add FROM / JOIN
 	 *
 	 * @param array<string,mixed> 	$parameters		Array of parameters
@@ -1358,20 +1396,20 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 
 		if (array_intersect($contexts, ['invoicelist', 'supplierinvoicelist', 'thirdpartylist', 'productservicelist', 'societelist'])) {
 			if (in_array('thirdpartylist', $contexts, true)) {
-				$this->resprints .= ' LEFT JOIN ' . $db->prefix() . "einvoicing_extlinks as ext ON ext.element_id = s.rowid AND ext.element_type = 'societe'";
+				$this->resprints .= ' LEFT JOIN ' . $db->prefix() . "einvoicing_extlinks as ext ON ext.element_id = s.rowid AND ext.element_type = 'societe'" . self::getExtLinkJoinCondition('societe');
 				$this->resprints .= ' LEFT JOIN ' . $db->prefix() . "einvoicing_routing rt ON rt.fk_soc = s.rowid";
 			}
 
 			if (in_array('invoicelist', explode(':', $parameters['context']))) {
-				$this->resprints .= " LEFT JOIN " . $db->prefix() . "einvoicing_extlinks as ext ON ext.element_id = f.rowid AND ext.element_type = 'facture'";
+				$this->resprints .= " LEFT JOIN " . $db->prefix() . "einvoicing_extlinks as ext ON ext.element_id = f.rowid AND ext.element_type = 'facture'" . self::getExtLinkJoinCondition('facture');
 			}
 
 			if (in_array('supplierinvoicelist', $contexts, true)) {
-				$this->resprints .= ' LEFT JOIN ' . $db->prefix() . "einvoicing_extlinks as ext ON ext.element_id = f.rowid AND ext.element_type = 'invoice_supplier'";
+				$this->resprints .= ' LEFT JOIN ' . $db->prefix() . "einvoicing_extlinks as ext ON ext.element_id = f.rowid AND ext.element_type = 'invoice_supplier'" . self::getExtLinkJoinCondition('invoice_supplier');
 			}
 
 			if (in_array('productservicelist', $contexts, true)) {
-				$this->resprints .= ' LEFT JOIN ' . $db->prefix() . "einvoicing_extlinks as ext ON ext.element_id = p.rowid AND ext.element_type = 'product'";
+				$this->resprints .= ' LEFT JOIN ' . $db->prefix() . "einvoicing_extlinks as ext ON ext.element_id = p.rowid AND ext.element_type = 'product'" . self::getExtLinkJoinCondition('product');
 			}
 		}
 


### PR DESCRIPTION
Part of #680. Split out of #697 at @eldy's request. Independent of the other four, and mergeable in any order with them (all 120 permutations merged into `main` without conflict before opening).

## The bug

An element can carry several rows in `llx_einvoicing_extlinks`: one per provider, and a provider registered both directly and through a partner. `printFieldListFrom()` joined the table without restricting it to one row, so every extra link added a line to the list of the core — and, because `list.php` builds its record count on the same `FROM` clause, counted the element twice.

## Measured on the bench, before → after, without touching the data

Seven instances, Dolibarr 18.0.10 to 24.0.0, one checkout of the module, PHP 8.4 / MariaDB 11.4.

- customer invoice list, Dolibarr 24: `COUNT(*)` **137 for 118 invoices → 118**; first page **100 row links for 97 distinct invoices → 100 / 100**
- supplier invoice list: a second link added on one invoice made it appear twice (200 rows for 199 invoices) → **200 / 200**, and the row kept is the one of the configured provider
- the six other instances were already 1:1 and stay 1:1 — the fix adds no row and removes none

## Which row is kept

The one `EInvoicing::fetchLastknownInvoiceStatus()` would keep, so a list and a card never disagree: the link of the configured provider first — whether it is registered directly or through a partner, the `ViaPartner` suffix says *how* the provider is reached, not *which* provider it is — and the same tie-break on the `rowid` as the card, which is not the same direction in the two cases.

The condition is the same for the four lists the module joins the table into (customer invoice, supplier invoice, thirdparty, product), the alias of the id column being the only thing that changes.

## Note on the query plan

`ext.rowid = (SELECT … LIMIT 1)` makes the join *disappear* from the plan of the count query — outer join elimination: at most one row, and no column of it is read. So a "no index, deduplicated join" measurement that comes out faster than "no index, original join" is not a measurement error.

