### PR TITLE
FIX [einvoicing] The three check endpoints stop building their provider list without $mysoc

### DIFF
--- a/einvoicing/ajax/checkdirectory.php
+++ b/einvoicing/ajax/checkdirectory.php
@@ -32,9 +32,8 @@ if (!defined('NOREQUIREHTML')) {
 if (!defined('NOREQUIREAJAX')) {
 	define('NOREQUIREAJAX', '1');
 }
-if (!defined('NOREQUIRESOC')) {
-	define('NOREQUIRESOC', '1');
-}
+// NOREQUIRESOC is deliberately not defined here: this endpoint builds a PDPProviderManager, which reads
+// $mysoc->country_code to decide the list of providers, so $mysoc must exist.
 if (!defined('NOCSRFCHECK')) {
 	define('NOCSRFCHECK', '1');
 }

--- a/einvoicing/ajax/checkinvoicestatus.php
+++ b/einvoicing/ajax/checkinvoicestatus.php
@@ -35,9 +35,8 @@ if (!defined('NOREQUIREHTML')) {
 if (!defined('NOREQUIREAJAX')) {
 	define('NOREQUIREAJAX', '1');
 }
-if (!defined('NOREQUIRESOC')) {
-	define('NOREQUIRESOC', '1');
-}
+// NOREQUIRESOC is deliberately not defined here: this endpoint builds a PDPProviderManager, which reads
+// $mysoc->country_code to decide the list of providers, so $mysoc must exist.
 if (!defined('NOCSRFCHECK')) {
 	define('NOCSRFCHECK', '1');
 }

--- a/einvoicing/ajax/checksupplierinvoicestatus.php
+++ b/einvoicing/ajax/checksupplierinvoicestatus.php
@@ -35,9 +35,8 @@ if (!defined('NOREQUIREHTML')) {
 if (!defined('NOREQUIREAJAX')) {
 	define('NOREQUIREAJAX', '1');
 }
-if (!defined('NOREQUIRESOC')) {
-	define('NOREQUIRESOC', '1');
-}
+// NOREQUIRESOC is deliberately not defined here: this endpoint builds a PDPProviderManager, which reads
+// $mysoc->country_code to decide the list of providers, so $mysoc must exist.
 if (!defined('NOCSRFCHECK')) {
 	define('NOCSRFCHECK', '1');
 }


### PR DESCRIPTION
## The bug

`ajax/checkdirectory.php`, `ajax/checkinvoicestatus.php` and `ajax/checksupplierinvoicestatus.php` define `NOREQUIRESOC`, so `master.inc.php` never builds `$mysoc`. All three then instantiate `PDPProviderManager`, whose constructor reads that object:

```php
// class/providers/PDPProviderManager.class.php:93
if ($mysoc->country_code != 'FR' || getDolGlobalString('EINVOICING_ALLOW_DEVTOOLS')) {
	$this->providersList['TESTPDP'] = array(...);
}
```

Two consequences, both in normal use — the invoice card fires these endpoints on its own:

1. every call writes `PHP Warning: Attempt to read property "country_code" on null` to the server log;
2. `null->country_code` is `null`, so `null != 'FR'` is **true** and the generation-only **`TESTPDP` provider is added to the list** on a French installation that must not see it. The list is not only internal: it is handed to the `einvoicingProviders` hook (`$parameters = array('providersList' => …)`, line 199), so another module reads the wrong one too.

The admin screen is not affected — it does not define `NOREQUIRESOC`, so it builds the right list. Only these three endpoints do.

## The fix

`NOREQUIRESOC` is removed from the three files, with a comment in place of the block saying why it must not come back. Nothing else changes: 3 files, +6 −9.

Guarding the read instead (`is_object($mysoc)`) was the other option. It would silence the warning, but it would leave the endpoints running without the object the module is entitled to, and it hides rather than removes the reason `TESTPDP` appeared. Happy to add the guard on top if you want the class hardened for future callers — it is one line and the two do not exclude each other.

## Measured over HTTP, not deduced

Seven instances, Dolibarr 18.0.10 → 24.0.0, same bench, same data, same logged-in user; the module tree is swapped between the two runs and php-fpm restarted, and each run asserts which tree served the request before measuring.

**The provider list the endpoints actually build**, read from a page carrying the exact header of `checkdirectory.php`:

| | before | after |
|---|---|---|
| 18.0.10 · 19.0.4 · 20.0.4 · 21.0.4 · 22.0.5 · 23.0.4 · 24.0.0 | `mysoc=NULL` → `ESALINK,SUPERPDP,TESTPDP` | `mysoc=Societe country=FR` → `ESALINK,SUPERPDP` |

**The warnings**, counted in the server error log around the three calls, per instance:

| instance | before | after | HTTP |
|---|---|---|---|
| 18.0.10 | 3 | **0** | 200 / 200 / 200 |
| 19.0.4 | 3 | **0** | 200 / 200 / 200 |
| 20.0.4 | 3 | **0** | 200 / 200 / 200 |
| 21.0.4 | 3 | **0** | 200 / 200 / 200 |
| 22.0.5 | 3 | **0** | 200 / 200 / 200 |
| 23.0.4 | 3 | **0** | 200 / 200 / 200 |
| 24.0.0 | 3 | **0** | 200 / 200 / 200 |

21 calls, 21 warnings before, none after, and every endpoint still answers its real payload (the directory check reaches the provider and returns `httpcode 200`, the two status checks return their status label).

## What loading `$mysoc` costs: nothing

`Societe::setMysoc()` reads the `MAIN_INFO_SOCIETE_*` constants that the page has already fetched with its single `llx_const` query, so no query is added. Counted with the MariaDB general log, one call each, warm:

| endpoint | queries before | queries after |
|---|---|---|
| `checkdirectory.php` | 32 | 32 |
| `checkinvoicestatus.php` | 20 | 20 |
| `checksupplierinvoicestatus.php` | 33 | 33 |

The statement lists are identical apart from one `UPDATE llx_actioncomm SET ref=…`, which is the agenda event the supplier check writes, present in both runs.

`phpunit`: 135/136 green on the bench before and after (the single failure is `EInvoicingSamplesTest` on Dolibarr 17, which the module no longer targets), three consecutive runs.
