### PR TITLE
FIX [einvoicing] Remove the unreachable shipping/delivery branch of _isLineFromExternalModule()

### DIFF
--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -1939,18 +1939,11 @@ trait CommonProtocol
 	 *    Check line type from external module ?
 	 *
 	 * @param  object $line       line we work on
-	 * @param  string $element    line object element (for special case like shipping)
 	 * @param  string $searchName module name we look for
 	 * @return boolean                        true if the line is a special one and was created by the module we ask for
 	 ************************************************/
-	private function _isLineFromExternalModule($line, $element, $searchName)
+	private function _isLineFromExternalModule($line, $searchName)
 	{
-		global $db;
-		if ($element == 'shipping' || $element == 'delivery') {
-			$fk_origin_line = $line->fk_origin_line;
-			$line = new OrderLine($db);
-			$line->fetch($fk_origin_line);
-		}
 		if ((int) $line->product_type != 9) {
 			return false;
 		}

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -389,7 +389,7 @@ foreach ($object->lines as $line) {
 	// they must not reach getCategoryRate() (would trigger a VATEX exemption error on rate 0 / no code).
 	// Detection is centralized in _isLineFromExternalModule(), which covers both the legacy modSubtotal
 	// module and the native core subtotal feature.
-	$isSubTotalLine = $this->_isLineFromExternalModule($line, $object->element, 'modSubtotal');
+	$isSubTotalLine = $this->_isLineFromExternalModule($line, 'modSubtotal');
 	if ($isSubTotalLine) {
 		continue;
 	}


### PR DESCRIPTION
Alternative to #728, which fixes a property name in a branch that cannot be entered. Rather than carrying a two-name compatibility shim on dead code, this removes it.

## Why the branch is unreachable

`_isLineFromExternalModule()` has exactly one caller, `einvoicing/lib/buildinvoicelines.inc.php:392`:

```php
$isSubTotalLine = $this->_isLineFromExternalModule($line, $object->element, 'modSubtotal');
```

and `$object` is built in that same file, at line 72:

```php
$tmpfacture = new Facture($db);
$object = $tmpfacture->fetch($invoice->id) > 0 ? $tmpfacture : $invoice;
```

`Facture::$element` is `'facture'` from 18 to 24 and its lines are `FactureLigne`. Every entry point that reaches the generation passes an invoice: the PDF hook guards with `$invoiceObject instanceof Facture`, the invoice-card action with `$object->element == 'facture'`, the list mass action builds `new Facture($db)`, and the specimen builds `new Facture($this->db)`. An invoice created *from* a shipment is not an exception either: `compta/facture/card.php` fetches the `Expedition` and copies its lines through `Facture::addline()`.

The branch comes from the initial factorization (`1a4e957`, then under the `pdpconnectfr` name), copied from the core PDF builders where the source object can legitimately be a shipment. Here it cannot, so `ExpeditionLigne` / `DeliveryLine` never take part in the generation.

## Test plan

- [x] `php -l` on both changed files, `phpcs` (repo ruleset) clean
- [x] Real chain on **Dolibarr 18.0.10, 20.0.4, 23.0.4 and 24.0.0**: order carrying a `product_type 9` title line → shipment → invoice created from that shipment (`llx_element_element`: `shipping#N -> facture#M`) with a title line on the invoice too → CII generation. On all four the second argument received is `facture`, the lines are `FactureLigne` (carrying neither `fk_origin_line` nor `fk_elementdet`), and the title line is skipped from the XML exactly as before the change: 2 invoice lines → 1 `IncludedSupplyChainTradeLineItem`, no `BENCH TITLE` text in the document.
- [x] Same run before and after the change, served from two private module trees so the comparison is code-only: identical results, and the run prints which tree it loaded (2 vs 3 parameters on the method) so a silent fallback to the other tree cannot pass unnoticed.
- [x] Module PHPUnit suite, A/B on the same four cores: **72 OK / 0 KO** with `main`, **72 OK / 0 KO** with this change.
- [x] Repo-wide check that no other call site or test passes the removed argument.

## Note for #728

The rename it describes is real for shipments — `ExpeditionLigne::fk_origin_line` (18/19) became `fk_elementdet` in 20, and moved to `expedition/class/expeditionligne.class.php` in 23/24 — and reading the old name on 20+ silently yields `null` (`DolDeprecationHandler::__get()`, `isDynamicPropertiesEnabled()` true, no alias in `deprecatedProperties()`). Two details do not hold, though: `DeliveryLine` still declares `fk_origin_line` on 20.0.4, 23.0.4 and 24.0.0, so the `delivery` half never changed; and the `Undefined property: stdClass::$fk_origin_line` quoted there comes from the `stdClass` mock, not from a core.

If the intent is instead to let the XML builder accept a shipment or a delivery as source object one day, then this PR should be dropped in favour of #728 — but that would need more than this branch, since nothing else in `buildinvoicelines.inc.php` handles a non-invoice object.
