### PR TITLE
FIX #680 [einvoicing] The join on einvoicing_routing stops repeating the thirdparties of the list

### DIFF
--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -1360,6 +1360,13 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 			if (in_array('thirdpartylist', $contexts, true)) {
 				$this->resprints .= ' LEFT JOIN ' . $db->prefix() . "einvoicing_extlinks as ext ON ext.element_id = s.rowid AND ext.element_type = 'societe'";
 				$this->resprints .= ' LEFT JOIN ' . $db->prefix() . "einvoicing_routing rt ON rt.fk_soc = s.rowid";
+				// A thirdparty can hold several routing identifiers, and a routing row for its default product
+				// on top of them, so joining on fk_soc alone repeats the thirdparty in the list as many times.
+				// The active default routing of type 'thirdparty' is the single row the list must show: it is
+				// the one the card of the thirdparty displays at the top of its list, and the one
+				// EInvoicing::fetchDefaultRouting() answers. The column stays empty for a thirdparty holding
+				// no routing identifier, so no row leaves the list.
+				$this->resprints .= " AND rt.routing_type = 'thirdparty' AND rt.active = 1 AND rt.is_default = 1";
 			}
 
 			if (in_array('invoicelist', explode(':', $parameters['context']))) {

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -3012,8 +3012,8 @@ class EInvoicing
 
 		$db->begin();
 
-		// Check if this entry was the default
-		$sql = "SELECT is_default FROM " . $db->prefix() . "einvoicing_routing";
+		// Check if this entry was the default, and for which type of routing
+		$sql = "SELECT is_default, routing_type FROM " . $db->prefix() . "einvoicing_routing";
 		$sql .= " WHERE rowid = " . (int) $rowid;
 		$resql = $db->query($sql);
 		if (!$resql) {
@@ -3023,6 +3023,7 @@ class EInvoicing
 		}
 		$obj = $db->fetch_object($resql);
 		$wasDefault = $obj ? (int) $obj->is_default : 0;
+		$routingtype = $obj ? $obj->routing_type : '';
 		$db->free($resql);
 
 		$sql = "DELETE FROM " . $db->prefix() . "einvoicing_routing";
@@ -3033,11 +3034,15 @@ class EInvoicing
 			return -1;
 		}
 
-		// Reassign default to oldest remaining entry if needed
+		// Reassign default to oldest remaining entry of the same type if needed. Without the filter on
+		// routing_type, a routing of the other type could take the default and leave the remaining entries
+		// of the deleted type without any, so fetchDefaultRouting() would answer nothing for a thirdparty
+		// that still holds an active routing identifier.
 		if ($wasDefault) {
 			$sql = "UPDATE " . $db->prefix() . "einvoicing_routing";
 			$sql .= " SET is_default = 1";
 			$sql .= " WHERE fk_soc = " . (int) $fk_soc . " AND active = 1";
+			$sql .= " AND routing_type = '" . $db->escape($routingtype) . "'";
 			$sql .= " ORDER BY rowid ASC LIMIT 1";
 			$db->query($sql); // Non-blocking: if no rows remain, nothing to reassign
 		}


### PR DESCRIPTION
Part of #680. Split out of #697 at @eldy's request. #713, #714 and #715 are merged; this one and #717 are independent of each other and of what is already in `main`.

Updated after @eldy's review: the correlated subquery is gone, the join now carries the three criteria he asked for.

## The bug

A thirdparty can hold several routing identifiers, and a routing row for its default product on top of them. `printFieldListFrom()` joined `llx_einvoicing_routing` on `fk_soc` alone, so the thirdparty list of the core repeated the thirdparty once per row of the table, and its record count with it.

## The fix

```php
LEFT JOIN llx_einvoicing_routing rt ON rt.fk_soc = s.rowid
  AND rt.routing_type = 'thirdparty' AND rt.active = 1 AND rt.is_default = 1
```

`is_default = 1` designates exactly one row: `addRouting()` sets it on the first active routing of the type, and `setDefaultRouting()` / `setRoutingAsDefault()` both clear the flag on the other rows of the same type before setting it. The row it designates is the one the card of the thirdparty shows at the top of its list, and the one `fetchDefaultRouting()` answers. It stays a `LEFT JOIN`: a thirdparty holding no routing identifier keeps an empty column instead of leaving the list.

## `deleteRouting()` had to filter the type as well

There was one reachable state where `is_default = 1` designated no row at all. When the default was deleted from the card, `deleteRouting()` promoted the next entry with `WHERE fk_soc = X AND active = 1 ORDER BY rowid ASC LIMIT 1`, **without filtering `routing_type`**. A `product` routing with a lower rowid took the default, and the surviving `thirdparty` routing kept `is_default = 0` — so `fetchDefaultRouting()` answered nothing for a thirdparty that still held an active identifier and still emitted with it.

Reproduced on the seven instances, one thirdparty holding a `product` routing then two active `thirdparty` routings, default deleted from the card:

| | before the delete | after the delete, `main` | after the delete, this PR |
|---|---|---|---|
| `is_default` of the surviving `thirdparty` routing | 0 | **0** | **1** |
| `fetchDefaultRouting()` | `0225:111111111` | **nothing** | `0225:222222222` |
| column of the list | `0225:111111111` | **empty** | `0225:222222222` |

## Measured on the bench, before → after, without touching the data

Seven instances, Dolibarr 18.0.10 to 24.0.0. Thirdparty list of the core, `?limit=100`, over HTTP as a real user.

| instance | rows / distinct thirdparties, `main` | this PR |
|---|---|---|
| Dolibarr 23.0.4 | 33 / 32 | **32 / 32** |
| Dolibarr 24.0.0 | 15 / 14 | **14 / 14** |

The five other instances hold one routing per thirdparty and were already 1:1; they stay 1:1. The four lists the module completes answer `200` with no SQL error on all seven, and the search on the routing identifier of #714 still finds a thirdparty by **every** one of its active identifiers, not only by the default one the column now shows (negative control `ZZZ-INEXISTANT` = 0 thirdparty). PHPUnit 21/21 on Dolibarr 18 to 24.
