### PR TITLE
NEW [einvoicing] The VAT category of a line is read from its VAT code (reverse charge, AE)

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -2,6 +2,22 @@
 
 ## 1.1.0
 
+NEW: The VAT category of a line (BT-151) is read from the VAT code the line carries, so a document can
+declare a regime the rate alone cannot tell. A rate of zero covers zero rated, exempt, reverse charge,
+export and intra-community supplies alike, and the generator used to answer exempt for all of them: a
+building trade subcontractor, whose customer declares the tax under article 283, 2 nonies of the CGI,
+could not issue a single valid invoice. The category is the segment of the code before its first dash -
+'AE' and 'AE-IC' are both reverse charge - and the exemption reason (BT-120) is the note of the
+dictionary line, so two regimes sharing one category quote the article that is theirs. The exemption
+reason code (BT-121) is the one of the dictionary line where the core holds it, the standard code of the
+regime otherwise - VATEX-FR-AE for a French seller under the reverse charge, which names article 283
+of the CGI the invoice has to quote, VATEX-EU-AE for the sellers of the other member states, and
+VATEX-EU-G and VATEX-EU-IC for exports and intra-community supplies. A code the dictionary does not translate is
+still refused by name rather than answered with a guess, a reverse charge code on a taxed rate is
+reported on BR-AE-05 instead of building a document the platform rejects, and a reverse charge line that
+names only one of the two parties is reported on BR-AE-02 or BR-AE-03. Lines with no code, and taxed
+lines, are built exactly as before.
+
 FIX: The remote information of the SuperPDP setup page now describes the e-invoice address the module
 really sends with. A company can hold several entries in the French directory at once - one per
 document family, '<siren>_Invoice' or '<siren>_Status', beside the bare identifier - and the screen

--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -1498,7 +1498,7 @@ trait CommonProtocol
 	 * @param 	CommonInvoiceLine		$line			Invoice line
 	 * @param 	Societe 				$seller			Seller
 	 * @param 	CommonInvoice			$buyer			Invoice the line belongs to, whose ->thirdparty is the buyer. Not a Societe: the single caller passes the invoice, and the buyer is read through it below.
-	 * @return 	array<string,string>					array('categoryVAT' => Category of VAT rate ('S', 'K', 'E', 'G'), 'ExemptionReason' => '', 'ExemptionReasonCode => '')
+	 * @return 	array<string,string>					array('categoryVAT' => Category of VAT rate ('S', 'Z', 'E', 'AE', 'K', 'G'), 'ExemptionReason' => '', 'ExemptionReasonCode => '')
 	 */
 	public function getCategoryRate($line, $seller, $buyer)
 	{
@@ -1621,6 +1621,93 @@ trait CommonProtocol
 				// satisfied by the reason text alone.
 				$exemptionReason = 'VAT not collected';
 			}
+			$exemptionReason = $exemptionReason ?: ($VATEX_CODE_LIST[(string) $exemptionReasonCode]['reason'] ?? $exemptionReasonCode);
+
+			return array('categoryVAT' => $categoryVAT, 'ExemptionReason' => $exemptionReason, 'ExemptionReasonCode' => $exemptionReasonCode);
+		}
+
+		// The VAT code the line carries (vat_src_code, the code column of the VAT dictionary) states the
+		// regime the line is invoiced under, and that regime is what BT-151 asks for. It is read here rather
+		// than deduced from the rate, because a rate of zero covers Z, E, AE, G and K alike: a generator that
+		// guesses from the rate builds a document that is valid and wrong, and BR-AE-05 and its siblings only
+		// catch the guesses that get the rate wrong as well.
+		//
+		// The category is the segment of the code before its first dash, so 'AE' and 'AE-IC' are both reverse
+		// charge and a dictionary can tell apart two regimes that share one category. A code that does not
+		// open on a category the module supports - a code holding a VATEX identifier, or any code an existing
+		// installation already uses - is left to the rules below, unchanged.
+		$declaredCategoryVAT = $this->_getVatCategoryFromVatCode($vat_src_code);
+
+		if ($declaredCategoryVAT !== '' && $declaredCategoryVAT !== 'S') {
+			// BR-AE-05, BR-E-05, BR-G-05, BR-K-05 and BR-Z-05: none of these categories is ever invoiced on a
+			// taxed rate. A line stating one of them at a rate above zero contradicts its own dictionary entry,
+			// and either of the two answers would build a document the Schematron refuses.
+			if ((float) $vat_rate != 0) {
+				throw new Exception('BADVATRATE[BR-'.$declaredCategoryVAT.'-05]: The VAT code \''.$vat_src_code.'\''.($id ? ' on line '.$id : '').' declares the VAT category '.$declaredCategoryVAT.', which EN 16931 only allows on a rate of 0, while the rate of the line is '.$vat_rate.'.');
+			}
+
+			$categoryVAT = $declaredCategoryVAT;
+
+			if ($categoryVAT == 'Z') {
+				// BR-Z-09 and BR-Z-10: a zero rated line is taxed, at zero, and must carry no exemption reason.
+				return array('categoryVAT' => $categoryVAT, 'ExemptionReason' => null, 'ExemptionReasonCode' => null);
+			}
+
+			if ($categoryVAT == 'AE') {
+				// BR-AE-02 and BR-AE-03: a reverse charge line names both parties, since the tax is declared by
+				// the one that receives the supply. The seller answers with its VAT identifier (BT-31) or its tax
+				// registration identifier (BT-32), the buyer with its VAT identifier (BT-48) or its legal
+				// registration identifier (BT-47). Reporting it here names the record to complete; left to the
+				// Schematron it comes back from the platform as a rejected document.
+				$buyerThirdparty = empty($buyer->thirdparty) ? null : $buyer->thirdparty;
+				if (empty($seller->tva_intra) && empty($seller->idprof1)) {
+					throw new Exception('BADVATNUMBER[BR-AE-02]: The VAT number or the professional id of the seller '.$seller->name.' is mandatory when a line is invoiced under the reverse charge (VAT category AE).');
+				}
+				if ($buyerThirdparty !== null && empty($buyerThirdparty->tva_intra) && empty($buyerThirdparty->idprof1)) {
+					throw new Exception('BADVATNUMBER[BR-AE-03]: The VAT number or the legal registration id of the customer '.$buyerThirdparty->name.' is mandatory when a line is invoiced under the reverse charge (VAT category AE).');
+				}
+			}
+
+			$dictionaryEntry = $this->_getVatDictionaryEntry($vat_rate, $vat_src_code);
+
+			// BT-120 is the note of the dictionary line, and nothing else: two regimes may share a category and
+			// quote different articles - subcontracting in the building trade answers to article 283, 2 nonies
+			// of the CGI where an intra-community supply answers to article 283-1 - and only the note of the
+			// line the invoice actually used tells them apart. Hard coding it would state one for the other.
+			$exemptionReason = $dictionaryEntry['note'];
+			$exemptionReasonCode = $dictionaryEntry['einvoice_vatex'];
+
+			if (empty($exemptionReasonCode)) {
+				// Dolibarr 23 and below have no einvoice_vatex column in the dictionary; there the code is the
+				// hidden constant the module already documents for the exempt lines.
+				$exemptionReasonCode = strtoupper(getDolGlobalString('MAIN_VAT_EXEMPTION_CODE_FOR_'.price2num($vat_rate, 2).'_'.strtoupper($vat_src_code)));
+			}
+			if (empty($exemptionReasonCode)) {
+				// The regime itself has a code in the VATEX list for AE, G and K, so those need no setup at all.
+				// E has none: what exempts the line is the article it quotes, which only the dictionary knows.
+				// A French seller quotes the French code of the reverse charge, which names the article the
+				// mention on the invoice has to name - article 283 of the CGI - where VATEX-EU-AE only says
+				// "reverse charge". Sellers of the other member states have that one and nothing more precise.
+				$defaultVatexOfCategory = array(
+					'AE' => 'VATEX-'.($seller->country_code == 'FR' ? 'FR' : 'EU').'-AE',
+					'G' => 'VATEX-EU-G',
+					'K' => 'VATEX-EU-IC',
+				);
+				$exemptionReasonCode = isset($defaultVatexOfCategory[$categoryVAT]) ? $defaultVatexOfCategory[$categoryVAT] : '';
+			}
+
+			if (empty($exemptionReason) && empty($exemptionReasonCode)) {
+				// BR-AE-10, BR-E-10, BR-G-10 and BR-K-10 all ask for one of the two, and the module does not
+				// invent either: it names the code it could not translate, as it does everywhere else.
+				$langs->load("compta");
+				$urltovatdic = DOL_URL_ROOT.'/admin/dict.php?id=10';
+				$errormsg = $langs->trans("UnknownVATEX1", $id, '0', $vat_src_code);
+				$errormsg .= '<br>'.$langs->trans("UnknownVATEX2b", '0', ($vat_src_code ? $vat_src_code : "''"), $urltovatdic, $langs->trans("VATExemptionCode"));
+
+				throw new Exception('MISSINGSETUP: '.$errormsg);
+			}
+
+			// If we have a code but no reason, we try to find the reason in the list of VATEX codes, otherwise we use the code as reason.
 			$exemptionReason = $exemptionReason ?: ($VATEX_CODE_LIST[(string) $exemptionReasonCode]['reason'] ?? $exemptionReasonCode);
 
 			return array('categoryVAT' => $categoryVAT, 'ExemptionReason' => $exemptionReason, 'ExemptionReasonCode' => $exemptionReasonCode);
@@ -1778,6 +1865,73 @@ trait CommonProtocol
 
 		return array('categoryVAT' => $categoryVAT, 'ExemptionReason' => $exemptionReason, 'ExemptionReasonCode' => $exemptionReasonCode);
 	}
+
+	/**
+	 * Read the EN 16931 VAT category the VAT code of a line declares.
+	 *
+	 * The category is the segment of the code before its first dash. That is a convention of the data,
+	 * not a guess about it: a dictionary that needs to tell apart two regimes sharing one category names
+	 * them 'AE' and 'AE-IC', and both are answered reverse charge without a line of code being written
+	 * for the second one.
+	 *
+	 * @param	string	$vat_src_code	Code of the VAT dictionary line the invoice line was built with
+	 * @return	string					VAT category of EN 16931 (BT-151), '' when the code declares none
+	 */
+	private function _getVatCategoryFromVatCode($vat_src_code)
+	{
+		// The categories of UNTDID 5305 this generator issues documents for. L and M (Canary Islands, Ceuta
+		// and Melilla) and O (outside the scope of VAT) are left out on purpose: each answers to rules of
+		// its own that the rest of the document does not honour yet, so a code opening on one of them is
+		// not taken at its word and keeps going through the rules that follow.
+		$supportedCategories = array('S', 'Z', 'E', 'AE', 'K', 'G');
+
+		$code = strtoupper(trim((string) $vat_src_code));
+		if ($code === '') {
+			return '';
+		}
+
+		$dash = strpos($code, '-');
+		$category = ($dash === false ? $code : substr($code, 0, $dash));
+
+		return in_array($category, $supportedCategories, true) ? $category : '';
+	}
+
+	/**
+	 * Read the VAT dictionary line a rate and a code point to.
+	 *
+	 * @param	float|string	$vat_rate		VAT rate of the invoice line
+	 * @param	string			$vat_src_code	Code of the VAT dictionary line the invoice line was built with
+	 * @return	array{note:string,einvoice_vatex:string}	Empty strings when the dictionary holds no such line
+	 */
+	private function _getVatDictionaryEntry($vat_rate, $vat_src_code)
+	{
+		global $db, $mysoc;
+
+		$entry = array('note' => '', 'einvoice_vatex' => '');
+
+		// The column holding the VATEX code of a dictionary line appeared with Dolibarr 24. Below that
+		// version the note is all the dictionary has to say about the line.
+		$hasVatexColumn = ((float) DOL_VERSION >= 24.0);
+
+		$sql = "SELECT note".($hasVatexColumn ? ", einvoice_vatex" : "")." FROM ".MAIN_DB_PREFIX."c_tva";
+		$sql .= " WHERE taux = ".((float) $vat_rate);
+		$sql .= " AND active = 1";
+		$sql .= " AND fk_pays = ".((int) $mysoc->country_id);
+		$sql .= " AND code = '".$db->escape($vat_src_code)."'";
+		$sql .= " LIMIT 1";
+
+		$resql = $db->query($sql);
+		if ($resql) {
+			$obj = $db->fetch_object($resql);
+			if ($obj) {
+				$entry['note'] = trim((string) $obj->note);
+				$entry['einvoice_vatex'] = ($hasVatexColumn ? strtoupper(trim((string) $obj->einvoice_vatex)) : '');
+			}
+		}
+
+		return $entry;
+	}
+
 
 
 	/**

--- a/einvoicing/test/phpunit/AllTests.php
+++ b/einvoicing/test/phpunit/AllTests.php
@@ -133,6 +133,8 @@ class AllTests
 		$suite->addTestSuite('SupplierInvoiceHelperTest');
 		require_once dirname(__FILE__).'/TransmittedLockTest.php';
 		$suite->addTestSuite('TransmittedLockTest');
+		require_once dirname(__FILE__).'/VatCategoryFromVatCodeTest.php';
+		$suite->addTestSuite('VatCategoryFromVatCodeTest');
 		require_once dirname(__FILE__).'/VatPointDateCodeTest.php';
 		$suite->addTestSuite('VatPointDateCodeTest');
 

--- a/einvoicing/test/phpunit/VatCategoryFromVatCodeTest.php
+++ b/einvoicing/test/phpunit/VatCategoryFromVatCodeTest.php
@@ -1,0 +1,285 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/VatCategoryFromVatCodeTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for the VAT category of a line, BT-151.
+ *                  A rate of 0 covers Z, E, AE, G and K alike, so the category is read from the VAT
+ *                  code the line carries and never deduced from the rate: the code is the only place
+ *                  the regime is stated. What the dictionary does not state, the module refuses to
+ *                  invent - it names the code it could not translate instead.
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+// See VatPointDateCodeTest for why DOLIBARR_HTDOCS is honoured before the relative path.
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
+dol_include_once('einvoicing/class/protocols/CIIProtocol.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class VatCategoryFromVatCodeTest extends CommonClassTest
+{
+	/**
+	 * An invoice line, reduced to what getCategoryRate() reads on it.
+	 *
+	 * @param	float|string	$rate			->tva_tx
+	 * @param	string			$vatCode		->vat_src_code, the code of the VAT dictionary line used
+	 * @return	stdClass
+	 */
+	private function line($rate, $vatCode)
+	{
+		$line = new stdClass();
+		$line->id = 310;
+		$line->tva_tx = $rate;
+		$line->vat_src_code = $vatCode;
+		$line->info_bits = 0;
+
+		return $line;
+	}
+
+	/**
+	 * A seller, described the way Societe::setMysoc() describes $mysoc.
+	 *
+	 * @param	string	$vatNumber	Intra-community VAT number, '' for a company that has none
+	 * @param	string	$siren		Professional id 1
+	 * @return	Societe
+	 */
+	private function seller($vatNumber = 'FR75911270304', $siren = '911270304')
+	{
+		global $db;
+
+		$seller = new Societe($db);
+		$seller->name = 'Seller';
+		$seller->tva_assuj = 1;
+		$seller->tva_intra = $vatNumber;
+		$seller->idprof1 = $siren;
+		$seller->country_code = 'FR';
+
+		return $seller;
+	}
+
+	/**
+	 * The invoice the line belongs to, whose ->thirdparty is the buyer: that is what the single caller
+	 * of getCategoryRate() hands over.
+	 *
+	 * @param	string	$vatNumber	Intra-community VAT number of the customer
+	 * @param	string	$siren		Professional id 1 of the customer
+	 * @return	stdClass
+	 */
+	private function invoiceOf($vatNumber = 'FR16384322020', $siren = '384322020')
+	{
+		global $db;
+
+		$buyer = new Societe($db);
+		$buyer->name = 'Customer';
+		$buyer->tva_intra = $vatNumber;
+		$buyer->idprof1 = $siren;
+		$buyer->country_code = 'FR';
+
+		$invoice = new stdClass();
+		$invoice->thirdparty = $buyer;
+
+		return $invoice;
+	}
+
+	/**
+	 * Read the category the code declares, on its own.
+	 *
+	 * @param	string	$vatCode	Code of a VAT dictionary line
+	 * @return	string
+	 */
+	private function categoryOfCode($vatCode)
+	{
+		global $db;
+
+		$method = new ReflectionMethod(CIIProtocol::class, '_getVatCategoryFromVatCode');
+		$method->setAccessible(true);
+
+		return $method->invoke(new CIIProtocol($db), $vatCode);
+	}
+
+	/**
+	 * The segment before the first dash is the category, which is why a dictionary can grow a second
+	 * reverse charge regime - 'AE-IC' for the intra-community one - without a line of code being
+	 * written for it. Case and spacing of the dictionary are not the operator's problem.
+	 *
+	 * @return void
+	 */
+	public function testTheSegmentBeforeTheDashIsTheCategory()
+	{
+		$this->assertSame('AE', $this->categoryOfCode('AE'));
+		$this->assertSame('AE', $this->categoryOfCode('AE-IC'));
+		$this->assertSame('AE', $this->categoryOfCode(' ae '));
+		$this->assertSame('G', $this->categoryOfCode('G'));
+		$this->assertSame('E', $this->categoryOfCode('E-CGI261-4'));
+		$this->assertSame('K', $this->categoryOfCode('K'));
+		$this->assertSame('Z', $this->categoryOfCode('Z'));
+	}
+
+	/**
+	 * Nothing else is read as a category. A line with no code says nothing about its regime, and the
+	 * codes an existing installation already holds - a VATEX identifier written in the code column, the
+	 * way the module documents it - must keep going through the rules that read them as such, or the
+	 * category of those documents would silently become 'VATEX'.
+	 *
+	 * @return void
+	 */
+	public function testNothingElseIsReadAsACategory()
+	{
+		$this->assertSame('', $this->categoryOfCode(''));
+		$this->assertSame('', $this->categoryOfCode('VATEX-FR-CGI261-4'));
+		$this->assertSame('', $this->categoryOfCode('VATEX-EU-AE'));
+		$this->assertSame('', $this->categoryOfCode('NPR'));
+
+		// Outside the scope of VAT, and the two Spanish territories: each answers to rules the rest of
+		// the document does not honour yet, so the code is not taken at its word.
+		$this->assertSame('', $this->categoryOfCode('O'));
+		$this->assertSame('', $this->categoryOfCode('L'));
+		$this->assertSame('', $this->categoryOfCode('M'));
+	}
+
+	/**
+	 * A line coded reverse charge is issued reverse charge. The rate says nothing here: it is 0 for Z,
+	 * E, AE, G and K alike.
+	 *
+	 * @return void
+	 */
+	public function testAReverseChargeLineIsIssuedReverseCharge()
+	{
+		$protocol = new CIIProtocol($GLOBALS['db']);
+
+		$result = $protocol->getCategoryRate($this->line(0, 'AE'), $this->seller(), $this->invoiceOf());
+
+		$this->assertSame('AE', $result['categoryVAT']);
+		$this->assertNotEmpty($result['ExemptionReason']);
+	}
+
+	/**
+	 * A French seller quotes the French code of the reverse charge: VATEX-FR-AE names article 283 of the
+	 * CGI, which is the article the mention carried by the invoice has to name, where VATEX-EU-AE says
+	 * "reverse charge" and nothing else. A seller of another member state has that one.
+	 *
+	 * @return void
+	 */
+	public function testTheReverseChargeCodeFollowsTheCountryOfTheSeller()
+	{
+		$protocol = new CIIProtocol($GLOBALS['db']);
+
+		$french = $protocol->getCategoryRate($this->line(0, 'AE'), $this->seller(), $this->invoiceOf());
+		$this->assertSame('VATEX-FR-AE', $french['ExemptionReasonCode']);
+
+		$seller = $this->seller('BE0123456789', '0123456789');
+		$seller->country_code = 'BE';
+		$belgian = $protocol->getCategoryRate($this->line(0, 'AE'), $seller, $this->invoiceOf());
+		$this->assertSame('VATEX-EU-AE', $belgian['ExemptionReasonCode']);
+	}
+
+	/**
+	 * BR-AE-05: reverse charge is only ever invoiced at a rate of zero. A line stating the code on a
+	 * taxed rate contradicts its own dictionary entry, and both answers - honouring the code, honouring
+	 * the rate - build a document the Schematron refuses. It is reported instead.
+	 *
+	 * @return void
+	 */
+	public function testAReverseChargeCodeOnATaxedRateIsRefused()
+	{
+		$protocol = new CIIProtocol($GLOBALS['db']);
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessageMatches('/BR-AE-05/');
+
+		$protocol->getCategoryRate($this->line(20, 'AE'), $this->seller(), $this->invoiceOf());
+	}
+
+	/**
+	 * BR-Z-09 and BR-Z-10: a zero rated line is taxed, at zero. It carries no exemption reason at all,
+	 * where an exempt line must carry one.
+	 *
+	 * @return void
+	 */
+	public function testAZeroRatedLineCarriesNoExemptionReason()
+	{
+		$protocol = new CIIProtocol($GLOBALS['db']);
+
+		$result = $protocol->getCategoryRate($this->line(0, 'Z'), $this->seller(), $this->invoiceOf());
+
+		$this->assertSame('Z', $result['categoryVAT']);
+		$this->assertNull($result['ExemptionReason']);
+		$this->assertNull($result['ExemptionReasonCode']);
+	}
+
+	/**
+	 * BR-AE-02 and BR-AE-03: the tax of a reverse charge line is declared by the party that receives the
+	 * supply, so the document names both parties. Reported here, the message names the record to
+	 * complete; left to the Schematron it comes back from the platform as a rejected document.
+	 *
+	 * @return void
+	 */
+	public function testAReverseChargeLineNamesBothParties()
+	{
+		$protocol = new CIIProtocol($GLOBALS['db']);
+
+		try {
+			$protocol->getCategoryRate($this->line(0, 'AE'), $this->seller('', ''), $this->invoiceOf());
+			$this->fail('A seller identified by neither a VAT number nor a professional id must be reported.');
+		} catch (Exception $e) {
+			$this->assertStringContainsString('BR-AE-02', $e->getMessage());
+		}
+
+		try {
+			$protocol->getCategoryRate($this->line(0, 'AE'), $this->seller(), $this->invoiceOf('', ''));
+			$this->fail('A customer identified by neither a VAT number nor a legal registration id must be reported.');
+		} catch (Exception $e) {
+			$this->assertStringContainsString('BR-AE-03', $e->getMessage());
+		}
+	}
+
+	/**
+	 * A taxed line has no exemption reason and needs no code: the rules below the category decide, and
+	 * the documents of every installation that never coded a rate keep being built the way they were.
+	 *
+	 * @return void
+	 */
+	public function testATaxedLineIsStandardRatedWithoutAnyCode()
+	{
+		$protocol = new CIIProtocol($GLOBALS['db']);
+
+		$result = $protocol->getCategoryRate($this->line(20, ''), $this->seller(), $this->invoiceOf());
+
+		$this->assertSame('S', $result['categoryVAT']);
+		$this->assertEmpty($result['ExemptionReasonCode']);
+	}
+}


### PR DESCRIPTION
## What this changes

`getCategoryRate()` reads the VAT category of a line (BT-151) from the VAT code the line carries
(`vat_src_code`, the `code` column of the VAT dictionary), instead of deducing it from the rate.

A rate of 0 covers `Z`, `E`, `AE`, `G` and `K` alike, and the generator answered `E` for all of them.
A building trade subcontractor in France invoices under the reverse charge (article 283, 2 nonies of
the CGI): its customer declares the tax. Category `AE` was never reachable — the only branch setting it
is `if (1 == 2)`, marked "TODO Not implemented" — so none of those invoices could produce a valid
document, and recording a payment failed with `MISSINGSETUP: Motif inconnu d'exemption de TVA`.

## The rule

The category is the segment of the code before its first dash, restricted to the categories this
generator issues documents for: `S`, `Z`, `E`, `AE`, `K`, `G`. So a dictionary can tell apart two
regimes sharing one category — `AE` and `AE-IC` are both reverse charge — without a line of code being
written for the second one.

`L`, `M` and `O` are deliberately left out: each answers to rules the rest of the document does not
honour yet, so a code opening on one of them is not taken at its word and keeps going through the
existing rules. A code that is not a category — a VATEX identifier written in the `code` column, the
way this module already documents it — is left to the existing rules too, unchanged, which is what
keeps existing installations building the same documents as before.

- **BT-120** is the `note` of the dictionary line, never a hard coded text: two regimes may share a
  category and quote different articles (subcontracting answers to article 283, 2 nonies of the CGI
  where an intra-community supply answers to article 283-1), and only the note tells them apart.
- **BT-121** is `einvoice_vatex` where the core holds it (Dolibarr 24 and above), the hidden constant
  `MAIN_VAT_EXEMPTION_CODE_FOR_<rate>_<code>` otherwise, and as a last resort the code the standard
  defines for the regime itself — `VATEX-FR-AE` for a French seller under the reverse charge, which
  names the article the mention on the invoice has to name, `VATEX-EU-AE` for the other member states,
  `VATEX-EU-G` and `VATEX-EU-IC` for exports and intra-community supplies.
- Category `Z` carries no exemption reason at all (BR-Z-09, BR-Z-10).

## What it refuses rather than guesses

- A category EN 16931 only allows at rate 0, stated on a taxed rate, is reported on `BR-<category>-05`
  instead of building a document the Schematron refuses. Answering either side — honouring the code or
  honouring the rate — would contradict the dictionary.
- A reverse charge line that names only one of the two parties is reported on BR-AE-02 / BR-AE-03. The
  message names the record to complete; left to the Schematron it comes back from the platform as a
  rejected document.
- An unknown code keeps getting the existing `UnknownVATEX` message. That behaviour is the point: a
  generator that guesses a category from the rate produces a document that is valid and wrong, which is
  the worst of the two.

## Not changed

Taxed lines, and lines with no VAT code, are built exactly as before.

## Tests

`test/phpunit/VatCategoryFromVatCodeTest.php`, registered in `AllTests.php`: the derivation itself, what
is deliberately not read as a category (`VATEX-…`, `O`, `L`, `M`, a lowercase or space-spelled variant),
the reverse charge answer and its code per country, the rate/category contradiction, and a taxed line
with no code.

Verified on an instance running Dolibarr 23.0.3 with 81 invoices and 729 lines under the reverse charge:
the document produced carries `CategoryCode AE`, `ExemptionReasonCode VATEX-FR-AE` and a rate of 0.
