### PR TITLE
FIX [einvoicing] A header allowance no longer breaks the whole synchronization on Dolibarr 18 and 19

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -3305,6 +3305,11 @@ class CIIProtocol extends AbstractProtocol
 			}
 
 			$remise = new DiscountAbsolute($db);
+			// Both properties carry the thirdparty, because the core does not read the same one everywhere:
+			// DiscountAbsolute::create() inserts fk_soc up to Dolibarr 19 and socid from Dolibarr 20 on. Filling
+			// only one of them writes fk_soc = 0 on the older cores, which the foreign key of
+			// llx_societe_remise_except refuses - and the whole synchronization stops on that flow.
+			$remise->fk_soc         = $fk_soc;
 			$remise->socid          = $fk_soc;
 			$remise->amount_ht       = $actualAmount;
 			$remise->amount_tva      = round($actualAmount * (($allowanceCharge['rateApplicablePercent'] ?? 0) / 100), 2);


### PR DESCRIPTION
## Problem

A received invoice carrying a **document level allowance** (BT-107) stops the **whole** incoming
synchronization of the instance on Dolibarr 18 and 19. Not just that invoice: `syncFlow()` returns
`-1`, `syncFlows()` breaks out of its loop, and every flow queued behind it stays pending until
somebody intervenes by hand.

`createHeaderDiscounts()` turns that allowance into a discount exception, and filled a single
property before creating it:

```php
$remise = new DiscountAbsolute($db);
$remise->socid = $fk_soc;
```

`DiscountAbsolute::create()` does not read the same property on every core. The column is `fk_soc`
everywhere; the property behind it is not:

| core | what `create()` inserts |
|---|---|
| 18.0.10, 19.0.4 | `$this->fk_soc` |
| 20.0.4 → 24.0.0 | `$this->socid` |

So on 18 and 19 the row went in with `fk_soc = 0`, and the foreign key refused it:

```
Cannot add or update a child row: a foreign key constraint fails
(`dolibarr_dd18`.`llx_societe_remise_except`, CONSTRAINT `fk_soc_remise_fk_soc`
FOREIGN KEY (`fk_soc`) REFERENCES `llx_societe` (`rowid`))
 - sql=INSERT INTO llx_societe_remise_except (entity, datec, fk_soc, ...) VALUES (1, ..., 0, ...)
```

`fk_soc` is annotated `@deprecated` on 18 and 19 while `create()` still reads it, and `fetch()` does
not fill `socid` there either — so writing the modern property alone, which is what one does after
reading the class, is a silent no-op on exactly the two oldest supported cores.

The core protects itself against its own rename: from 20 on, **all eight** places where it creates a
discount exception set **both** properties — `Societe::set_remise_except()`, `comm/remx.php`,
`commande/list.php`, `reception/list.php`, `PaiementFourn::create()`, `Paiement::create()`,
`compta/facture/card.php` and `fourn/facture/card.php`. On 19 those same eight set `fk_soc` alone
(bar one). And `discount.class.php` is the only class of the core whose `create()` changed property
between 19 and 23 — checked class by class over both trees.

**Why it surfaces now.** The path has existed since the header-discount support was added, but a
document level allowance is rare in the wild and nothing on the bench produced one. The fix for #674
made this module emit exactly that shape for every situation invoice from the second on, so the
import branch went from never exercised to routine, and took two instances down for three days.

## What this does

Fill both properties, the way `getOrCreateDepositDiscount()` — the deposit path of the same file,
the one every ordinary import goes through — has done since the beginning:

```php
$remise->fk_soc = $fk_soc;
$remise->socid  = $fk_soc;
```

One line, plus the comment saying why both. `FacturXProtocol` inherits `createHeaderDiscounts()`, so
the Factur-X path is fixed with the plain CII one.

The rest of the module was checked for the same shape: it creates a `DiscountAbsolute` in two places
only, and the other one already filled both. No other object it writes has the ambiguity.

## Tested

Live on the bench, on this branch deployed there, seven cores: **18.0.10, 19.0.4, 20.0.4, 21.0.4,
22.0.5, 23.0.4 and 24.0.0**.

**The core behaviour, isolated.** A discount exception created with `socid` alone, then with both,
inside a transaction that is rolled back:

| core | `socid` alone | both |
|---|---|---|
| 18.0.10 | `-1`, foreign key refused | OK, `fk_soc` correct |
| 19.0.4 | `-1`, foreign key refused | OK, `fk_soc` correct |
| 20.0.4 → 24.0.0 | OK | OK |

**End to end, the real shape.** A situation invoice n°2 issued through the Access Point sandbox — its
document carries one allowance of 600.00, "Deduction of the situations already invoiced", for an
instalment of 800.00. Imported on all seven receiving instances:

```
dd18   18.0.10  : supplier invoice #5419  total_ht=800  | discount#171 fk_soc=7 ht=600
dd19   19.0.4   : supplier invoice #3792  total_ht=800  | discount#149 fk_soc=1 ht=600
dd20   20.0.4   : supplier invoice #4619  total_ht=800  | discount#29  fk_soc=7 ht=600
dd21   21.0.4   : supplier invoice #3848  total_ht=800  | discount#8   fk_soc=1 ht=600
dd22   22.0.5   : supplier invoice #3824  total_ht=800  | discount#28  fk_soc=1 ht=600
dd23   23.0.4   : supplier invoice #5611  total_ht=800  | discount#165 fk_soc=1 ht=600
dd24   24.0.0   : supplier invoice #4634  total_ht=800  | discount#29  fk_soc=1 ht=600
```

**Negative control**, same bench, same flow, the fix removed and put back:

| | without the fix | with the fix |
|---|---|---|
| dd18 | `res: -1`, `syncedFlows: 0`, "Aborting synchronization due to errors" | `res: 1`, `syncedFlows: 1`, discount created |
| dd19 | `res: -1`, `syncedFlows: 0`, "Aborting synchronization due to errors" | `res: 1`, `syncedFlows: 1`, discount created |
| dd23 | `res: 1`, imported | `res: 1`, imported |

dd23 importing the same flow while 18 and 19 abort is what proves the cause is the property and not
the document.

**No regression.** The full lifecycle matrix — every supported version, both directions, issue →
route → import → approve (205) → pay (211) → cash in (212): **14 cycles out of 14**. PHPUnit over the
whole grid, seven instances × 17 files: **119 runs, 119 OK**. `php -l` and the repository's phpcs
ruleset clean on the changed file.
