### PR TITLE
FIX [einvoicing] The four discount sentinels of the core no longer reach the customer

### DIFF
--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -1491,7 +1491,9 @@ class EInvoicing
 				$hasLabel = trim((string) ($line->product_label ?? '')) !== '';
 				$hasDesc = trim(dol_string_nohtmltag((string) ($line->desc ?? ''), 0)) !== '';
 				if (!$hasLabel && !$hasDesc) {
-					$linesWithNoName[] = (int) ($line->rang ?: count($linesWithNoName) + 1);
+					// The rank places the line on the paper, the rowid is what a correction is addressed to.
+					// Naming both is what lets whoever reads this go straight to the line and fix it.
+					$linesWithNoName[] = ($line->rang ? '#'.((int) $line->rang) : '').' (id '.((int) $line->id).')';
 				}
 			}
 		}

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -1493,7 +1493,11 @@ class EInvoicing
 				if (!$hasLabel && !$hasDesc) {
 					// The rank places the line on the paper, the rowid is what a correction is addressed to.
 					// Naming both is what lets whoever reads this go straight to the line and fix it.
-					$linesWithNoName[] = ($line->rang ? '#'.((int) $line->rang) : '').' (id '.((int) $line->id).')';
+					// FactureLigne and FactureFournisseurLigne both hold the rank, their common parent
+					// does not declare it, and this reads whichever of the two the invoice carries.
+					// @phan-suppress-next-line PhanUndeclaredProperty
+					$rank = (int) ($line->rang ?? 0);
+					$linesWithNoName[] = ($rank ? '#'.$rank : '').' (id '.((int) $line->id).')';
 				}
 			}
 		}

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -1482,6 +1482,11 @@ class EInvoicing
 		// Title and subtotal lines are not concerned: they are pseudo-lines that never reach the
 		// document. A discount line is not concerned either, its name being built from the piece it
 		// deducts (see einvoicingDiscountLabel()).
+		//
+		// Customer invoices only, afterPDFCreation() gating on instanceof Facture: FactureFournisseurLigne
+		// fills ->description and not ->desc before 20.0, so extending this guard to supplier invoices
+		// needs a ?: $line->description or every free line of an 18.0/19.0 purchase invoice reads as
+		// having no name.
 		$linesWithNoName = [];
 		if (!empty($invoice->lines) && is_array($invoice->lines)) {
 			foreach ($invoice->lines as $line) {

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -1473,6 +1473,32 @@ class EInvoicing
 			}
 		}
 
+		// BR-25: every line of the document names what it invoices (BT-153). The name is built from the
+		// label of the product, or from the first line of the description when there is no product, so a
+		// line holding neither is issued with an empty name and the document is refused - and refused by
+		// the platform, after transmission, on a line number the seller then has to go and find. Every
+		// such line is listed here instead, before anything is sent.
+		//
+		// Title and subtotal lines are not concerned: they are pseudo-lines that never reach the
+		// document. A discount line is not concerned either, its name being built from the piece it
+		// deducts (see einvoicingDiscountLabel()).
+		$linesWithNoName = [];
+		if (!empty($invoice->lines) && is_array($invoice->lines)) {
+			foreach ($invoice->lines as $line) {
+				if ((int) $line->product_type == 9 || !empty($line->fk_remise_except)) {
+					continue;
+				}
+				$hasLabel = trim((string) ($line->product_label ?? '')) !== '';
+				$hasDesc = trim(dol_string_nohtmltag((string) ($line->desc ?? ''), 0)) !== '';
+				if (!$hasLabel && !$hasDesc) {
+					$linesWithNoName[] = (int) ($line->rang ?: count($linesWithNoName) + 1);
+				}
+			}
+		}
+		if (!empty($linesWithNoName)) {
+			$baseErrors[] = $langs->trans("FxCheckErrorLinesWithNoName", implode(', ', $linesWithNoName));
+		}
+
 		if (!empty($baseErrors)) {
 			$res = -1;
 			$message .= '<br> Error: ' . implode('<br> Error: ', $baseErrors);

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -729,3 +729,11 @@ EInvoicePreviewXml=Show the e-invoice XML
 EInvoiceNoFileToPreview=No e-invoice XML has been generated for this invoice.
 EInvoiceNoReceivedFileToPreview=No e-invoice XML has been received for this invoice.
 EInvoiceXmlReindented=received on a single line, shown reindented
+
+# Wording of a discount line whose source piece cannot be named (BT-153 / BT-97)
+EInvDiscountOnInvoice=on invoice %s
+DiscountFromCreditNoteNoSource=Discount from a credit note
+DiscountFromDepositNoSource=Down payment deducted
+DiscountFromExcessReceivedNoSource=Payment in excess deducted
+DiscountFromExcessPaidNoSource=Payment in excess deducted
+FxCheckErrorLinesWithNoName=The following lines have neither a product label nor a description, so the item name of the e-invoice (BT-153) would be empty, which rule BR-25 refuses: %s. Enter a description on each of them.

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -736,4 +736,4 @@ DiscountFromCreditNoteNoSource=Discount from a credit note
 DiscountFromDepositNoSource=Down payment deducted
 DiscountFromExcessReceivedNoSource=Payment in excess deducted
 DiscountFromExcessPaidNoSource=Payment in excess deducted
-FxCheckErrorLinesWithNoName=The following lines have neither a product label nor a description, so the item name of the e-invoice (BT-153) would be empty, which rule BR-25 refuses: %s. Enter a description on each of them.
+FxCheckErrorLinesWithNoName=The following lines have neither a product label nor a description, so the item name of the e-invoice (BT-153) would be empty, which rule BR-25 refuses: %s. Enter a description on each of them (rank in the document, then line id).

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -838,19 +838,22 @@ foreach ($linesData as $numligne => $vals) {
 	}
 }
 
+foreach ($globalDiscounts as $discountIndex => $vals) {
+	if (in_array((string) ($vals['reason'] ?? ''), $discountSentinels, true)) {
+		dol_syslog("EInvoicing: allowance ".$discountIndex." of ".$object->ref." carries the unresolved discount marker ".$vals['reason']." in BT-97. The discount source piece could not be read.", LOG_ERR);
+	}
+}
+
 // BR-25: a line with no name is not a document the platform accepts, so it is refused here rather than
 // after transmission, on a line number the seller would then have to go and find. Every such line is
 // named at once: sending them back one refusal at a time would be a round trip per line. This is the
 // same missing data the pre-check reports before validation (validateInvoiceConfiguration()); a
 // document reaching this point with one is one whose lines changed since, or one built by a path that
-// does not run the pre-check.
+// does not run the pre-check. Refused after both halves of the last look above, never between them: a
+// document carrying a nameless line and an unresolved marker in BT-97 would otherwise leave without the
+// marker ever being reported - the very case that last look exists to catch.
 if (!empty($linesWithNoName)) {
 	throw new Exception('MISSINGDATA[BR-25]: The line'.(count($linesWithNoName) > 1 ? 's ' : ' ').implode(', ', $linesWithNoName).' of '.$object->ref.' '.(count($linesWithNoName) > 1 ? 'have' : 'has').' no item name (BT-153). Enter a description on the line, or a label on the product it invoices.');
-}
-foreach ($globalDiscounts as $discountIndex => $vals) {
-	if (in_array((string) ($vals['reason'] ?? ''), $discountSentinels, true)) {
-		dol_syslog("EInvoicing: allowance ".$discountIndex." of ".$object->ref." carries the unresolved discount marker ".$vals['reason']." in BT-97. The discount source piece could not be read.", LOG_ERR);
-	}
 }
 
 // Rounding convention of the totals: Dolibarr sums the amounts already rounded on each line ("total of

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -807,6 +807,29 @@ if (!empty($object->situation_counter) && $object->situation_counter > 1
 	}
 }
 
+// Last look for a sentinel that reached a field the customer reads. Everything above resolves the four
+// of them, so anything left here is a way of building a document that this file does not know about -
+// which is not a supposition: the resolution was written for the reason of a document level allowance
+// and the item name of a deposit line was found carrying the sentinel afterwards, at the second look.
+//
+// The test is an equality, never an inclusion: a line of work named 'Reprise (DEPOSIT) du chantier' is
+// a legitimate text and must go out untouched. And it reports rather than refuses - a marker in an item
+// name is ugly, not invalid, and holding back an invoice over it would cost the seller more than it
+// saves.
+$discountSentinels = array_keys(einvoicingDiscountSentinels());
+foreach ($linesData as $numligne => $vals) {
+	foreach (array('prodname' => 'BT-153', 'proddesc' => 'BT-154') as $field => $businessTerm) {
+		if (in_array((string) ($vals[$field] ?? ''), $discountSentinels, true)) {
+			dol_syslog("EInvoicing: line ".$numligne." of ".$object->ref." carries the unresolved discount marker ".$vals[$field]." in ".$businessTerm.". The line is a discount whose source piece could not be read.", LOG_ERR);
+		}
+	}
+}
+foreach ($globalDiscounts as $discountIndex => $vals) {
+	if (in_array((string) ($vals['reason'] ?? ''), $discountSentinels, true)) {
+		dol_syslog("EInvoicing: allowance ".$discountIndex." of ".$object->ref." carries the unresolved discount marker ".$vals['reason']." in BT-97. The discount source piece could not be read.", LOG_ERR);
+	}
+}
+
 // Rounding convention of the totals: Dolibarr sums the amounts already rounded on each line ("total of
 // round", the default), unless MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND rounds the sum instead. The loop
 // above always applies the first one, so follow the instance or the document claims a cent less than

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -440,7 +440,8 @@ foreach ($object->lines as $line) {
 	// The second method need to use the field BT-113. We don't use it as we use the first method.
 	$depositFactRef  = null;
 	$depositFactDate = null;
-	if ($line->desc == '(DEPOSIT)') {
+	$lineDiscount    = null;	// Discount the line was built from, when it is a discount line
+	if ($line->desc == '(DEPOSIT)' && !empty($line->fk_remise_except)) {
 		$isDepositLine   = 1;
 		$depositFactRef  = "";
 		$depositFactDate = new DateTime();
@@ -450,6 +451,7 @@ foreach ($object->lines as $line) {
 		dol_syslog("Fetch discount " . $line->fk_remise_except . ", res=" . $resdiscount, LOG_DEBUG);
 
 		if ($resdiscount > 0) {
+			$lineDiscount = $discount;
 			$origFact    = new Facture($this->db);
 			$resOrigFact = $origFact->fetch($discount->fk_facture_source);
 			dol_syslog("Fetch origFact " . $discount->fk_facture_source . ", res=" . $resOrigFact, LOG_DEBUG);
@@ -483,9 +485,16 @@ foreach ($object->lines as $line) {
 		$resdiscount = $discount->fetch($line->fk_remise_except);
 		dol_syslog("Fetch discount " . $line->fk_remise_except . ", res=" . $resdiscount, LOG_DEBUG);
 
+		$lineDiscount = ($resdiscount > 0 ? $discount : null);
+
+		// BT-97. The description of a discount built from another piece is a sentinel, not a text to
+		// show: resolved here, the customer reads which credit note or which excess payment is deducted
+		// instead of '(CREDIT_NOTE)'. A discount entered by hand keeps the reason that was typed.
+		$discountReason = einvoicingDiscountLabel($lineDiscount, $discount->description ?? '', $outputlangs);
+
 		$globalDiscounts[] = array(
 			'value' => (float) $discount->total_ht,
-			'reason' => $discount->description ?? 'REMISE',
+			'reason' => $discountReason ?: ($discount->description ?? 'REMISE'),
 			'taxRate' => (float) $discount->tva_tx,
 			'categoryVAT' => $categoryVAT,
 		);
@@ -546,6 +555,15 @@ foreach ($object->lines as $line) {
 		if ($libelle == $description) {
 			$description = "";
 		}
+	}
+
+	// A discount line still standing at this point is a deposit deducted from the invoice, and its
+	// description is the sentinel the core stores, not a text meant to be read. Left as it is, the
+	// customer reads '(DEPOSIT)' as the name of the line (BT-153).
+	$discountLabel = einvoicingDiscountLabel($lineDiscount, $line->desc ?? '', $outputlangs);
+	if ($discountLabel !== '') {
+		$libelle     = $discountLabel;
+		$description = "";
 	}
 
 	// Billing period of the line

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -369,6 +369,7 @@ $lines_total_ht 	= $lines_total_tva = $lines_total_ttc = 0;
 $grand_total_ht    	= $grand_total_tva = $grand_total_ttc = 0;
 $prepaidAmount     	= 0;
 $depositlines      	= [];
+$lineRowIds        	= [];	// Document line number => llx_facturedet.rowid, for the messages
 $globalDiscounts	= [];
 $billing_period    	= [];
 $numligne          	= 1;
@@ -654,6 +655,11 @@ foreach ($object->lines as $line) {
 
 
 
+	// The rowid of the line, kept beside its document line number: the number places the line in the
+	// document, the rowid is what a correction is addressed to, and a message that names only the first
+	// leaves its reader to count the lines to find it.
+	$lineRowIds[$numligne] = (int) $line->id;
+
 	// Filling $linesData (based on $lineTemplate)
 	$linesData[$numligne] = [
 		'lineid'                    => $numligne,
@@ -820,7 +826,7 @@ $discountSentinels = array_keys(einvoicingDiscountSentinels());
 $linesWithNoName = array();
 foreach ($linesData as $numligne => $vals) {
 	if (trim((string) ($vals['prodname'] ?? '')) === '') {
-		$linesWithNoName[] = $numligne;
+		$linesWithNoName[] = $numligne.' (id '.($lineRowIds[$numligne] ?? 0).')';
 	}
 	foreach (array('prodname' => 'BT-153', 'proddesc' => 'BT-154') as $field => $businessTerm) {
 		if (in_array((string) ($vals[$field] ?? ''), $discountSentinels, true)) {

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -561,7 +561,10 @@ foreach ($object->lines as $line) {
 	// A discount line still standing at this point is a deposit deducted from the invoice, and its
 	// description is the sentinel the core stores, not a text meant to be read. Left as it is, the
 	// customer reads '(DEPOSIT)' as the name of the line (BT-153).
-	$discountLabel = einvoicingDiscountLabel($lineDiscount, $line->desc ?? '', $outputlangs, einvoicingDiscountRelatedInvoiceRef($lineDiscount, $this->db));
+	// The line has to carry a discount for that to hold, which is why the resolution goes through
+	// einvoicingDiscountLabelOfLine(): a line of work an operator named '(DEPOSIT)', pointing at no
+	// discount, is legitimate text and keeps the name it was given.
+	$discountLabel = einvoicingDiscountLabelOfLine($line, $lineDiscount, $outputlangs, einvoicingDiscountRelatedInvoiceRef($lineDiscount, $this->db));
 	if ($discountLabel !== '') {
 		$libelle     = $discountLabel;
 		$description = "";

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -490,7 +490,7 @@ foreach ($object->lines as $line) {
 		// BT-97. The description of a discount built from another piece is a sentinel, not a text to
 		// show: resolved here, the customer reads which credit note or which excess payment is deducted
 		// instead of '(CREDIT_NOTE)'. A discount entered by hand keeps the reason that was typed.
-		$discountReason = einvoicingDiscountLabel($lineDiscount, $discount->description ?? '', $outputlangs);
+		$discountReason = einvoicingDiscountLabel($lineDiscount, $discount->description ?? '', $outputlangs, einvoicingDiscountRelatedInvoiceRef($lineDiscount, $this->db));
 
 		$globalDiscounts[] = array(
 			'value' => (float) $discount->total_ht,
@@ -560,7 +560,7 @@ foreach ($object->lines as $line) {
 	// A discount line still standing at this point is a deposit deducted from the invoice, and its
 	// description is the sentinel the core stores, not a text meant to be read. Left as it is, the
 	// customer reads '(DEPOSIT)' as the name of the line (BT-153).
-	$discountLabel = einvoicingDiscountLabel($lineDiscount, $line->desc ?? '', $outputlangs);
+	$discountLabel = einvoicingDiscountLabel($lineDiscount, $line->desc ?? '', $outputlangs, einvoicingDiscountRelatedInvoiceRef($lineDiscount, $this->db));
 	if ($discountLabel !== '') {
 		$libelle     = $discountLabel;
 		$description = "";
@@ -817,12 +817,26 @@ if (!empty($object->situation_counter) && $object->situation_counter > 1
 // name is ugly, not invalid, and holding back an invoice over it would cost the seller more than it
 // saves.
 $discountSentinels = array_keys(einvoicingDiscountSentinels());
+$linesWithNoName = array();
 foreach ($linesData as $numligne => $vals) {
+	if (trim((string) ($vals['prodname'] ?? '')) === '') {
+		$linesWithNoName[] = $numligne;
+	}
 	foreach (array('prodname' => 'BT-153', 'proddesc' => 'BT-154') as $field => $businessTerm) {
 		if (in_array((string) ($vals[$field] ?? ''), $discountSentinels, true)) {
 			dol_syslog("EInvoicing: line ".$numligne." of ".$object->ref." carries the unresolved discount marker ".$vals[$field]." in ".$businessTerm.". The line is a discount whose source piece could not be read.", LOG_ERR);
 		}
 	}
+}
+
+// BR-25: a line with no name is not a document the platform accepts, so it is refused here rather than
+// after transmission, on a line number the seller would then have to go and find. Every such line is
+// named at once: sending them back one refusal at a time would be a round trip per line. This is the
+// same missing data the pre-check reports before validation (validateInvoiceConfiguration()); a
+// document reaching this point with one is one whose lines changed since, or one built by a path that
+// does not run the pre-check.
+if (!empty($linesWithNoName)) {
+	throw new Exception('MISSINGDATA[BR-25]: The line'.(count($linesWithNoName) > 1 ? 's ' : ' ').implode(', ', $linesWithNoName).' of '.$object->ref.' '.(count($linesWithNoName) > 1 ? 'have' : 'has').' no item name (BT-153). Enter a description on the line, or a label on the product it invoices.');
 }
 foreach ($globalDiscounts as $discountIndex => $vals) {
 	if (in_array((string) ($vals['reason'] ?? ''), $discountSentinels, true)) {

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -1154,6 +1154,36 @@ function einvoicingDiscountLabel($discount, $description, $outputlangs, $related
 }
 
 /**
+ * Text a discount line of the invoice stands for, '' when the line carries no discount at all.
+ *
+ * einvoicingDiscountLabel() decides on the description alone, which is what a document level
+ * allowance needs: there, the caller has already established that a discount is behind the amount.
+ * A line of the invoice has not, and the description alone cannot tell - a line of work can be named
+ * '(DEPOSIT)' and carry nothing, and it was then renamed 'Down payment deducted' on its way out,
+ * under the wording meant for a discount whose source piece cannot be read, which is a different
+ * situation entirely.
+ *
+ * The test of the core is in two halves, the description AND the discount the line points at
+ * (pdf_getlinedesc(): $desc == '(DEPOSIT)' && $object->lines[$i]->fk_remise_except). This is where
+ * the second half is made, so that the two call sites read the line the same way: the one writing
+ * BT-97 already stands inside a test on fk_remise_except, the one writing BT-153 does not.
+ *
+ * @param	?object				$line				Line of the invoice being written
+ * @param	?DiscountAbsolute	$discount			Discount the line was built from, already fetched
+ * @param	Translate			$outputlangs		Language of the document being built
+ * @param	string				$relatedInvoiceRef	Invoice the deducted piece corrects, from einvoicingDiscountRelatedInvoiceRef()
+ * @return	string									Resolved text, '' when the line is no discount line
+ */
+function einvoicingDiscountLabelOfLine($line, $discount, $outputlangs, $relatedInvoiceRef = '')
+{
+	if (empty($line) || empty($line->fk_remise_except)) {
+		return '';
+	}
+
+	return einvoicingDiscountLabel($discount, $line->desc ?? '', $outputlangs, $relatedInvoiceRef);
+}
+
+/**
  * Reference of the invoice the piece behind a discount corrects, '' when there is none to name.
  *
  * A credit note converted into a discount names the invoice it corrects in its own fk_facture_source,

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -1067,7 +1067,7 @@ function einvoicingIsAllowedRedirectUrl($url)
 }
 
 /**
- * Text a discount line stands for, in place of the sentinel Dolibarr stores in its description.
+ * The four sentinels Dolibarr stores in the description of a discount, and the text each stands for.
  *
  * A discount built from another piece - a credit note applied, a deposit deducted, an excess payment
  * carried over - carries no text of its own: the core writes one of four sentinels in the description
@@ -1082,6 +1082,23 @@ function einvoicingIsAllowedRedirectUrl($url)
  * even spelled alike: '(CREDIT_NOTE)' holds an underscore where '(EXCESS PAID)' and
  * '(EXCESS RECEIVED)' hold a space.
  *
+ * @return	array<string,string>	Sentinel of the core => translation key of the text it stands for
+ */
+function einvoicingDiscountSentinels()
+{
+	return array(
+		'(CREDIT_NOTE)'     => 'DiscountFromCreditNote',
+		'(DEPOSIT)'         => 'DiscountFromDeposit',
+		'(EXCESS RECEIVED)' => 'DiscountFromExcessReceived',
+		'(EXCESS PAID)'     => 'DiscountFromExcessPaid',
+	);
+}
+
+/**
+ * Text a discount line stands for, in place of the sentinel Dolibarr stores in its description.
+ *
+ * See einvoicingDiscountSentinels() for what the four sentinels are and why they are matched exactly.
+ *
  * @param	?DiscountAbsolute	$discount		Discount the line was built from, already fetched
  * @param	string				$description	Description to resolve, of the line or of the discount
  * @param	Translate			$outputlangs	Language of the document being built
@@ -1089,12 +1106,7 @@ function einvoicingIsAllowedRedirectUrl($url)
  */
 function einvoicingDiscountLabel($discount, $description, $outputlangs)
 {
-	$transkeyOfSentinel = array(
-		'(CREDIT_NOTE)'     => 'DiscountFromCreditNote',
-		'(DEPOSIT)'         => 'DiscountFromDeposit',
-		'(EXCESS RECEIVED)' => 'DiscountFromExcessReceived',
-		'(EXCESS PAID)'     => 'DiscountFromExcessPaid',
-	);
+	$transkeyOfSentinel = einvoicingDiscountSentinels();
 
 	$description = (string) $description;
 	if (!isset($transkeyOfSentinel[$description]) || empty($discount) || empty($discount->id)) {

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -1065,3 +1065,54 @@ function einvoicingIsAllowedRedirectUrl($url)
 
 	return false;
 }
+
+/**
+ * Text a discount line stands for, in place of the sentinel Dolibarr stores in its description.
+ *
+ * A discount built from another piece - a credit note applied, a deposit deducted, an excess payment
+ * carried over - carries no text of its own: the core writes one of four sentinels in the description
+ * of the discount, insert_discount() copies it into the description of the line, and pdf_getlinedesc()
+ * resolves it against the piece it comes from at print time. Nothing resolves it for an e-invoice, so
+ * the customer used to read '(CREDIT_NOTE)' in the item name of the line (BT-153) or in the reason of
+ * a document level allowance (BT-97).
+ *
+ * The test is the one the core makes: the description equals a sentinel exactly, and the line is
+ * actually a discount line. Matching the text alone is wrong in both directions - a description edited
+ * by hand is missed, and a service line quoting the string is caught - and the four sentinels are not
+ * even spelled alike: '(CREDIT_NOTE)' holds an underscore where '(EXCESS PAID)' and
+ * '(EXCESS RECEIVED)' hold a space.
+ *
+ * @param	?DiscountAbsolute	$discount		Discount the line was built from, already fetched
+ * @param	string				$description	Description to resolve, of the line or of the discount
+ * @param	Translate			$outputlangs	Language of the document being built
+ * @return	string								Resolved text, '' when the description is no sentinel
+ */
+function einvoicingDiscountLabel($discount, $description, $outputlangs)
+{
+	$transkeyOfSentinel = array(
+		'(CREDIT_NOTE)'     => 'DiscountFromCreditNote',
+		'(DEPOSIT)'         => 'DiscountFromDeposit',
+		'(EXCESS RECEIVED)' => 'DiscountFromExcessReceived',
+		'(EXCESS PAID)'     => 'DiscountFromExcessPaid',
+	);
+
+	$description = (string) $description;
+	if (!isset($transkeyOfSentinel[$description]) || empty($discount) || empty($discount->id)) {
+		return '';
+	}
+
+	// Which piece is quoted depends on the side the discount belongs to: a discount held on a supplier
+	// invoice names that invoice, and reading ref_facture_source there would name nothing at all.
+	$sourceref = !empty($discount->discount_type) ? $discount->ref_invoice_supplier_source : $discount->ref_facture_source;
+
+	$outputlangs->load("bills");
+	$label = $outputlangs->transnoentitiesnoconv($transkeyOfSentinel[$description], $sourceref);
+
+	// The PDF of the core adds the date of the deposit when the option asks for it; the e-invoice reads
+	// the same way as the paper it accompanies.
+	if ($description == '(DEPOSIT)' && getDolGlobalString('INVOICE_ADD_DEPOSIT_DATE')) {
+		$label .= ' ('.dol_print_date($discount->datec, 'day', '', $outputlangs).')';
+	}
+
+	return $label;
+}

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -1099,26 +1099,50 @@ function einvoicingDiscountSentinels()
  *
  * See einvoicingDiscountSentinels() for what the four sentinels are and why they are matched exactly.
  *
- * @param	?DiscountAbsolute	$discount		Discount the line was built from, already fetched
- * @param	string				$description	Description to resolve, of the line or of the discount
- * @param	Translate			$outputlangs	Language of the document being built
- * @return	string								Resolved text, '' when the description is no sentinel
+ * @param	?DiscountAbsolute	$discount			Discount the line was built from, already fetched
+ * @param	string				$description		Description to resolve, of the line or of the discount
+ * @param	Translate			$outputlangs		Language of the document being built
+ * @param	string				$relatedInvoiceRef	Invoice the deducted piece corrects, from einvoicingDiscountRelatedInvoiceRef()
+ * @return	string									Resolved text, '' when the description is no sentinel
  */
-function einvoicingDiscountLabel($discount, $description, $outputlangs)
+function einvoicingDiscountLabel($discount, $description, $outputlangs, $relatedInvoiceRef = '')
 {
 	$transkeyOfSentinel = einvoicingDiscountSentinels();
 
 	$description = (string) $description;
-	if (!isset($transkeyOfSentinel[$description]) || empty($discount) || empty($discount->id)) {
+	if (!isset($transkeyOfSentinel[$description])) {
 		return '';
 	}
 
+	$outputlangs->load("bills");
+	$outputlangs->load("einvoicing@einvoicing");
+
 	// Which piece is quoted depends on the side the discount belongs to: a discount held on a supplier
 	// invoice names that invoice, and reading ref_facture_source there would name nothing at all.
-	$sourceref = !empty($discount->discount_type) ? $discount->ref_invoice_supplier_source : $discount->ref_facture_source;
+	$sourceref = '';
+	if (!empty($discount) && !empty($discount->id)) {
+		$sourceref = !empty($discount->discount_type) ? $discount->ref_invoice_supplier_source : $discount->ref_facture_source;
+	}
+	$sourceref = trim((string) $sourceref);
 
-	$outputlangs->load("bills");
+	if ($sourceref === '') {
+		// No piece to name: a discount entered by hand, or one whose source has been deleted. The text
+		// of the core quotes a reference and would be issued with a hole in the middle of the sentence,
+		// so the module has a wording of its own for the case. What must never happen is the marker
+		// going out as it stands: BT-153 refuses an empty item name (BR-25), and it refuses a technical
+		// marker in spirit.
+		return $outputlangs->transnoentitiesnoconv($transkeyOfSentinel[$description].'NoSource');
+	}
+
 	$label = $outputlangs->transnoentitiesnoconv($transkeyOfSentinel[$description], $sourceref);
+
+	// The piece deducted usually corrects another invoice, and naming it is what lets the customer
+	// reconcile the deduction without opening its own ledger. Skipped when it would name the piece
+	// already named, which happens on a deposit deducted from the invoice it was asked on.
+	$relatedInvoiceRef = trim((string) $relatedInvoiceRef);
+	if ($relatedInvoiceRef !== '' && $relatedInvoiceRef !== $sourceref) {
+		$label .= ' ('.$outputlangs->transnoentitiesnoconv('EInvDiscountOnInvoice', $relatedInvoiceRef).')';
+	}
 
 	// The PDF of the core adds the date of the deposit when the option asks for it; the e-invoice reads
 	// the same way as the paper it accompanies.
@@ -1127,4 +1151,36 @@ function einvoicingDiscountLabel($discount, $description, $outputlangs)
 	}
 
 	return $label;
+}
+
+/**
+ * Reference of the invoice the piece behind a discount corrects, '' when there is none to name.
+ *
+ * A credit note converted into a discount names the invoice it corrects in its own fk_facture_source,
+ * one level below the discount. Read from the discount alone, a deduction only says which credit note
+ * it comes from; the customer still has to find which invoice that credit note was about.
+ *
+ * @param	?DiscountAbsolute	$discount	Discount the line was built from, already fetched
+ * @param	DoliDB				$db			Database handler
+ * @return	string							Reference of the corrected invoice, '' when there is none
+ */
+function einvoicingDiscountRelatedInvoiceRef($discount, $db)
+{
+	if (empty($discount) || empty($discount->fk_facture_source)) {
+		return '';
+	}
+
+	require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture.class.php';
+
+	$sourcePiece = new Facture($db);
+	if ($sourcePiece->fetch((int) $discount->fk_facture_source) <= 0 || empty($sourcePiece->fk_facture_source)) {
+		return '';
+	}
+
+	$correctedInvoice = new Facture($db);
+	if ($correctedInvoice->fetch((int) $sourcePiece->fk_facture_source) <= 0) {
+		return '';
+	}
+
+	return (string) $correctedInvoice->ref;
 }

--- a/einvoicing/test/phpunit/DiscountSentinelTest.php
+++ b/einvoicing/test/phpunit/DiscountSentinelTest.php
@@ -75,6 +75,22 @@ class DiscountSentinelTest extends CommonClassTest
 	}
 
 	/**
+	 * The list of the sentinels is the one of the core, spelled exactly as the core spells it. It is
+	 * pinned here because it is shared by the resolution and by the last look that reports a sentinel
+	 * having reached a field of the document: a fifth entry, or one spelling drifting, would silently
+	 * make one of the four unresolvable again.
+	 *
+	 * @return void
+	 */
+	public function testTheSentinelsAreTheOnesOfTheCore()
+	{
+		$this->assertSame(
+			array('(CREDIT_NOTE)', '(DEPOSIT)', '(EXCESS RECEIVED)', '(EXCESS PAID)'),
+			array_keys(einvoicingDiscountSentinels())
+		);
+	}
+
+	/**
 	 * The four sentinels are resolved, each into the text of the core for the case it stands for, and
 	 * each naming the piece the amount comes from. The spelling of the four is not homogeneous -
 	 * '(CREDIT_NOTE)' holds an underscore where '(EXCESS PAID)' and '(EXCESS RECEIVED)' hold a space -

--- a/einvoicing/test/phpunit/DiscountSentinelTest.php
+++ b/einvoicing/test/phpunit/DiscountSentinelTest.php
@@ -75,6 +75,20 @@ class DiscountSentinelTest extends CommonClassTest
 	}
 
 	/**
+	 * A discount object that was never fetched: nothing to read on it, which is what a deleted or
+	 * unreadable source piece leaves behind.
+	 *
+	 * @return stdClass
+	 */
+	private function unfetchedDiscount()
+	{
+		$discount = $this->discount();
+		$discount->id = 0;
+
+		return $discount;
+	}
+
+	/**
 	 * The list of the sentinels is the one of the core, spelled exactly as the core spells it. It is
 	 * pinned here because it is shared by the resolution and by the last look that reports a sentinel
 	 * having reached a field of the document: a fifth entry, or one spelling drifting, would silently
@@ -157,20 +171,55 @@ class DiscountSentinelTest extends CommonClassTest
 	}
 
 	/**
-	 * A description that is a sentinel but has no discount behind it is left alone: there is no piece to
-	 * name, so there is no text to build, and inventing one would announce a deduction from nothing.
+	 * A sentinel with no piece to name still gets a text of its own, and never goes out as it stands.
+	 * The wording of the core quotes a reference, so it would be issued with a hole in the middle of the
+	 * sentence; the module has its own for the case. The one thing that must not happen is the marker
+	 * reaching the document: an item name that is a technical marker is what BR-25 refuses in spirit,
+	 * and it is what the customer would read.
 	 *
 	 * @return void
 	 */
-	public function testASentinelWithNoDiscountBehindItIsLeftAlone()
+	public function testASentinelWithNoPieceToNameStillGetsAText()
 	{
 		global $langs;
 
-		$this->assertSame('', einvoicingDiscountLabel(null, '(CREDIT_NOTE)', $langs));
+		foreach (array(null, $this->discount(''), $this->unfetchedDiscount()) as $noSource) {
+			$label = einvoicingDiscountLabel($noSource, '(CREDIT_NOTE)', $langs);
 
-		$unfetched = $this->discount();
-		$unfetched->id = 0;
-		$this->assertSame('', einvoicingDiscountLabel($unfetched, '(CREDIT_NOTE)', $langs));
+			$this->assertNotSame('', $label);
+			$this->assertStringNotContainsString('(CREDIT_NOTE)', $label);
+		}
+
+		// And each case keeps a wording of its own, a deposit deducted not being a credit note applied.
+		$this->assertNotSame(
+			einvoicingDiscountLabel(null, '(CREDIT_NOTE)', $langs),
+			einvoicingDiscountLabel(null, '(DEPOSIT)', $langs)
+		);
+	}
+
+	/**
+	 * The invoice the deducted piece corrects is named beside the piece itself: a deduction that only
+	 * says which credit note it comes from leaves the customer to find which invoice that credit note
+	 * was about. It is skipped when it would name the piece already named, which is what a deposit
+	 * deducted from the very invoice it was asked on would do.
+	 *
+	 * @return void
+	 */
+	public function testTheCorrectedInvoiceIsNamedBesideThePiece()
+	{
+		global $langs;
+
+		$withCorrected = einvoicingDiscountLabel($this->discount(), '(CREDIT_NOTE)', $langs, 'FA2026-0100');
+		$withoutCorrected = einvoicingDiscountLabel($this->discount(), '(CREDIT_NOTE)', $langs);
+
+		$this->assertStringStartsWith($withoutCorrected, $withCorrected);
+		$this->assertStringContainsString('FA2026-0100', $withCorrected);
+
+		// The same reference on both sides is named once.
+		$this->assertSame(
+			einvoicingDiscountLabel($this->discount('FA2026-0180'), '(DEPOSIT)', $langs),
+			einvoicingDiscountLabel($this->discount('FA2026-0180'), '(DEPOSIT)', $langs, 'FA2026-0180')
+		);
 	}
 
 	/**

--- a/einvoicing/test/phpunit/DiscountSentinelTest.php
+++ b/einvoicing/test/phpunit/DiscountSentinelTest.php
@@ -1,0 +1,183 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/DiscountSentinelTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for the four sentinels a discount line carries.
+ *                  A discount built from another piece has no text of its own: the core stores
+ *                  '(CREDIT_NOTE)', '(DEPOSIT)', '(EXCESS RECEIVED)' or '(EXCESS PAID)' in its
+ *                  description and resolves it at print time. An e-invoice that does not resolve it
+ *                  shows the sentinel to the customer, in the item name of a line (BT-153) or in the
+ *                  reason of a document level allowance (BT-97).
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+// See VatPointDateCodeTest for why DOLIBARR_HTDOCS is honoured before the relative path.
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+dol_include_once('einvoicing/lib/einvoicing.lib.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class DiscountSentinelTest extends CommonClassTest
+{
+	/**
+	 * A discount, reduced to what einvoicingDiscountLabel() reads on it. Not a DiscountAbsolute: the
+	 * function reads five properties and fetches nothing, which is what makes it testable without
+	 * writing a discount into the database.
+	 *
+	 * @param	string	$customerRef	->ref_facture_source, the piece a customer side discount names
+	 * @param	int		$discountType	->discount_type, 1 on the supplier side
+	 * @param	string	$supplierRef	->ref_invoice_supplier_source
+	 * @return	stdClass
+	 */
+	private function discount($customerRef = 'FA2026-0180', $discountType = 0, $supplierRef = '')
+	{
+		$discount = new stdClass();
+		$discount->id = 24;
+		$discount->discount_type = $discountType;
+		$discount->ref_facture_source = $customerRef;
+		$discount->ref_invoice_supplier_source = $supplierRef;
+		$discount->datec = dol_mktime(0, 0, 0, 6, 30, 2026);
+
+		return $discount;
+	}
+
+	/**
+	 * The four sentinels are resolved, each into the text of the core for the case it stands for, and
+	 * each naming the piece the amount comes from. The spelling of the four is not homogeneous -
+	 * '(CREDIT_NOTE)' holds an underscore where '(EXCESS PAID)' and '(EXCESS RECEIVED)' hold a space -
+	 * which is what a single pattern gets wrong.
+	 *
+	 * @return void
+	 */
+	public function testTheFourSentinelsAreResolved()
+	{
+		global $langs;
+
+		foreach (array('(CREDIT_NOTE)', '(DEPOSIT)', '(EXCESS RECEIVED)') as $sentinel) {
+			$label = einvoicingDiscountLabel($this->discount(), $sentinel, $langs);
+
+			$this->assertNotSame('', $label, 'The sentinel '.$sentinel.' must be resolved.');
+			$this->assertStringNotContainsString('(', $label, 'No sentinel may survive in '.$sentinel.'.');
+			$this->assertStringContainsString('FA2026-0180', $label, 'The piece the amount comes from must be named.');
+		}
+
+		// The supplier side names its own piece, and reading ref_facture_source there would name nothing.
+		$label = einvoicingDiscountLabel($this->discount('', 1, 'SUPPLIER-2026-77'), '(EXCESS PAID)', $langs);
+		$this->assertStringContainsString('SUPPLIER-2026-77', $label);
+	}
+
+	/**
+	 * Each sentinel is resolved into the text of its own case: a deposit deducted is not a credit note
+	 * applied, and a document that called one the other would misdescribe what it deducts.
+	 *
+	 * @return void
+	 */
+	public function testEachSentinelGetsTheTextOfItsOwnCase()
+	{
+		global $langs;
+
+		$creditNote = einvoicingDiscountLabel($this->discount(), '(CREDIT_NOTE)', $langs);
+		$deposit = einvoicingDiscountLabel($this->discount(), '(DEPOSIT)', $langs);
+		$excess = einvoicingDiscountLabel($this->discount(), '(EXCESS RECEIVED)', $langs);
+
+		$this->assertNotSame($creditNote, $deposit);
+		$this->assertNotSame($creditNote, $excess);
+		$this->assertNotSame($deposit, $excess);
+	}
+
+	/**
+	 * Nothing else is resolved. The test of the core is an exact equality on the description AND a
+	 * discount behind the line, and matching the text loosely is wrong in both directions: a line of
+	 * work quoting the string would be renamed, and the reason an operator typed by hand would be
+	 * replaced by a text about a piece that does not exist.
+	 *
+	 * @return void
+	 */
+	public function testNothingElseIsResolved()
+	{
+		global $langs;
+
+		$discount = $this->discount();
+
+		$this->assertSame('', einvoicingDiscountLabel($discount, '', $langs));
+		$this->assertSame('', einvoicingDiscountLabel($discount, 'Remise commerciale', $langs));
+		$this->assertSame('', einvoicingDiscountLabel($discount, 'credit_note', $langs));
+		$this->assertSame('', einvoicingDiscountLabel($discount, 'CREDIT_NOTE', $langs));
+		$this->assertSame('', einvoicingDiscountLabel($discount, '(CREDIT NOTE)', $langs));
+		$this->assertSame('', einvoicingDiscountLabel($discount, 'Reprise (DEPOSIT) du chantier', $langs));
+	}
+
+	/**
+	 * A description that is a sentinel but has no discount behind it is left alone: there is no piece to
+	 * name, so there is no text to build, and inventing one would announce a deduction from nothing.
+	 *
+	 * @return void
+	 */
+	public function testASentinelWithNoDiscountBehindItIsLeftAlone()
+	{
+		global $langs;
+
+		$this->assertSame('', einvoicingDiscountLabel(null, '(CREDIT_NOTE)', $langs));
+
+		$unfetched = $this->discount();
+		$unfetched->id = 0;
+		$this->assertSame('', einvoicingDiscountLabel($unfetched, '(CREDIT_NOTE)', $langs));
+	}
+
+	/**
+	 * The date of the deposit follows the option of the core, so the e-invoice reads the same way as the
+	 * PDF it accompanies.
+	 *
+	 * @return void
+	 */
+	public function testTheDepositDateFollowsTheOptionOfTheCore()
+	{
+		global $conf, $langs;
+
+		$savOption = getDolGlobalString('INVOICE_ADD_DEPOSIT_DATE');
+
+		$conf->global->INVOICE_ADD_DEPOSIT_DATE = '';
+		$withoutDate = einvoicingDiscountLabel($this->discount(), '(DEPOSIT)', $langs);
+
+		$conf->global->INVOICE_ADD_DEPOSIT_DATE = '1';
+		$withDate = einvoicingDiscountLabel($this->discount(), '(DEPOSIT)', $langs);
+
+		$conf->global->INVOICE_ADD_DEPOSIT_DATE = $savOption;
+
+		$this->assertNotSame($withoutDate, $withDate);
+		$this->assertStringStartsWith($withoutDate, $withDate);
+	}
+}

--- a/einvoicing/test/phpunit/DiscountSentinelTest.php
+++ b/einvoicing/test/phpunit/DiscountSentinelTest.php
@@ -75,6 +75,23 @@ class DiscountSentinelTest extends CommonClassTest
 	}
 
 	/**
+	 * A line of the invoice, reduced to the two fields the resolution reads on it: the description it
+	 * carries, and the discount it points at - 0 for a line that points at none.
+	 *
+	 * @param	string	$desc				->desc, the description the core stores on the line
+	 * @param	int		$fk_remise_except	->fk_remise_except, the discount behind the line
+	 * @return	stdClass
+	 */
+	private function line($desc, $fk_remise_except)
+	{
+		$line = new stdClass();
+		$line->desc = $desc;
+		$line->fk_remise_except = $fk_remise_except;
+
+		return $line;
+	}
+
+	/**
 	 * A discount object that was never fetched: nothing to read on it, which is what a deleted or
 	 * unreadable source piece leaves behind.
 	 *
@@ -244,5 +261,36 @@ class DiscountSentinelTest extends CommonClassTest
 
 		$this->assertNotSame($withoutDate, $withDate);
 		$this->assertStringStartsWith($withoutDate, $withDate);
+	}
+
+	/**
+	 * A line an operator named after a sentinel, carrying no discount, keeps the name it was given.
+	 *
+	 * This is the half of the test of the core that lives on the line and not on the description: a
+	 * line of work can be named '(DEPOSIT)' and point at nothing, and the resolution has no business
+	 * renaming it. It used to go out as 'Down payment deducted', under the wording meant for a
+	 * discount whose source piece cannot be read - which says something false about a line that
+	 * deducts nothing at all.
+	 *
+	 * @return void
+	 */
+	public function testASentinelNameOnALineWithNoDiscountIsLeftAlone()
+	{
+		global $langs;
+
+		foreach (array_keys(einvoicingDiscountSentinels()) as $sentinel) {
+			$this->assertSame('', einvoicingDiscountLabelOfLine($this->line($sentinel, 0), null, $langs));
+		}
+
+		// And the line that does carry a discount is still resolved, sentinel by sentinel.
+		foreach (array_keys(einvoicingDiscountSentinels()) as $sentinel) {
+			$label = einvoicingDiscountLabelOfLine($this->line($sentinel, 24), $this->discount(), $langs);
+
+			$this->assertNotSame('', $label);
+			$this->assertStringNotContainsString($sentinel, $label);
+		}
+
+		// A line of work quoting a sentinel inside a sentence is untouched either way, discount or not.
+		$this->assertSame('', einvoicingDiscountLabelOfLine($this->line('Reprise (DEPOSIT) du chantier', 24), $this->discount(), $langs));
 	}
 }


### PR DESCRIPTION
## What this changes

A discount built from another piece — a credit note applied, a deposit deducted, an excess payment
carried over — carries no wording of its own. The core writes one of four sentinels in the description
of the discount, `insert_discount()` copies it into the description of the line, and
`pdf_getlinedesc()` resolves it against the piece it comes from when it prints.

Nothing resolved it for the e-invoice. The customer received the raw marker, in two places:

- **BT-97**, the reason of a document level allowance: `<ram:Reason>(CREDIT_NOTE)</ram:Reason>`
- **BT-153**, the item name of a deducted deposit line, which stays a line in the document (method 1 of
  XP Z12-014): `<ram:Name>(DEPOSIT)</ram:Name>`

They now read the same text as the PDF, naming the piece the amount comes from, and beside it the
invoice that piece corrects — a deduction that only says which credit note it comes from leaves the
customer to find which invoice that credit note was about.

## Why not a search through the text

The test is the one the core makes: an exact description on a line that really carries a discount
(`fk_remise_except`). Matching the text loosely is wrong in both directions — a line of work named
`Reprise (DEPOSIT) du chantier` would be renamed, and a description edited by hand would be missed.

And the four sentinels are not spelled alike: `(CREDIT_NOTE)` holds an underscore where `(EXCESS PAID)`
and `(EXCESS RECEIVED)` hold a space. A single pattern over `[A-Z_]+` misses two of the four.

The reference the text quotes follows the side the discount belongs to
(`ref_invoice_supplier_source` when `discount_type` is set, `ref_facture_source` otherwise); reading the
customer side unconditionally names nothing at all on a supplier discount.

## A line named `(DEPOSIT)` that deducts nothing

`main` treats any line whose description is exactly `(DEPOSIT)` as a deducted deposit without ever
looking at `fk_remise_except`, and flips its sign. A line of work an operator happened to name that way
took a 300 € invoice out at `-300.00` — basis, grand total and amount due — so the document declared
that the seller owed the customer the price of the job. This is the most expensive defect of the lot and
it was missing from this description until the review pointed it out.

The test here is the one the core makes, both halves of it: the description **and** the discount the
line points at. Such a line now keeps its name, its sign and its amount.

The second half lives in `einvoicingDiscountLabelOfLine()` rather than inline in the condition, because
the two call sites do not read a line the same way. The one writing BT-97 already stands inside a test
on `fk_remise_except`, and it must still resolve when the discount behind it cannot be fetched — that
is what the `...NoSource` wording exists for. Reached from a line carrying no discount at all, that same
wording would state that a line deducting nothing is a deposit deducted, which is a different situation
and a false one.

## A line with no name

While looking at what reaches BT-153: a line holding neither a product label nor a description is
issued with an empty name, and refused by the platform on **BR-25**, on a line number the seller then
has to go and find.

`validateInvoiceConfiguration()` now lists every such line before validation, and the generator refuses
to build the document, naming them all at once rather than one refusal per round trip. Title and
subtotal pseudo-lines are not concerned, and neither are discount lines, whose name is built from the
piece they deduct.

The shape that gets there is not an empty description: the free-line branch of the card refuses that on
every core from 18 to 24 (`empty($product_desc)`, renamed `$line_desc` in 22). It is a description made
of markup only — `<p><br></p>`, what the WYSIWYG editor leaves behind when the text is deleted. The POST
is not empty, so the card accepts the line, and `dol_string_nohtmltag()` then strips it to nothing.

## A last look before the document leaves

One shared list, `einvoicingDiscountSentinels()`, feeds both the resolution and a final check that
reports a sentinel having reached BT-153, BT-154 or BT-97. Two lists would let one spelling drift on one
side only, which is the shape of the original defect.

That check is an equality, never an inclusion, and it reports in the log rather than refusing: an
unresolved marker is ugly, not invalid, and holding an invoice back over it would cost the seller more
than it saves. It exists because the leak was found in two places, the second after the first was
fixed — an analysis can miss a construction path.

## Tests

`test/phpunit/DiscountSentinelTest.php`, registered in `AllTests.php`: the four sentinels and the piece
each names, the supplier side reference, the false positives that must go out untouched, the case with
no readable source piece, a line named after a sentinel while carrying no discount (each of the four,
with and without a discount behind the line), the corrected invoice named beside the piece, the deposit
date option, and the exact spelling of the four sentinels pinned against a future drift.

Verified end to end on an instance running Dolibarr 23.0.3: on the invoice that carried four
`(CREDIT_NOTE)` allowances, the regenerated CII differs from the previous one by those four reasons and
nothing else — no total moved.

## Housekeeping

Rebased on `main` (c06deafe).

The amounts half of this branch is gone. `main` now reads BT-113 from `getSommePaiement()`,
`getSumDepositsUsed()` and `getSumCreditNotesUsed()`, and joins the BT-25/BT-26 references on the type
of the source invoice — which is what the review suggested, and a better job than the three-value `IN`
over descriptions this branch carried: it holds by construction and hands over `f.type` for the
document type codes rather than deriving one back from a description string. Nothing of it is left here.

`AllTests.php` is out as well, `main` having replaced the hand written list with a `glob()`. The
`ChangeLog.md` entry is gone from the whole series and not only from its final state, the file being
regenerated from commit titles, and `langs/fr_FR/einvoicing.lang` is out too — translations other than
`en_US` come back through the translation platform.

What remains is the resolution of the four sentinels, the line named after one while deducting nothing,
the BR-25 refusal and the last look.
