### PR TITLE
FIX #680 [einvoicing] The columns of the module become reachable on the cores that have no completeArrayFields hook

### DIFF
--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -565,6 +565,13 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	{
 		global $db, $langs, $user, $conf;
 
+		// Before anything else, and before the early return below: a list of the core builds its
+		// $arrayfields before it knows any action, and the versions that offer no 'completeArrayFields'
+		// hook pass the array by reference here instead. See addFieldsToList().
+		if (isset($parameters['arrayfields'])) {
+			self::addFieldsToList($parameters['arrayfields'], $parameters['context']);
+		}
+
 		if (empty($action)) {
 			return 0;
 		}
@@ -1510,16 +1517,39 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 */
 	public function completeArrayFields($parameters, $object, &$action, $hookmanager)
 	{
-		if (in_array('invoicelist', explode(':', $parameters['context'])) && (!getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP') || getDolGlobalString('EINVOICING_ONLY_GENERATE'))) {
+		if (isset($parameters['arrayfields'])) {
+			self::addFieldsToList($parameters['arrayfields'], $parameters['context']);
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Declare the columns of the module in the list of fields a list of the core offers to display.
+	 *
+	 * Called from two hooks on purpose: the core runs 'completeArrayFields' only from Dolibarr 22 on
+	 * the customer invoice list and 23 on the two others, while 'doActions' gets the same array by
+	 * reference from 18, 19 and 20. Without both, the checkboxes of the module do not exist at all on
+	 * the older cores. Writing the same keys twice, where both hooks run, changes nothing.
+	 *
+	 * @param 	array<string,mixed>	$arrayfields	Fields of the list, as the core passes them by reference
+	 * @param 	string				$context		Value of $parameters['context'] as the hook manager builds it
+	 * @return 	void
+	 */
+	protected static function addFieldsToList(&$arrayfields, $context)
+	{
+		$contexts = explode(':', $context);
+
+		if (in_array('invoicelist', $contexts, true) && (!getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP') || getDolGlobalString('EINVOICING_ONLY_GENERATE'))) {
 			// Add fields to invoice list
-			$parameters['arrayfields']['einvoicegenerated'] = array(
+			$arrayfields['einvoicegenerated'] = array(
 				'label' => 'EInvoiceFile',
 				'checked' => -1,
 				'position' => 900,
 				'enabled' => 1,
 				'perms' => '1'
 			);
-			$parameters['arrayfields']['pdp_syncstatus'] = array(
+			$arrayfields['pdp_syncstatus'] = array(
 				'label' => 'PDPSyncStatus',
 				'checked' => 1,
 				'position' => 901,
@@ -1528,10 +1558,10 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 			);
 		}
 
-		if (in_array('thirdpartylist', explode(':', $parameters['context']))) {
+		if (in_array('thirdpartylist', $contexts, true)) {
 			// Routing ID column: kept even under EINVOICING_ONLY_GENERATE, like the field on the thirdparty card.
 			if (!getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP') || !getDolGlobalString('EINVOICING_DISABLE_SYNC_AP_TO_DOLI') || getDolGlobalString('EINVOICING_ONLY_GENERATE')) {
-				$parameters['arrayfields']['routing_id'] = array(
+				$arrayfields['routing_id'] = array(
 					'label' => 'RoutingIdField',
 					'help' => 'SpecificRoutingFieldHelp',
 					'checked' => -1,
@@ -1542,7 +1572,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 			}
 			// Default product for import: reception only.
 			if (!einvoicingIsReceiveDisabled()) {
-				$parameters['arrayfields']['routing_product_id'] = array(
+				$arrayfields['routing_product_id'] = array(
 					'label' => 'DefaultProductEBilling',
 					'checked' => -1,
 					'position' => 901,
@@ -1551,8 +1581,6 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 				);
 			}
 		}
-
-		return 0;
 	}
 
 
@@ -1891,7 +1919,9 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 
 
 		if (in_array('thirdpartylist', explode(':', $parameters['context'])) && (!getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP') || !getDolGlobalString('EINVOICING_DISABLE_SYNC_AP_TO_DOLI') || getDolGlobalString('EINVOICING_ONLY_GENERATE'))) {
-			if (!empty($parameters['arrayfields']['einvoicegenerated']['checked'])) {
+			// 'routing_id' is the field addFieldsToList() declares for that list; 'einvoicegenerated' is the
+			// one of the invoice list, so the column of the thirdparty list never followed its own checkbox
+			if (!empty($parameters['arrayfields']['routing_id']['checked'])) {
 				print '<td class="liste_titre">';
 				print '<input type="text" name="search_routing_id" value="' . dolPrintHTMLForAttribute(GETPOST('search_routing_id', 'alpha')) . '" class="minwidth50 maxwidth100">';
 				print '</td>';
@@ -1950,7 +1980,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 		}
 
 		if (in_array('thirdpartylist', $contexts) && (!getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP') || !getDolGlobalString('EINVOICING_DISABLE_SYNC_AP_TO_DOLI') || getDolGlobalString('EINVOICING_ONLY_GENERATE'))) {
-			if (!empty($parameters['arrayfields']['einvoicegenerated']['checked'])) {
+			if (!empty($parameters['arrayfields']['routing_id']['checked'])) {
 				print_liste_field_titre($langs->transnoentitiesnoconv('einvoicingThirdPartyRoutingTitle'));
 			}
 		}
@@ -2059,7 +2089,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 		}
 
 		if (in_array('thirdpartylist', explode(':', $parameters['context']), true)) {
-			if (!empty($parameters['arrayfields']['einvoicegenerated']['checked'])) {
+			if (!empty($parameters['arrayfields']['routing_id']['checked'])) {
 				$obj = $parameters['obj'];
 
 				print '<td class="tdoverflowmax125">';


### PR DESCRIPTION
Part of #680. Split out of #697 at @eldy's request. #713, #714 and #715 are merged; this one and #716 are independent of each other and of what is already in `main`.

## The bug

The module declares its columns from the `completeArrayFields` hook alone. The core only executes that hook from **Dolibarr 22** on the customer invoice list, and from **23** on the supplier invoice and thirdparty lists — read in `compta/facture/list.php`, `fourn/facture/list.php` and `societe/list.php` on 18, 19, 20, 21, 22, 23 and 24. Below those versions the checkboxes of the module simply do not exist, so its columns can never be displayed at all.

Those same versions *do* pass `$arrayfields` by reference to `doActions`:

| list | `doActions` carries `arrayfields` from | `completeArrayFields` executed from |
|---|---|---|
| customer invoice | **18** | 22 |
| supplier invoice | **19** | 23 |
| thirdparty | **20** | 23 |

## The fix

The declaration moves to `addFieldsToList()` and is called from both hooks. Writing the same keys twice, where both hooks run, changes nothing.

Two details that matter and are easy to get wrong:
- `$action` is empty on a normal list load, so the declaration has to happen **before** the `if (empty($action)) return 0;` of the module's `doActions`.
- `checked` is set by `multiSelectArrayWithCheckbox($…, &$arrayfields, …)`, well after `doActions` runs, so the order is right.

Measured on the bench, "is the column offered in the *select columns* menu of the list", replayed on the current `main` (so with #713, #714 and #715 in), seven instances from Dolibarr 18.0.10 to 24.0.0:

| instance | invoice / `einvoicegenerated` | thirdparty / `routing_id` |
|---|---|---|
| 18.0.10 | absent → **offered** | absent, and stays absent |
| 19.0.4 | absent → **offered** | absent, and stays absent |
| 20.0.4 | absent → **offered** | absent → **offered** |
| 21.0.4 | absent → **offered** | absent → **offered** |
| 22.0.5 | offered | absent → **offered** |
| 23.0.4 | offered | offered |
| 24.0.0 | offered | offered |

18 and 19 stay without the thirdparty column: `societe/list.php` passes `$arrayfields` to no hook at all there, which no module can work around.

## And the column it declares was read under another name

On the thirdparty list, the header, the search input and the cell of the routing identifier all tested `$arrayfields['einvoicegenerated']` — the field of the *invoice* list. So the column never followed its own checkbox. They read `routing_id` now, the field declared for that list. That is why the table above shows the thirdparty column as *rendered* from 20, and not merely declared.
