### PR TITLE
FIX #726 [einvoicing] A received line with an amount but no quantity stops being imported as zero

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -1565,12 +1565,14 @@ class CIIProtocol extends AbstractProtocol
 	 *    header, a subtotal. BR-FREXT-CO-10 sums BT-106 over the DETAIL lines only, so such a line carries
 	 *    no amount of its own and importing it as a priced line would count its amount a second time. It
 	 *    becomes a text line. BR-FREXT-BR-22 is also why it may carry no quantity at all.
-	 * 2. A regular item with an amount but no invoiced quantity. On the EN 16931 profile the document is
-	 *    already non-conformant - BR-22 is fatal and only tests the presence of ram:BilledQuantity, so a
-	 *    quantity of zero passes and an absent element does not - but the document has been received and
-	 *    it states what is owed. Quantity times price would make the line zero and change the total of the
-	 *    invoice without a word, so the amount is carried as a single unit instead, the way it would be
-	 *    keyed in by hand.
+	 * 2. A regular item that announces an amount its quantity cannot rebuild, because that quantity is
+	 *    zero or absent. Such a document is not necessarily wrong: BR-22 only tests the presence of
+	 *    ram:BilledQuantity, so a quantity of zero satisfies it, and nothing in EN 16931 requires BT-131 to
+	 *    equal BT-129 times BT-146. The document of issue #726 is exactly that - EXTENDED CTC-FR, a line
+	 *    carrying <BilledQuantity unitCode="C62">0.0000</BilledQuantity>, no BT-X-8, and a BT-131 of 12.00
+	 *    that BR-FREXT-CO-10 does count into BT-106. It is therefore the import that has to cope: quantity
+	 *    times price makes the line zero and changes the total of the invoice without a word, so the amount
+	 *    is carried as a single unit instead, the way it would be keyed in by hand.
 	 * 3. Everything else: check that what the core is about to compute is what the document announces, and
 	 *    say so when it is not. The tolerance is the one BR-FREXT-CO-10 applies to the totals.
 	 *
@@ -1591,7 +1593,7 @@ class CIIProtocol extends AbstractProtocol
 
 		if (empty($qty) && !empty($announced)) {
 			$warning = 'Line ' . $lineid . ' of the received document carries a net amount (BT-131) of ' . $announced
-				. ' but no invoiced quantity (BT-129), which BR-22 requires. It was imported as a single unit at that amount, so the total of the invoice matches the document.';
+				. ' while its invoiced quantity (BT-129) is zero or absent, so quantity times unit price rebuilds 0.00. It was imported as a single unit at that amount, so the total of the invoice matches the document.';
 
 			return array('qty' => 1.0, 'subprice' => $announced, 'remise_percent' => 0.0, 'warning' => $warning);
 		}

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -262,8 +262,12 @@ class CIIProtocol extends AbstractProtocol
 		$this->lineTemplate = [
 
 			'lineid' => './ram:AssociatedDocumentLineDocument/ram:LineID',
-			'linestatuscode' => 'NA',
-			'linestatusreasoncode' => 'NA',
+			// BT-X-7 / BT-X-8, the EXTENDED status of the line. Absent from the EN 16931 profile, where
+			// every line is a regular one; on EXTENDED CTC-FR the reason code tells a real invoice line
+			// (DETAIL) from a line that only carries text or a subtotal, and the French rules treat the
+			// two differently - see isDetailLine().
+			'linestatuscode' => './ram:AssociatedDocumentLineDocument/ram:LineStatusCode',
+			'linestatusreasoncode' => './ram:AssociatedDocumentLineDocument/ram:LineStatusReasonCode',
 			'lineNote' => './ram:AssociatedDocumentLineDocument/ram:IncludedNote/ram:Content',
 
 			'prodname' => './ram:SpecifiedTradeProduct/ram:Name',
@@ -444,8 +448,8 @@ class CIIProtocol extends AbstractProtocol
 		 * }	$invoiceData
 		 * @var array<int, array{
 		 *   lineid: int,
-		 *   linestatuscode: 'NA',
-		 *   linestatusreasoncode: 'NA',
+		 *   linestatuscode: null|string,
+		 *   linestatusreasoncode: null|string,
 		 *   lineNote: null,
 		 *   prodname: string,
 		 *   proddesc: string,
@@ -502,7 +506,7 @@ class CIIProtocol extends AbstractProtocol
 		'
 		@phan-var-force Facture 			$object			The $invoice object used in entry on inc file, but completed.
 		@phan-var-force array{documentno:string,documenttypecode:null|string,documentdate:DateTimeInterface,invoiceCurrency:string|array<string>,taxCurrency:null,documentname:null,documentlanguage:string,effectiveSpecifiedPeriod:\'NA\',documentDeliveryDate:DateTimeInterface,invoicingPeriodStart:?DateTimeInterface,invoicingPeriodEnd:?DateTimeInterface,businessProcessId:string,isTestDocument:bool,documentNotePublic:string,documentNotePMT:string,documentNotePMD:string,documentNoteAAB:string,documentNoteTXD:string,documentNotes:array,vatDueDateTypeCode:string,sellername:string,sellerids:string,sellerlineone:string,sellerlinetwo:string,sellerlinethree:string,sellerpostcode:string,sellercity:string,sellercountry:string,sellersubdivision:null,sellercontactpersonname:string,sellercontactdepartmentname:null,sellercontactphoneno:string,sellercontactfaxno:string,sellercontactemailaddr:string,sellerCommunicationUriScheme:string,sellerCommunicationUri:string,sellerGlobalIds:array<array{schemeID:string,value:string}>,sellerTaxRegistrations:array<array{type:string,value:string}>,sellervatnumber:string,sellerLegalOrgId:string,sellerLegalOrgScheme:string,sellerTradingName:string,buyername:string,buyerids:string,buyerlineone:string,buyerlinetwo:string,buyerlinethree:string,buyerpostcode:string,buyercity:string,buyercountry:string,buyersubdivision:null,buyervatnumber:string,buyerGlobalIds:array<array{schemeID:string,value:string}>,buyerRoutingCode:null|string,buyerLegalOrgId:string,buyerLegalOrgScheme:string,buyerTradingName:string,buyerReference:null|string,buyerCommunicationUriScheme:string,buyerCommunicationUri:string,buyercontactpersonname:null,buyercontactemailaddr:null,buyercontactphoneno:null,grandTotalAmount:float|int,duePayableAmount:float|int,lineTotalAmount:float|int,chargeTotalAmount:float,allowanceTotalAmount:float|int,taxBasisTotalAmount:float|int,taxTotalAmount:float|int,roundingAmount:null,totalPrepaidAmount:float|int,iban_id:int,iban:string,bic:string,accountName:string,accountRef:string,accountLabel:string,paymentDueDate:DateTimeInterface,paymentTermsText:string,headerAllowancesCharges:array,invoiceRefDocs:array|array<array{ref:string|int,date:DateTimeInterface,type:string}>,orderReference:string,contractReference:null|string,despatchAdviceRef:null,taxBreakdown:array|array<array<string,array>>,_chorus:bool,_depositlines:array|array<array{lineId:int,invoiceRef:string,invoiceDate:DateTimeInterface}>,_globalDiscounts:array|array<array{value:float,reason:string,taxRate:float,categoryVAT:string}>,_customerOrderReferenceList:string[],_project:Project|null,paymentMeansCode?:int,paymentMeansText?:string,_shipFromContactBill?:array{address:null|string,zip:null|string,town:null|string,country:string},_shipFromContactShip?:array{name:string,address:null|string,zip:null|string,town:null|string,country:string}} $invoiceData
-		@phan-var-force array<int,array{lineid:int,linestatuscode:\'NA\',linestatusreasoncode:\'NA\',lineNote:null,prodname:string,proddesc:string,prodsellerid:string,prodbuyerid:null|string,prodglobalidtype:null|string,prodglobalid:null|string,prodmultilangs:array,prodClassificationCode:null|string,prodClassificationScheme:null|string,prodOriginCountry:null|string,netpriceamount:float,netpricebasisquantity:null|float,netpricebasisquantityunitcode:null|string,billedquantity:float,billedquantityunitcode:string,chargeFreeQuantity:null|float,chargeFreeQuantityunitcode:null|string,packageQuantity:null|float,packageQuantityunitcode:null|string,lineTotalAmount:float|string,totalAllowanceChargeAmount:null|float,categoryCode:string,typeCode:\'VAT\',rateApplicablePercent:string,tva_tx:float|string,vat_src_code:string,ExemptionReason:string,ExemptionReasonCode:string,calculatedAmount:null|float,lineAllowances:array,lineGrossPriceAllowances:array,lineremisepercent:\'NA\'|float,linePeriodStart:?DateTimeInterface,linePeriodEnd:?DateTimeInterface,additionalRefDocs:array,isDepositLine:bool,depositInvoiceRef:null|string,depositInvoiceDate:?DateTimeInterface,parentDocumentNo:null|string,is_deposit:int<0,1>,fk_remise:null|int,discountPercent:float,grosspriceamount:null|float,grosspricebasisquantity:null|float,grosspricebasisquantityunitcode:null|string}> $linesData
+		@phan-var-force array<int,array{lineid:int,linestatuscode:null|string,linestatusreasoncode:null|string,lineNote:null,prodname:string,proddesc:string,prodsellerid:string,prodbuyerid:null|string,prodglobalidtype:null|string,prodglobalid:null|string,prodmultilangs:array,prodClassificationCode:null|string,prodClassificationScheme:null|string,prodOriginCountry:null|string,netpriceamount:float,netpricebasisquantity:null|float,netpricebasisquantityunitcode:null|string,billedquantity:float,billedquantityunitcode:string,chargeFreeQuantity:null|float,chargeFreeQuantityunitcode:null|string,packageQuantity:null|float,packageQuantityunitcode:null|string,lineTotalAmount:float|string,totalAllowanceChargeAmount:null|float,categoryCode:string,typeCode:\'VAT\',rateApplicablePercent:string,tva_tx:float|string,vat_src_code:string,ExemptionReason:string,ExemptionReasonCode:string,calculatedAmount:null|float,lineAllowances:array,lineGrossPriceAllowances:array,lineremisepercent:\'NA\'|float,linePeriodStart:?DateTimeInterface,linePeriodEnd:?DateTimeInterface,additionalRefDocs:array,isDepositLine:bool,depositInvoiceRef:null|string,depositInvoiceDate:?DateTimeInterface,parentDocumentNo:null|string,is_deposit:int<0,1>,fk_remise:null|int,discountPercent:float,grosspriceamount:null|float,grosspricebasisquantity:null|float,grosspricebasisquantityunitcode:null|string}> $linesData
 		@phan-var-force string 				$outputlang		Value of $outputlangs->defaultlang
 		@phan-var-force Account				$account
 		@phan-var-force EInvoicing			$einvoicing
@@ -1354,6 +1358,23 @@ class CIIProtocol extends AbstractProtocol
 			$line->total_tva = $parsedLine['calculatedAmount'] ?? 0;
 			$line->total_ttc = $parsedLine['lineTotalAmount'] + ($parsedLine['calculatedAmount'] ?? 0);
 
+			// The three properties just set are not what reaches the database: the line is written by
+			// createSupplierInvoiceLinesIntoDatabase(), which hands quantity, unit price and discount to
+			// FactureFournisseur::updateline() and lets the core recompute the totals. So BT-131 is read
+			// and then dropped, and whatever quantity times price gives is what the invoice ends up with.
+			// A deposit line is left alone: its amount does not come from the document but from the
+			// discount created out of the deposit invoice.
+			if (!$is_deposit_line) {
+				$amounts = $this->resolveLineAmounts($parsedLine, (float) $line->qty, (float) $line->subprice, (float) $line->remise_percent);
+				$line->qty = $amounts['qty'];
+				$line->subprice = $amounts['subprice'];
+				$line->remise_percent = $amounts['remise_percent'];
+				if ($amounts['warning'] !== '') {
+					$return_messages[] = $amounts['warning'];
+					dol_syslog(get_class($this) . '::createSupplierInvoiceLinesFromSource ' . $amounts['warning'], LOG_WARNING);
+				}
+			}
+
 			// Billing period of the line (BT-134 / BT-135). The two dates were read from the document and
 			// then went nowhere: createSupplierInvoiceLinesIntoDatabase() has always handed
 			// $line->date_start / ->date_end to updateline(), but nothing ever set them, so a service line
@@ -1531,6 +1552,87 @@ class CIIProtocol extends AbstractProtocol
 		$v = str_replace(',', '.', trim($v));
 		return is_numeric($v) ? (float) $v : null;
 	}
+
+	/**
+	 * Decide the quantity, unit price and discount a received line must carry in Dolibarr.
+	 *
+	 * The line is written by createSupplierInvoiceLinesIntoDatabase(), which hands those three to
+	 * FactureFournisseur::updateline() and lets the core recompute the totals of the line. The net amount
+	 * the document announces for the line, BT-131, is therefore never stored as such: whatever quantity
+	 * times unit price gives is what the invoice ends up with. Three cases have to be told apart.
+	 *
+	 * 1. A line that is not a regular item - EXTENDED CTC-FR, BT-X-8 other than DETAIL: a comment, a group
+	 *    header, a subtotal. BR-FREXT-CO-10 sums BT-106 over the DETAIL lines only, so such a line carries
+	 *    no amount of its own and importing it as a priced line would count its amount a second time. It
+	 *    becomes a text line. BR-FREXT-BR-22 is also why it may carry no quantity at all.
+	 * 2. A regular item with an amount but no invoiced quantity. On the EN 16931 profile the document is
+	 *    already non-conformant - BR-22 is fatal and only tests the presence of ram:BilledQuantity, so a
+	 *    quantity of zero passes and an absent element does not - but the document has been received and
+	 *    it states what is owed. Quantity times price would make the line zero and change the total of the
+	 *    invoice without a word, so the amount is carried as a single unit instead, the way it would be
+	 *    keyed in by hand.
+	 * 3. Everything else: check that what the core is about to compute is what the document announces, and
+	 *    say so when it is not. The tolerance is the one BR-FREXT-CO-10 applies to the totals.
+	 *
+	 * @param	array<string,mixed>		$parsedLine			One line as parseInvoiceLines() returns it
+	 * @param	float					$qty				Quantity read from the document (BT-129)
+	 * @param	float					$subprice			Unit price the caller resolved (BT-146, discount applied)
+	 * @param	float					$remisePercent		Discount percent the caller resolved
+	 * @return	array{qty:float,subprice:float,remise_percent:float,warning:string}	What to store, and what to report about it
+	 */
+	protected function resolveLineAmounts(array $parsedLine, $qty, $subprice, $remisePercent)
+	{
+		$lineid = (string) ($parsedLine['lineid'] ?? '?');
+		$announced = round((float) ($parsedLine['lineTotalAmount'] ?? 0), 2);
+
+		if (!$this->isDetailLine($parsedLine)) {
+			return array('qty' => 0.0, 'subprice' => 0.0, 'remise_percent' => 0.0, 'warning' => '');
+		}
+
+		if (empty($qty) && !empty($announced)) {
+			$warning = 'Line ' . $lineid . ' of the received document carries a net amount (BT-131) of ' . $announced
+				. ' but no invoiced quantity (BT-129), which BR-22 requires. It was imported as a single unit at that amount, so the total of the invoice matches the document.';
+
+			return array('qty' => 1.0, 'subprice' => $announced, 'remise_percent' => 0.0, 'warning' => $warning);
+		}
+
+		$rebuilt = round($qty * $subprice * (1 - ($remisePercent / 100)), 2);
+		$warning = '';
+		if (abs($rebuilt - $announced) > 0.01) {
+			$warning = 'Line ' . $lineid . ' of the received document announces a net amount (BT-131) of ' . $announced
+				. ', but its quantity and unit price rebuild ' . $rebuilt . '. The invoice carries the rebuilt amount.';
+		}
+
+		return array('qty' => $qty, 'subprice' => $subprice, 'remise_percent' => $remisePercent, 'warning' => $warning);
+	}
+
+
+	/**
+	 * Tell whether a parsed line is a regular invoice item, the only kind that carries an amount.
+	 *
+	 * EN 16931 has one sort of line and every one of them is priced. The EXTENDED profile adds a subtype,
+	 * BT-X-8, carried by ram:AssociatedDocumentLineDocument/ram:LineStatusReasonCode, and the French rules
+	 * hang two behaviours on it:
+	 *
+	 * - BR-FREXT-BR-22 requires the invoiced quantity (BT-129) only when the subtype is DETAIL or absent,
+	 *   so a comment or a group header may legitimately carry no quantity at all;
+	 * - BR-FREXT-CO-10 sums BT-131 into BT-106 over those same lines only:
+	 *   [not(ram:AssociatedDocumentLineDocument/ram:LineStatusReasonCode)
+	 *    or ram:AssociatedDocumentLineDocument/ram:LineStatusReasonCode = 'DETAIL'].
+	 *
+	 * The predicate below is that XPath. An absent code means a regular item, which is also what every
+	 * EN 16931 document gives, so nothing changes for the profiles that have no subtype.
+	 *
+	 * @param	array<string,mixed>		$parsedLine		One line as parseInvoiceLines() returns it
+	 * @return	bool									True for a regular item, false for a line that carries no amount
+	 */
+	protected function isDetailLine(array $parsedLine)
+	{
+		$reason = trim((string) ($parsedLine['linestatusreasoncode'] ?? ''));
+
+		return $reason === '' || strtoupper($reason) === 'DETAIL';
+	}
+
 
 	/**
 	 * Billing period of a received line (BG-26 / BT-134 / BT-135), as the timestamps a Dolibarr line holds.

--- a/einvoicing/test/phpunit/AllTests.php
+++ b/einvoicing/test/phpunit/AllTests.php
@@ -121,6 +121,8 @@ class AllTests
 		$suite->addTestSuite('EInvoicingSamplesTest');
 		require_once dirname(__FILE__).'/InvoicingPeriodTest.php';
 		$suite->addTestSuite('InvoicingPeriodTest');
+		require_once dirname(__FILE__).'/LineWithoutQuantityTest.php';
+		$suite->addTestSuite('LineWithoutQuantityTest');
 		require_once dirname(__FILE__).'/PDPProviderManagerTest.php';
 		$suite->addTestSuite('PDPProviderManagerTest');
 		require_once dirname(__FILE__).'/RecipientDirectoryTest.php';

--- a/einvoicing/test/phpunit/LineWithoutQuantityTest.php
+++ b/einvoicing/test/phpunit/LineWithoutQuantityTest.php
@@ -1,0 +1,294 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/LineWithoutQuantityTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for a received line that carries an amount but no invoiced quantity
+ *                  (issue #726), and for the subtype of an EXTENDED line.
+ *
+ *                  BR-22 is fatal on the EN 16931 profile and tests the presence of
+ *                  ram:BilledQuantity, so a quantity of zero passes and an absent element does not.
+ *                  On EXTENDED CTC-FR, BR-FREXT-BR-22 requires it only for a line whose subtype
+ *                  BT-X-8 is DETAIL or absent, and BR-FREXT-CO-10 sums BT-131 into BT-106 over those
+ *                  same lines only. The parser has to read that subtype, and the import has to stop
+ *                  turning the amount of such a line into a silent zero.
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+dol_include_once('einvoicing/class/protocols/CIIProtocol.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class LineWithoutQuantityTest extends CommonClassTest
+{
+	/**
+	 * Call CIIProtocol::resolveLineAmounts() through reflection: pure decision logic, no DB access
+	 * and no side effect, the kind of protected method the project convention allows testing this way
+	 * instead of through a full import.
+	 *
+	 * @param	CIIProtocol		$protocol		Protocol instance
+	 * @param	array			$parsedLine		One line as parseInvoiceLines() returns it
+	 * @param	float			$qty			Quantity read from the document
+	 * @param	float			$subprice		Unit price resolved by the caller
+	 * @param	float			$remisePercent	Discount percent resolved by the caller
+	 * @return	array{qty:float,subprice:float,remise_percent:float,warning:string}	What the import would store
+	 */
+	private function callResolveLineAmounts(CIIProtocol $protocol, array $parsedLine, $qty, $subprice, $remisePercent = 0.0)
+	{
+		$method = new ReflectionMethod(CIIProtocol::class, 'resolveLineAmounts');
+		$method->setAccessible(true);
+
+		return $method->invoke($protocol, $parsedLine, $qty, $subprice, $remisePercent);
+	}
+
+	/**
+	 * Build a one-line CII document, with the line body given as a string.
+	 *
+	 * @param	string	$lineBody	The children of ram:IncludedSupplyChainTradeLineItem
+	 * @return	string				A parsable CII document
+	 */
+	private function documentWithLine($lineBody)
+	{
+		return '<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+  <rsm:ExchangedDocument><ram:ID>INV-726</ram:ID></rsm:ExchangedDocument>
+  <rsm:SupplyChainTradeTransaction>
+    <ram:IncludedSupplyChainTradeLineItem>' . $lineBody . '</ram:IncludedSupplyChainTradeLineItem>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>';
+	}
+
+	/**
+	 * The subtype of the line (BT-X-8) used to be hardcoded to the placeholder 'NA', so the import had
+	 * no way to tell a regular item from a comment or a subtotal. It is now read from the document.
+	 *
+	 * @return	void
+	 */
+	public function testLineSubtypeIsReadFromTheDocument()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$xml = $this->documentWithLine('
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>899</ram:LineID>
+        <ram:LineStatusCode>NEW</ram:LineStatusCode>
+        <ram:LineStatusReasonCode>INFORMATION</ram:LineStatusReasonCode>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct><ram:Name>COMMENT</ram:Name></ram:SpecifiedTradeProduct>');
+
+		$lines = $protocol->parseInvoiceLines($xml);
+		$this->assertCount(1, $lines);
+		$this->assertSame('NEW', $lines[0]['linestatuscode'], 'BT-X-7 reaches the parsed line');
+		$this->assertSame('INFORMATION', $lines[0]['linestatusreasoncode'], 'BT-X-8 reaches the parsed line');
+	}
+
+	/**
+	 * An EN 16931 document has no subtype at all, and every one of its lines is a regular item.
+	 *
+	 * @return	void
+	 */
+	public function testLineSubtypeIsEmptyWhenTheDocumentHasNone()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$xml = $this->documentWithLine('
+      <ram:AssociatedDocumentLineDocument><ram:LineID>1</ram:LineID></ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct><ram:Name>4W90111</ram:Name></ram:SpecifiedTradeProduct>');
+
+		$lines = $protocol->parseInvoiceLines($xml);
+		$this->assertCount(1, $lines);
+		$this->assertEmpty($lines[0]['linestatusreasoncode'], 'no BT-X-8 in the document, none in the line');
+		$this->assertTrue($this->isDetail($lines[0]), 'a line without a subtype is a regular item');
+	}
+
+	/**
+	 * The predicate of BR-FREXT-CO-10, over the codes a document can carry.
+	 *
+	 * @return	void
+	 */
+	public function testOnlyDetailLinesCarryAnAmount()
+	{
+		$this->assertTrue($this->isDetail(array()), 'an absent BT-X-8 means a regular item');
+		$this->assertTrue($this->isDetail(array('linestatusreasoncode' => null)));
+		$this->assertTrue($this->isDetail(array('linestatusreasoncode' => '')));
+		$this->assertTrue($this->isDetail(array('linestatusreasoncode' => 'DETAIL')));
+		$this->assertTrue($this->isDetail(array('linestatusreasoncode' => ' detail ')), 'the code is compared without case or padding');
+
+		$this->assertFalse($this->isDetail(array('linestatusreasoncode' => 'INFORMATION')));
+		$this->assertFalse($this->isDetail(array('linestatusreasoncode' => 'GROUP')));
+		$this->assertFalse($this->isDetail(array('linestatusreasoncode' => 'SUB_TOTAL')));
+	}
+
+	/**
+	 * Call CIIProtocol::isDetailLine() through reflection.
+	 *
+	 * @param	array	$parsedLine		One parsed line
+	 * @return	bool					What the predicate answers
+	 */
+	private function isDetail(array $parsedLine)
+	{
+		global $db;
+
+		$method = new ReflectionMethod(CIIProtocol::class, 'isDetailLine');
+		$method->setAccessible(true);
+
+		return $method->invoke(new CIIProtocol($db), $parsedLine);
+	}
+
+	/**
+	 * The reported case (issue #726): a line with a net amount and no invoiced quantity. The import used
+	 * to store a quantity of zero, so the core recomputed the line at 0.00 and the invoice no longer
+	 * totalled what the document announced.
+	 *
+	 * @return	void
+	 */
+	public function testAnAmountWithoutQuantityIsCarriedAsOneUnit()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$parsedLine = array('lineid' => '899', 'lineTotalAmount' => 12.0, 'linestatusreasoncode' => 'DETAIL');
+		$amounts = $this->callResolveLineAmounts($protocol, $parsedLine, 0.0, 12.0);
+
+		$this->assertSame(1.0, $amounts['qty'], 'the amount is carried as a single unit');
+		$this->assertSame(12.0, $amounts['subprice']);
+		$this->assertSame(0.0, $amounts['remise_percent']);
+		$this->assertStringContainsString('BT-129', $amounts['warning'], 'the repair is reported, not silent');
+		$this->assertStringContainsString('BR-22', $amounts['warning']);
+	}
+
+	/**
+	 * A line that is not a regular item carries no amount: BR-FREXT-CO-10 leaves it out of BT-106, so
+	 * importing it as a priced line would count its amount a second time.
+	 *
+	 * @return	void
+	 */
+	public function testANonDetailLineCarriesNoAmount()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$parsedLine = array('lineid' => '002', 'lineTotalAmount' => 12.0, 'linestatusreasoncode' => 'INFORMATION');
+		$amounts = $this->callResolveLineAmounts($protocol, $parsedLine, 0.0, 12.0);
+
+		$this->assertSame(0.0, $amounts['qty']);
+		$this->assertSame(0.0, $amounts['subprice']);
+		$this->assertSame('', $amounts['warning'], 'a comment line without a quantity is not an anomaly');
+	}
+
+	/**
+	 * A line that adds up is left exactly as it was, warning included: this is the whole existing corpus
+	 * of received documents, and it must not move.
+	 *
+	 * @return	void
+	 */
+	public function testALineThatAddsUpIsUntouched()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$parsedLine = array('lineid' => '001', 'lineTotalAmount' => 930.30, 'linestatusreasoncode' => '');
+		$amounts = $this->callResolveLineAmounts($protocol, $parsedLine, 2.0, 465.15);
+
+		$this->assertSame(2.0, $amounts['qty']);
+		$this->assertSame(465.15, $amounts['subprice']);
+		$this->assertSame('', $amounts['warning']);
+	}
+
+	/**
+	 * A discounted line still has to add up, the discount being applied.
+	 *
+	 * @return	void
+	 */
+	public function testADiscountedLineThatAddsUpIsUntouched()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$parsedLine = array('lineid' => '003', 'lineTotalAmount' => 90.0, 'linestatusreasoncode' => 'DETAIL');
+		$amounts = $this->callResolveLineAmounts($protocol, $parsedLine, 1.0, 100.0, 10.0);
+
+		$this->assertSame(1.0, $amounts['qty']);
+		$this->assertSame('', $amounts['warning'], '100.00 less 10 percent is the 90.00 the document announces');
+	}
+
+	/**
+	 * A line whose quantity and price do not rebuild what the document announces keeps the amount the
+	 * core computes - it is the only one Dolibarr can store - but says so.
+	 *
+	 * @return	void
+	 */
+	public function testAnAmountThatDoesNotRebuildIsReported()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$parsedLine = array('lineid' => '004', 'lineTotalAmount' => 100.0, 'linestatusreasoncode' => 'DETAIL');
+		$amounts = $this->callResolveLineAmounts($protocol, $parsedLine, 2.0, 40.0);
+
+		$this->assertSame(2.0, $amounts['qty'], 'nothing is invented, the document is only reported');
+		$this->assertSame(40.0, $amounts['subprice']);
+		$this->assertStringContainsString('BT-131', $amounts['warning']);
+		$this->assertStringContainsString('80', $amounts['warning'], 'the warning names what was rebuilt');
+	}
+
+	/**
+	 * A line at zero on both sides - a free sample, a heading - is not an anomaly and must stay silent.
+	 *
+	 * @return	void
+	 */
+	public function testAZeroLineIsNotReported()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$parsedLine = array('lineid' => '002', 'lineTotalAmount' => 0.0, 'linestatusreasoncode' => '');
+		$amounts = $this->callResolveLineAmounts($protocol, $parsedLine, 0.0, 0.0);
+
+		$this->assertSame(0.0, $amounts['qty']);
+		$this->assertSame('', $amounts['warning']);
+	}
+}

--- a/einvoicing/test/phpunit/LineWithoutQuantityTest.php
+++ b/einvoicing/test/phpunit/LineWithoutQuantityTest.php
@@ -192,7 +192,38 @@ class LineWithoutQuantityTest extends CommonClassTest
 		$this->assertSame(12.0, $amounts['subprice']);
 		$this->assertSame(0.0, $amounts['remise_percent']);
 		$this->assertStringContainsString('BT-129', $amounts['warning'], 'the repair is reported, not silent');
-		$this->assertStringContainsString('BR-22', $amounts['warning']);
+		$this->assertStringContainsString('BT-131', $amounts['warning']);
+	}
+
+	/**
+	 * The shape of the document actually reported on #726: the quantity is not absent, it is present and
+	 * zero - which satisfies BR-22, a presence test - and the line still announces 12.00.
+	 *
+	 * @return	void
+	 */
+	public function testAQuantityPresentAndZeroIsTreatedTheSameWay()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$xml = $this->documentWithLine('
+      <ram:AssociatedDocumentLineDocument><ram:LineID>899</ram:LineID></ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct><ram:Name>COMMENT</ram:Name></ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeDelivery><ram:BilledQuantity unitCode="C62">0.0000</ram:BilledQuantity></ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation><ram:LineTotalAmount>12.00</ram:LineTotalAmount></ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>');
+
+		$lines = $protocol->parseInvoiceLines($xml);
+		$this->assertCount(1, $lines);
+		$this->assertEquals(0.0, (float) $lines[0]['billedquantity'], 'BT-129 is there and it is zero');
+		$this->assertTrue($this->isDetail($lines[0]), 'no BT-X-8 means a regular item, whatever the product is called');
+
+		$amounts = $this->callResolveLineAmounts($protocol, $lines[0], (float) $lines[0]['billedquantity'], 12.0);
+		$this->assertSame(1.0, $amounts['qty']);
+		$this->assertSame(12.0, $amounts['subprice']);
+		$this->assertNotSame('', $amounts['warning']);
 	}
 
 	/**


### PR DESCRIPTION
**The XML has arrived on #726 and the diagnosis is confirmed** — with one correction to my own
reasoning, which this branch now carries.

The line does **not** lack its quantity. It carries `<BilledQuantity unitCode="C62">0.0000</BilledQuantity>`,
and `BR-22` is a *presence* test, so a zero satisfies it. The line carries no `LineStatusReasonCode`
either, so on the reported profile (`urn:cen.eu:en16931:2017#conformant#urn.cpro.gouv.fr:1p0:extended-ctc-fr`)
`BR-FREXT-BR-22` reads it as a regular item and `BR-FREXT-CO-10` counts its `LineTotalAmount` of 12.00
into BT-106. Nothing in EN 16931 requires BT-131 to equal BT-129 × BT-146. **The document is
conformant and it is the import that has to cope with it.**

The behaviour was already right — a quantity of zero and an absent one reach the same branch — so the
second commit changes no logic: it fixes the docblock, which claimed the document was
non-conformant, and the warning message, which named BR-22 as broken. It also adds a test built on the
line as posted, quantity present and zero.

---

**The second loss of #726 is now #731, fixed by #732.** This PR keeps the line-level half. The two are
independent, touch different methods, and can land in either order — measured together at the bottom of
this page. #726 holds **two** losses:

```
930.30   line 001
 12.00   line 899, BT-131            -> this PR
 10.40   document level charge, FC   -> not covered here
------
952.70   what the document announces ; Dolibarr showed 930.30
```

The second is `createHeaderDiscounts()`, which parses every document-level allowance and charge and
then skips the charges on purpose:

```php
// Skip charges
if (($allowanceCharge['indicator'] ?? '') !== 'false') {
    continue;
}
```

It has its own issue (#731) and its own pull request (#732), because it is a different defect in a
different method — but a user sees a single wrong total, so the two are worth looking at together.

## The defect

A supplier invoice imported from a received CII document did not total what the document announced.
The line is not stored with the amount the parser read: `createSupplierInvoiceLinesIntoDatabase()`
hands quantity, unit price and discount to `FactureFournisseur::updateline()`, and the core recomputes
the total from those three. So `$line->total_ht`, set from BT-131 a few lines earlier, is dropped, and
a quantity of zero makes the line worth zero, without a word anywhere.

## The change

One file plus its test.

- `lineTemplate` reads BT-X-7 and BT-X-8 from `ram:AssociatedDocumentLineDocument` instead of the
  placeholder `'NA'` they were hardcoded to. An EN 16931 document has neither, and an absent subtype
  means a regular item, so nothing moves for the profiles that do not carry one.
- `isDetailLine()` is the XPath predicate of `BR-FREXT-CO-10`, as a method.
- `resolveLineAmounts()` decides what the line stores, and returns what it has to say about it:
  1. **not a regular item** (BT-X-8 other than `DETAIL`) → no amount. BT-106 already excludes it, so
     importing it as a priced line added it a second time;
  2. **a regular item whose quantity cannot rebuild its amount** — zero or absent → the amount, carried
     as a single unit, the way it would be keyed in by hand. **This is the reported case**;
  3. **anything else** → untouched, and reported when quantity times price does not rebuild BT-131,
     with the 0.01 tolerance `BR-FREXT-CO-10` uses.
- Deposit lines are excluded: their amount comes from the discount built out of the deposit invoice,
  not from the document.

Case 1 is not exercised by the reported document, which carries no subtype at all; it is there because
reading BT-X-8 without acting on it would leave the double-count of a subtotal line in place.

`FacturXProtocol` shares the fix — it builds its lines through the same
`createSupplierInvoiceLinesFromSource()`.

(Rules quoted from the FNFE schematron, `fnfempe/France_RFE`, EUPL:
`CII/EN16931/schematron/EN16931-CII-validation-preprocessed.sch` and
`CII/EXTENDED-CTC-FR/schematron/EXTENDED-CTC-FR-CII.sch`.)

## Tested

`LineWithoutQuantityTest` (new, registered in `AllTests`): 10 tests, 39 assertions, green on the seven
instances. It pins the parsing of the subtype, the predicate over the codes a document can carry, and
the three branches including the two that must not move.

Live on the bench, **Dolibarr 18.0.10, 19.0.4, 20.0.4, 21.0.4, 22.0.5, 23.0.4 and 24.0.0**, documents
imported through `CIIProtocol::createSupplierInvoiceFromSource()` and read back from a second process.
Same base invoice of 450.23 HT plus one line worth 12.00:

| document | announced | `main` | this PR |
|---|---|---|---|
| **A** — regular line, 12.00, quantity absent | 554.67 | 540.27 ❌ | **554.67** ✅ |
| **B** — the same line marked `INFORMATION`, no quantity | 540.27 | 540.27 ✅ | 540.27 ✅ |
| **C** — an `INFORMATION` line carrying 2 × 6.00 | 540.27 | 554.67 ❌ counted twice | **540.27** ✅ |
| **D** — the reported shape: quantity present at `0.0000`, no BT-X-8, plus the `FC` charge of 10.40 | 567.16 | 540.27 ❌ | 554.67 ⚠️ the line is back, the charge is not |

A, B and C are identical on the seven instances; D was run on 18.0.10, 23.0.4 and 24.0.0. B is the
control that proves nothing moves where nothing should.

And the **real invoice of the reporter**, imported the same way — three lines totalling 942.30 (BT-106),
one `FC` charge of 10.40 (BT-108), 1143.24 TTC announced:

| tree | TTC obtained |
|---|---|
| `main` | 1116.36 — both amounts lost |
| **this PR** alone | 1130.76 |
| #732 alone (the charge) | 1128.84 |
| **both merged** | **1143.24** — exactly what the document announces |

Identical on 18.0.10, 23.0.4 and 24.0.0. The document was checked first with the FNFE schematron
(`fnfempe/France_RFE`, EUPL): XSD valid, `EXTENDED-CTC-FR-CII` **159 checks / 0 failure**,
`BR-FR-Flux2` 90 / 0 — it is conformant, the loss is entirely ours.

PHPUnit, the whole suite on the seven instances: 133 runs, 133 OK. `phpcs` clean with the Dolibarr
ruleset.

## Open, deliberately

The warnings of cases 2 and 3 reach `$return_messages`, so they end up in the message of the flow and
in `dol_syslog` at `LOG_WARNING`, but `syncFlows()` drops the message of a flow that succeeded — it
only counts it. Making an imported-with-warnings flow visible in the synchronization report is a change
to that loop, which is the subject of #718, so I have left it out rather than settle it by the side
door.


Round trip through the Access Point sandbox, on the tree holding **both** pull requests:
`allfullx.sh` → **14/14 complete cycles**, the seven versions in both directions, each with the whole
lifecycle `[200, 201, 205, 211, 212]`. None of those documents carries a document level charge or a
line without a quantity, which is the point: it is the non-regression control, and both changes are
inert on everything that does not hit them.
