### PR TITLE
FIX #731 [einvoicing] A document level charge (BG-21) of a received document stops leaving the total

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -3358,6 +3358,10 @@ class CIIProtocol extends AbstractProtocol
 	{
 		global $db, $langs;
 
+		if (empty($headerAllowancesCharges)) {
+			return array();
+		}
+
 		$chargeLines = array();
 
 		foreach ($headerAllowancesCharges as $allowanceCharge) {

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -1109,6 +1109,14 @@ class CIIProtocol extends AbstractProtocol
 				}
 			}
 
+			// Insert document level charges (BG-21) as lines of this supplier invoice
+			if (!empty($parsedHeader['headerAllowancesCharges'])) {
+				$chargeRes = $this->createHeaderChargeLines($supplierInvoiceId, $parsedHeader['headerAllowancesCharges'], $return_messages);
+				if ($chargeRes['res'] < 0) {
+					return $chargeRes;
+				}
+			}
+
 			// Create or update supplier prices for imported products
 			if (!empty($supplierPriceEntries)) {
 				require_once DOL_DOCUMENT_ROOT . '/fourn/class/fournisseur.product.class.php';
@@ -3282,6 +3290,114 @@ class CIIProtocol extends AbstractProtocol
 
 
 	/**
+	 * Carry the document level charges of a received document (BG-21) as lines of the supplier invoice.
+	 *
+	 * EN 16931 puts two symmetric groups at document level: BG-20, an allowance, which subtracts from the
+	 * total, and BG-21, a charge, which adds to it - freight, packaging, a handling fee. BR-CO-13 defines
+	 * the total of the invoice as
+	 * "Σ Invoice line net amount (BT-131) - Sum of allowances on document level (BT-107)
+	 *  + Sum of charges on document level (BT-108)",
+	 * so a charge is part of what is owed, exactly like a line is.
+	 *
+	 * In CII the two are the same element, ram:SpecifiedTradeAllowanceCharge, told apart only by
+	 * ram:ChargeIndicator/udt:Indicator. The allowances become a DiscountAbsolute, which is the object
+	 * Dolibarr has for them; the charges had nowhere to go, because a supplier invoice holds no positive
+	 * amount at document level, and they were dropped - the invoice then totalled less than the document
+	 * it came from, silently (issue #726).
+	 *
+	 * A line is what a human would key in, so that is what is written here: one line per charge, a single
+	 * unit at the charge amount (BT-99), with the VAT rate the charge declares (BT-103) and the reason it
+	 * gives (BT-104, or its reason code BT-105 when only that is present - BR-38 requires one of the two).
+	 * They are written through createSupplierInvoiceLinesIntoDatabase(), the same path as every other line
+	 * of the import, so nothing new touches the core.
+	 *
+	 * @param	int						$supplierInvoiceId			Id of the invoice being imported
+	 * @param	array<int,array<string,mixed>>	$headerAllowancesCharges	Parsed ram:SpecifiedTradeAllowanceCharge of the header
+	 * @param	array<int,string>		$return_messages			Messages of the import, completed here
+	 * @return	array{res:int,message?:string}						res 1 on success, -1 on failure
+	 */
+	protected function createHeaderChargeLines($supplierInvoiceId, array $headerAllowancesCharges, &$return_messages): array
+	{
+		global $db;
+
+		$chargeLines = $this->buildHeaderChargeLines($headerAllowancesCharges);
+
+		if (empty($chargeLines)) {
+			return ['res' => 1];
+		}
+
+		// Reuse the writer of the import rather than FactureFournisseur::addline(), whose signature moved
+		// between the supported cores: the invoice is reloaded and handed only the lines to add, so the
+		// ones already written are left alone.
+		$carrier = new FactureFournisseur($db);
+		if ($carrier->fetch((int) $supplierInvoiceId) <= 0) {
+			return ['res' => -1, 'message' => 'Failed to reload the supplier invoice to add its document level charges'];
+		}
+		$carrier->lines = $chargeLines;
+
+		if (!$this->createSupplierInvoiceLinesIntoDatabase($carrier)) {
+			return ['res' => -1, 'message' => 'Failed to add the document level charges of the received document as invoice lines'];
+		}
+
+		$return_messages[] = count($chargeLines) . ' document level charge(s) of the received document were added as invoice lines.';
+
+		return ['res' => 1];
+	}
+
+
+	/**
+	 * Turn the document level charges of a received document into the invoice lines that carry them.
+	 *
+	 * Split out of createHeaderChargeLines() because it is the whole decision - which entries are charges,
+	 * what each line is worth and how it is labelled - and it touches neither the database nor the core.
+	 *
+	 * @param	array<int,array<string,mixed>>	$headerAllowancesCharges	Parsed ram:SpecifiedTradeAllowanceCharge of the header
+	 * @return	SupplierInvoiceLine[]										One line per charge, in the order of the document
+	 */
+	protected function buildHeaderChargeLines(array $headerAllowancesCharges)
+	{
+		global $db, $langs;
+
+		$chargeLines = array();
+
+		foreach ($headerAllowancesCharges as $allowanceCharge) {
+			// Charges only (BG-21). The allowances are handled by createHeaderDiscounts().
+			if (($allowanceCharge['indicator'] ?? '') !== 'true') {
+				continue;
+			}
+
+			$actualAmount = (float) ($allowanceCharge['actualAmount'] ?? 0);
+			if ($actualAmount == 0.0) {
+				continue;
+			}
+
+			$reason = trim((string) ($allowanceCharge['reason'] ?? ''));
+			$reasonCode = trim((string) ($allowanceCharge['reasonCode'] ?? ''));
+			if ($reason === '') {
+				// BR-38 accepts a reason code alone, and a bare code says nothing to whoever reads the
+				// invoice, so it is labelled.
+				$reason = $langs->transnoentitiesnoconv('EInvoicingDocumentLevelCharge');
+				if ($reasonCode !== '') {
+					$reason .= ' (' . $reasonCode . ')';
+				}
+			}
+
+			$line = new SupplierInvoiceLine($db);
+			$line->desc = $reason;
+			$line->qty = 1;
+			$line->subprice = $actualAmount;
+			$line->tva_tx = (float) ($allowanceCharge['rateApplicablePercent'] ?? 0);
+			$line->product_type = 1;	// A charge is a service, never a stocked good
+			$line->remise_percent = 0;
+
+			$chargeLines[] = $line;
+		}
+
+		return $chargeLines;
+	}
+
+
+	/**
 	 * Create Dolibarr global discount exceptions from CII header allowances.
 	 *
 	 * Only processes allowances (indicator = "false"), ignores charges (indicator = "true").
@@ -3299,7 +3415,9 @@ class CIIProtocol extends AbstractProtocol
 		$result = [];
 
 		foreach ($headerAllowancesCharges as $index => $allowanceCharge) {
-			// Skip charges
+			// Allowances only (BG-20, ChargeIndicator false). A document level charge (BG-21) adds to the
+			// total instead of subtracting from it, and a discount of Dolibarr can only subtract, so it is
+			// carried as a line of the invoice by createHeaderChargeLines().
 			if (($allowanceCharge['indicator'] ?? '') !== 'false') {
 				continue;
 			}

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -361,6 +361,7 @@ CantReadTheDocumentOfTheImportedInvoice=The invoice of flow %s could not be read
 CantFindLinkedInvoiceOfTheImportedInvoice=The received invoice %s refers to the invoice %s, which is not in your database. It is needed to link the two, so the flow was not imported and will be retried on the next synchronization. Record the missing supplier invoice with that exact supplier reference, and it will come in.
 CreateTheMissingSupplierInvoiceToImport=Create the supplier invoice with the reference %s, then let the next synchronization run.
 EInvoicingDeductionOfPreviousSituations=Deduction of the situations already invoiced
+EInvoicingDocumentLevelCharge=Document level charge
 AccessPointConversionFormatNotSet=Your Access Point reports that no conversion format is configured for this client.
 SetTheAccessPointConversionFormat=On your Access Point account, set the preferred conversion format to a syntax supported here (CII or Factur-X, not UBL): it decides in which syntax a received invoice is handed over to this module.
 DisabledInProductionMode=Disabled in production mode.

--- a/einvoicing/test/phpunit/AllTests.php
+++ b/einvoicing/test/phpunit/AllTests.php
@@ -119,6 +119,8 @@ class AllTests
 		$suite->addTestSuite('CompatShimReloadTest');
 		require_once dirname(__FILE__).'/EInvoicingSamplesTest.php';
 		$suite->addTestSuite('EInvoicingSamplesTest');
+		require_once dirname(__FILE__).'/HeaderChargeLineTest.php';
+		$suite->addTestSuite('HeaderChargeLineTest');
 		require_once dirname(__FILE__).'/InvoicingPeriodTest.php';
 		$suite->addTestSuite('InvoicingPeriodTest');
 		require_once dirname(__FILE__).'/PDPProviderManagerTest.php';

--- a/einvoicing/test/phpunit/HeaderChargeLineTest.php
+++ b/einvoicing/test/phpunit/HeaderChargeLineTest.php
@@ -1,0 +1,229 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/HeaderChargeLineTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for the document level charges of a received document (BG-21).
+ *
+ *                  BR-CO-13 defines the total of the invoice as the sum of the line net amounts,
+ *                  minus the allowances of the document level (BT-107), plus its charges (BT-108).
+ *                  In CII an allowance and a charge are the same element, told apart only by
+ *                  ram:ChargeIndicator, and the import used to keep the allowances and drop the
+ *                  charges - so the invoice totalled less than the document it came from.
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+dol_include_once('einvoicing/class/protocols/CIIProtocol.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class HeaderChargeLineTest extends CommonClassTest
+{
+	/**
+	 * Call CIIProtocol::buildHeaderChargeLines() through reflection: the whole decision, no database
+	 * access and no side effect.
+	 *
+	 * @param	CIIProtocol		$protocol	Protocol instance
+	 * @param	array			$charges	Parsed header allowances and charges
+	 * @return	array						The lines the import would add
+	 */
+	private function callBuildHeaderChargeLines(CIIProtocol $protocol, array $charges)
+	{
+		$method = new ReflectionMethod(CIIProtocol::class, 'buildHeaderChargeLines');
+		$method->setAccessible(true);
+
+		return $method->invoke($protocol, $charges);
+	}
+
+	/**
+	 * A document carrying one allowance and one charge at document level.
+	 *
+	 * @return	string	A parsable CII document
+	 */
+	private function documentWithAllowanceAndCharge()
+	{
+		return '<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+  <rsm:ExchangedDocument><ram:ID>INV-BG21</ram:ID></rsm:ExchangedDocument>
+  <rsm:SupplyChainTradeTransaction>
+    <ram:ApplicableHeaderTradeSettlement>
+      <ram:SpecifiedTradeAllowanceCharge>
+        <ram:ChargeIndicator><udt:Indicator>false</udt:Indicator></ram:ChargeIndicator>
+        <ram:ActualAmount>5.00</ram:ActualAmount>
+        <ram:ReasonCode>95</ram:ReasonCode>
+        <ram:Reason>Commercial gesture</ram:Reason>
+        <ram:CategoryTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>20.00</ram:RateApplicablePercent>
+        </ram:CategoryTradeTax>
+      </ram:SpecifiedTradeAllowanceCharge>
+      <ram:SpecifiedTradeAllowanceCharge>
+        <ram:ChargeIndicator><udt:Indicator>true</udt:Indicator></ram:ChargeIndicator>
+        <ram:ActualAmount>10.40</ram:ActualAmount>
+        <ram:ReasonCode>FC</ram:ReasonCode>
+        <ram:CategoryTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>20.00</ram:RateApplicablePercent>
+        </ram:CategoryTradeTax>
+      </ram:SpecifiedTradeAllowanceCharge>
+    </ram:ApplicableHeaderTradeSettlement>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>';
+	}
+
+	/**
+	 * An allowance and a charge are the same element in CII: the parser must keep the indicator that
+	 * tells them apart, along with the amount, the reason code and the VAT rate.
+	 *
+	 * @return	void
+	 */
+	public function testTheIndicatorReachesTheParsedHeader()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+		$header = $protocol->parseInvoiceHeader($this->documentWithAllowanceAndCharge());
+
+		$this->assertCount(2, $header['headerAllowancesCharges']);
+		$this->assertSame('false', $header['headerAllowancesCharges'][0]['indicator'], 'BG-20, an allowance');
+		$this->assertSame('true', $header['headerAllowancesCharges'][1]['indicator'], 'BG-21, a charge');
+		$this->assertEqualsWithDelta(10.40, $header['headerAllowancesCharges'][1]['actualAmount'], 0.001);
+		$this->assertSame('FC', $header['headerAllowancesCharges'][1]['reasonCode']);
+		$this->assertEqualsWithDelta(20.0, $header['headerAllowancesCharges'][1]['rateApplicablePercent'], 0.001);
+	}
+
+	/**
+	 * Only the charges become lines: an allowance is a DiscountAbsolute and is handled elsewhere, and
+	 * turning it into a line here would subtract it twice.
+	 *
+	 * @return	void
+	 */
+	public function testOnlyChargesBecomeLines()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+		$header = $protocol->parseInvoiceHeader($this->documentWithAllowanceAndCharge());
+		$lines = $this->callBuildHeaderChargeLines($protocol, $header['headerAllowancesCharges']);
+
+		$this->assertCount(1, $lines, 'the allowance is not one of them');
+		$this->assertEquals(1, $lines[0]->qty);
+		$this->assertEqualsWithDelta(10.40, $lines[0]->subprice, 0.001);
+		$this->assertEqualsWithDelta(20.0, $lines[0]->tva_tx, 0.001);
+		$this->assertEquals(0, $lines[0]->remise_percent);
+		$this->assertEquals(1, $lines[0]->product_type, 'a charge is a service');
+	}
+
+	/**
+	 * BR-38 accepts a reason code alone. A bare "FC" says nothing to whoever reads the invoice, so the
+	 * line is labelled and the code kept alongside.
+	 *
+	 * @return	void
+	 */
+	public function testAChargeWithOnlyAReasonCodeIsLabelled()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+		$lines = $this->callBuildHeaderChargeLines($protocol, array(
+			array('indicator' => 'true', 'actualAmount' => 10.40, 'reasonCode' => 'FC', 'reason' => '', 'rateApplicablePercent' => 20.0),
+		));
+
+		$this->assertCount(1, $lines);
+		$this->assertStringContainsString('FC', $lines[0]->desc, 'the code of the document is kept');
+		$this->assertNotSame('FC', $lines[0]->desc, 'but it is not the whole label');
+	}
+
+	/**
+	 * When the document gives a reason in clear (BT-104), it is what the line says - nothing is invented.
+	 *
+	 * @return	void
+	 */
+	public function testTheReasonOfTheDocumentIsUsedWhenThereIsOne()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+		$lines = $this->callBuildHeaderChargeLines($protocol, array(
+			array('indicator' => 'true', 'actualAmount' => 12.00, 'reasonCode' => 'FC', 'reason' => 'Frais de port', 'rateApplicablePercent' => 5.5),
+		));
+
+		$this->assertSame('Frais de port', $lines[0]->desc);
+		$this->assertEqualsWithDelta(5.5, $lines[0]->tva_tx, 0.001);
+	}
+
+	/**
+	 * Several charges give several lines, in the order of the document; a charge at zero gives none,
+	 * the way a zero allowance creates no discount.
+	 *
+	 * @return	void
+	 */
+	public function testSeveralChargesAndTheZeroOne()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+		$lines = $this->callBuildHeaderChargeLines($protocol, array(
+			array('indicator' => 'true', 'actualAmount' => 10.40, 'reason' => 'Freight', 'rateApplicablePercent' => 20.0),
+			array('indicator' => 'true', 'actualAmount' => 0.00, 'reason' => 'Nothing', 'rateApplicablePercent' => 20.0),
+			array('indicator' => 'true', 'actualAmount' => 2.50, 'reason' => 'Packaging', 'rateApplicablePercent' => 20.0),
+		));
+
+		$this->assertCount(2, $lines);
+		$this->assertSame('Freight', $lines[0]->desc);
+		$this->assertSame('Packaging', $lines[1]->desc);
+	}
+
+	/**
+	 * A document with no allowance and no charge must add nothing - this is the whole existing corpus of
+	 * received documents, and it must not move.
+	 *
+	 * @return	void
+	 */
+	public function testADocumentWithoutChargesAddsNothing()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$this->assertCount(0, $this->callBuildHeaderChargeLines($protocol, array()));
+		$this->assertCount(0, $this->callBuildHeaderChargeLines($protocol, array(
+			array('indicator' => 'false', 'actualAmount' => 5.00, 'reason' => 'Commercial gesture', 'rateApplicablePercent' => 20.0),
+		)));
+	}
+}


### PR DESCRIPTION
Closes #731. Second half of the invoice reported on #726, which loses two different amounts; the
line-level half is #729. **The two are independent and touch different methods** — they can land in
either order, and I have measured that they compose (table below).

## The defect

A **document level charge** never reached the imported invoice. EN 16931 puts two symmetric groups at
that level: **BG-20**, an allowance, which subtracts from the total, and **BG-21**, a charge, which
adds to it — freight, packaging, a handling fee. `BR-CO-13` makes the charge part of what is owed:

```
[BR-CO-13]-Invoice total amount without VAT (BT-109) = Σ Invoice line net amount (BT-131)
           - Sum of allowances on document level (BT-107) + Sum of charges on document level (BT-108).
```

In CII the two are the **same element**, `ram:SpecifiedTradeAllowanceCharge`, told apart only by
`ram:ChargeIndicator`. Everything was parsed — indicator, reason, reason code, amount, VAT category and
rate — and then dropped:

```php
foreach ($headerAllowancesCharges as $index => $allowanceCharge) {
    // Skip charges
    if (($allowanceCharge['indicator'] ?? '') !== 'false') {
        continue;
    }
```

That is understandable rather than careless: an allowance has a home in Dolibarr — a
`DiscountAbsolute`, inserted as a discount line further down — while a supplier invoice holds **no
positive amount at document level**, so a charge had nowhere to go. But dropping it changes the amount
owed, and nothing said so.

## The change

A charge becomes **what a human would key in**: one invoice line per charge, a single unit at the
charge amount (BT-99), with the VAT rate the charge declares (BT-103) and the reason it gives (BT-104,
or its reason code BT-105 when only that is present — `BR-38` allows either).

- `buildHeaderChargeLines()` is the whole decision — which entries are charges, what each line is worth,
  how it is labelled — and touches neither the database nor the core, so it is unit tested directly.
- `createHeaderChargeLines()` writes them through **`createSupplierInvoiceLinesIntoDatabase()`**, the
  path every other line of the import already takes. That is deliberate: `FactureFournisseur::addline()`
  changed signature between the supported cores (`$date_start = ''` on 18, `0` from 23, an extra
  `$origin_type` on 24), and reusing the writer of the import depends on none of it.
- A charge at zero creates no line, the way a zero allowance creates no discount.
- The `// Skip charges` comment now says *why* allowances only, and where the charges went.
- One `en_US` key, `EInvoicingDocumentLevelCharge`, to label a charge that gives only a reason code —
  a bare `FC` on an invoice line says nothing to whoever reads it, so the code is kept in brackets
  after the label.

Not in scope, but worth recording: the **emission side has the same gap**. `buildAllowanceChargeNode()`
takes an `$isCharge` flag and both of its callers pass `false`, so the module never produces a BG-21
either. A Dolibarr invoice has no document level charge to express today, so nothing is lost right now —
I mention it so it is not rediscovered as a surprise.

## Tested

`HeaderChargeLineTest` (new, registered in `AllTests`): 6 tests, 22 assertions. It pins that the
indicator survives parsing, that **only** the charges become lines (turning an allowance into one would
subtract it twice), the labelling with and without BT-104, several charges in document order, the zero
charge, and — the control that matters — that a document with no charge at all adds nothing.

Live on the bench, the **real invoice of the reporter** imported through
`CIIProtocol::createSupplierInvoiceFromSource()` and read back from a second process. Three lines
totalling 942.30 (BT-106), one `FC` charge of 10.40 (BT-108), BT-109 952.70, **1143.24 TTC**:

| tree | TTC obtained |
|---|---|
| `main` | 1116.36 — both amounts lost |
| **#729** alone (the line) | 1130.76 |
| **this PR** alone (the charge) | 1128.84 |
| **both merged** | **1143.24** — exactly what the document announces |

Identical on **Dolibarr 18.0.10, 23.0.4 and 24.0.0**. The document itself was checked first with the
FNFE schematron (`fnfempe/France_RFE`, EUPL): XSD valid, `EXTENDED-CTC-FR-CII` **159 checks / 0
failure**, `BR-FR-Flux2` 90 / 0 — it is conformant, the loss is entirely ours.

PHPUnit, the whole suite on the seven supported cores (18.0.10, 19.0.4, 20.0.4, 21.0.4, 22.0.5, 23.0.4,
24.0.0): **133 runs, 133 OK** on this branch, **140 / 140** on the tree holding both PRs. The four list
hooks answer on the four list contexts on all seven. `phpcs` clean with the Dolibarr ruleset.


Round trip through the Access Point sandbox, on the tree holding **both** pull requests:
`allfullx.sh` → **14/14 complete cycles**, the seven versions in both directions, each with the whole
lifecycle `[200, 201, 205, 211, 212]`. None of those documents carries a document level charge or a
line without a quantity, which is the point: it is the non-regression control, and both changes are
inert on everything that does not hit them.
