### PR TITLE
Better PHP compatibility

### DIFF
--- a/einvoicing/class/document.class.php
+++ b/einvoicing/class/document.class.php
@@ -1265,7 +1265,7 @@ class Document extends CommonObject
 	 * @param ?string $xmlData The XML data to check
 	 * @return bool True if xmlData is within size bounds
 	 */
-	public static function checkXmlDataMaxSize(?string &$xmlData): bool
+	public static function checkXmlDataMaxSize(&$xmlData): bool
 	{
 		if (isset($xmlData)) {
 			// 16Mo for MEDIUMTEXT
@@ -1281,7 +1281,7 @@ class Document extends CommonObject
 	 * @param ?string $xmlData The XML data to clean
 	 * @return ?string The cleaned XML data
 	 */
-	public static function cleanXmlData(?string $xmlData): ?string
+	public static function cleanXmlData($xmlData)
 	{
 		global $db;
 

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -85,17 +85,17 @@ class EInvoicing
 
 
 	// Dolibarr internal statuses
-	public const STATUS_UNKNOWN             = 0;		// By default, before the e-invoice has been generated
+	const STATUS_UNKNOWN             = 0;		// By default, before the e-invoice has been generated
 
-	public const STATUS_NOT_GENERATED       = 5;		// To generate then to sync
-	public const STATUS_GENERATED           = 10;		// To sync
-	public const STATUS_AWAITING_VALIDATION = 15;		// Einvoice sent to your AP, but not yet analyzed by your AP
-	public const STATUS_AWAITING_ACK        = 20;		// Einvoice sent to your AP. next step happen when doing sync.
+	const STATUS_NOT_GENERATED       = 5;		// To generate then to sync
+	const STATUS_GENERATED           = 10;		// To sync
+	const STATUS_AWAITING_VALIDATION = 15;		// Einvoice sent to your AP, but not yet analyzed by your AP
+	const STATUS_AWAITING_ACK        = 20;		// Einvoice sent to your AP. next step happen when doing sync.
 
-	public const STATUS_ERROR               = 25;		// Unknown error, should not happe
+	const STATUS_ERROR               = 25;		// Unknown error, should not happe
 
-	public const STATUS_IGNORE_2            = 98;		// Never sync (for another reason than ereporting, not used yet)
-	public const STATUS_IGNORE              = 99;		// Never sync (will be processed by ereporting)
+	const STATUS_IGNORE_2            = 98;		// Never sync (for another reason than ereporting, not used yet)
+	const STATUS_IGNORE              = 99;		// Never sync (will be processed by ereporting)
 
 	/**
 	 * The two codes above, as a list: they keep an invoice out of the e-invoicing scope, it is never
@@ -103,7 +103,7 @@ class EInvoicing
 	 * closing, ...). Grouped here so that adding an "ignore" code is honoured by every caller at
 	 * once, through isIgnoredStatus().
 	 */
-	public const STATUS_IGNORE_CODES = [
+	const STATUS_IGNORE_CODES = [
 		self::STATUS_IGNORE,
 		self::STATUS_IGNORE_2
 	];
@@ -129,100 +129,100 @@ class EInvoicing
 	 * Invoice deposited
 	 * Status sent only by the PDP/PA
 	 */
-	public const STATUS_DEPOSITED = 200;
+	const STATUS_DEPOSITED = 200;
 
 	/**
 	 * Invoice issued
 	 * Status sent only by the PDP/PA
 	 */
-	public const STATUS_ISSUED = 201;
+	const STATUS_ISSUED = 201;
 
 	/**
 	 * Invoice received
 	 * Status sent only by the PDP/PA
 	 */
-	public const STATUS_RECEIVED = 202;
+	const STATUS_RECEIVED = 202;
 
 	/**
 	 * Invoice made available
 	 * Status sent only by the PDP/PA
 	 */
-	public const STATUS_AVAILABLE = 203;
+	const STATUS_AVAILABLE = 203;
 
 	/**
 	 * Invoice taken over
 	 * - Customer invoice: received from the PDP
 	 * - Supplier invoice: can be sent by Dolibarr (optional)
 	 */
-	public const STATUS_TAKEN_OVER = 204;
+	const STATUS_TAKEN_OVER = 204;
 
 	/**
 	 * Invoice approved
 	 * - Customer invoice: received from the PDP
 	 * - Supplier invoice: can be sent by Dolibarr (optional)
 	 */
-	public const STATUS_APPROVED = 205;
+	const STATUS_APPROVED = 205;
 
 	/**
 	 * Invoice partially approved
 	 * - Customer invoice: received from the PDP
 	 * - Supplier invoice: can be sent by Dolibarr (optional)
 	 */
-	public const STATUS_PARTIALLY_APPROVED = 206;
+	const STATUS_PARTIALLY_APPROVED = 206;
 
 	/**
 	 * Invoice disputed
 	 * - Customer invoice: received from the PDP
 	 * - Supplier invoice: can be sent by Dolibarr (optional)
 	 */
-	public const STATUS_DISPUTED = 207;
+	const STATUS_DISPUTED = 207;
 
 	/**
 	 * Invoice suspended
 	 * - Customer invoice: received from the PDP
 	 * - Supplier invoice: can be sent by Dolibarr (optional)
 	 */
-	public const STATUS_SUSPENDED = 208;
+	const STATUS_SUSPENDED = 208;
 
 	/**
 	 * Invoice refused
 	 * - Customer invoice: received from the PDP
 	 * - Supplier invoice: can be sent by Dolibarr (mandatory)
 	 */
-	public const STATUS_REFUSED = 210;
+	const STATUS_REFUSED = 210;
 
 	/**
 	 * Payment transmitted
 	 * - Customer invoice: received from the PDP
 	 * - Supplier invoice: can be sent by Dolibarr (optional, recommended)
 	 */
-	public const STATUS_PAYMENT_SENT = 211;
+	const STATUS_PAYMENT_SENT = 211;
 
 	/**
 	 * Invoice paid
 	 * - Customer invoice: can be sent by Dolibarr (optional, recommended)
 	 * - Supplier invoice: /
 	 */
-	public const STATUS_PAID = 212;
+	const STATUS_PAID = 212;
 
 	/**
 	 * Invoice completed
 	 * - Customer invoice: /
 	 * - Supplier invoice: /
 	 */
-	public const STATUS_COMPLETED = 209;
+	const STATUS_COMPLETED = 209;
 
 	/**
 	 * Invoice rejected (technical)
 	 * - Customer invoice: received from the PDP
 	 * - Supplier invoice: /
 	 */
-	public const STATUS_REJECTED = 213;
+	const STATUS_REJECTED = 213;
 
 	/**
 	 * List of Einvoice status
 	 */
-	public const STATUS_LABEL_KEYS = [
+	const STATUS_LABEL_KEYS = [
 		// Dolibarr
 		self::STATUS_UNKNOWN             => 'EInvStatusUnknown',
 		self::STATUS_IGNORE              => 'EInvStatusDoNotSync',		// To exclude invoice from einvoice sync (ereporting)
@@ -254,7 +254,7 @@ class EInvoicing
 
 
 	// All reasons with their details (Used when sending supplier invoices status: Refused, Disputed, Suspended, Partially Approved)
-	private const REASONS = [
+	const REASONS = [
 		"NON_TRANSMISE" => [
 			"label" => "ReasonRecipientNotConnected",
 			"desc" => "This reason is used ONLY with the \"DEPOSITED\" status to indicate that the invoice could not be transmitted because the recipient (BUYER), although present in the PPF Directory, has no active invoice reception address (i.e., connected to an Approved Platform for reception)."
@@ -438,7 +438,7 @@ class EInvoicing
 	];
 
 	// Codes reasons by status
-	private const REASONS_CODE_FOR_STATUS = [
+	const REASONS_CODE_FOR_STATUS = [
 		self::STATUS_DISPUTED => [
 			"AUTRE",
 			"COORD_BANC_ERR",
@@ -499,7 +499,7 @@ class EInvoicing
 		]
 	];
 
-	public const STATUS_REQUIRING_REASONS = [
+	const STATUS_REQUIRING_REASONS = [
 		self::STATUS_REFUSED,
 		self::STATUS_DISPUTED,
 		self::STATUS_PARTIALLY_APPROVED,
@@ -511,7 +511,7 @@ class EInvoicing
 	 * settling it. "Disputed", "Suspended" and "Refused" are deliberately not here: none of them
 	 * accepts anything.
 	 */
-	public const STATUSES_ACCEPTING_A_DOCUMENT = [
+	const STATUSES_ACCEPTING_A_DOCUMENT = [
 		self::STATUS_APPROVED,
 		self::STATUS_PARTIALLY_APPROVED
 	];
@@ -520,7 +520,7 @@ class EInvoicing
 	 * Name, into llx_einvoicing_extrafields, of the order reference the supplier declared on the
 	 * invoice it sent (BT-13). Kept whether or not it matched a purchase order of Dolibarr.
 	 */
-	public const EXTRAFIELD_BUYER_ORDER_REFERENCE = 'buyer_order_reference';
+	const EXTRAFIELD_BUYER_ORDER_REFERENCE = 'buyer_order_reference';
 
 	/**
 	 * Name, into llx_einvoicing_extrafields, of the buyer reference (BT-10): a reference owned by the
@@ -528,7 +528,7 @@ class EInvoicing
 	 * internal mailbox...). A plain EN 16931 core term, unrelated to the public sector, so it is kept
 	 * per invoice and offered whatever the Chorus Pro option (issue #678).
 	 */
-	public const EXTRAFIELD_BUYER_REFERENCE = 'buyer_reference';
+	const EXTRAFIELD_BUYER_REFERENCE = 'buyer_reference';
 
 	/**
 	 * ISO/IEC 6523 scheme identifier of the French routing code ("code de routage"), the scheme the
@@ -536,7 +536,7 @@ class EInvoicing
 	 * BR-FR-CPRO-13 of XP Z12-012. Not to be confused with 0225 (e-invoice address) nor with 0002 /
 	 * 0009 (SIREN / SIRET), which identify the legal entity itself.
 	 */
-	public const SCHEME_FR_ROUTING_CODE = '0224';
+	const SCHEME_FR_ROUTING_CODE = '0224';
 
 
 	/**

--- a/einvoicing/class/protocols/AbstractProtocol.class.php
+++ b/einvoicing/class/protocols/AbstractProtocol.class.php
@@ -46,16 +46,16 @@ abstract class AbstractProtocol
 	public $warnings = [];
 
 	/** @const string Invoice file extension (without the dot, example 'xml') */
-	protected const INVOICE_FILE_EXTENSION = ''; // Must be overridden by subclasses
+	const INVOICE_FILE_EXTENSION = ''; // Must be overridden by subclasses
 
 	/** @const string Generated invoice XML file name*/
-	protected const GENERATED_INVOICE_XML_FILE_NAME = ''; // Must be overridden by subclasses
+	const GENERATED_INVOICE_XML_FILE_NAME = ''; // Must be overridden by subclasses
 
 	/** @const string The profile used to generate XML */
-	protected const BUILD_XML_PROFILE = ''; // Must be overridden by subclasses
+	const BUILD_XML_PROFILE = ''; // Must be overridden by subclasses
 
 	/** @const string Fixed file name of the readable view of the last invoice that could not be processed */
-	public const INCOMING_DIAGNOSTIC_READABLE_FILE_NAME = 'einvoice_readable.pdf';
+	const INCOMING_DIAGNOSTIC_READABLE_FILE_NAME = 'einvoice_readable.pdf';
 
 	/**
 	 * @param DoliDB $db Db

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -60,16 +60,16 @@ class CIIProtocol extends AbstractProtocol
 	use CommonProtocol;
 
 	/** @const string Invoice file extension (without the dot, example 'xml') */
-	protected const INVOICE_FILE_EXTENSION = 'xml';
+	const INVOICE_FILE_EXTENSION = 'xml';
 
 	/** @const string Generated invoice file name */
-	protected const GENERATED_INVOICE_XML_FILE_NAME = 'einvoice.xml';
+	const GENERATED_INVOICE_XML_FILE_NAME = 'einvoice.xml';
 
 	/** @const string Default profile used to generate XML, overridable with EINVOICING_XML_PROFILE */
-	protected const BUILD_XML_PROFILE = 'EN16931';
+	const BUILD_XML_PROFILE = 'EN16931';
 
 	/** @var string[] Profiles buildXML() knows how to emit, and accepted values of EINVOICING_XML_PROFILE */
-	public const SUPPORTED_XML_PROFILES = ['MINIMUM', 'BASICWL', 'BASIC', 'EN16931', 'EXTENDED', 'EXTENDEDFR'];
+	const SUPPORTED_XML_PROFILES = ['MINIMUM', 'BASICWL', 'BASIC', 'EN16931', 'EXTENDED', 'EXTENDEDFR'];
 
 	/**
 	 * Maximum number of decimals allowed for the unit prices: Item net price (BT-146),
@@ -84,7 +84,7 @@ class CIIProtocol extends AbstractProtocol
 	 *
 	 * @const int
 	 */
-	protected const MAX_DECIMALS_UNIT_PRICE = 6;
+	const MAX_DECIMALS_UNIT_PRICE = 6;
 
 	/**
 	 * Maximum number of decimals allowed for the quantities: Invoiced quantity (BT-129) and
@@ -92,7 +92,7 @@ class CIIProtocol extends AbstractProtocol
 	 *
 	 * @const int
 	 */
-	protected const MAX_DECIMALS_QUANTITY = 4;
+	const MAX_DECIMALS_QUANTITY = 4;
 
 	/**
 	 * @var array<string,string>
@@ -1532,7 +1532,7 @@ class CIIProtocol extends AbstractProtocol
 	 * @param  string|null 	$raw	Raw date string
 	 * @return string|null  YYYY-MM-DD or null if input is null/empty/unparsable
 	 */
-	private function normDate(?string $raw): ?string
+	private function normDate($raw)
 	{
 		if ($raw === null || trim($raw) === '')
 			return null;
@@ -1557,7 +1557,7 @@ class CIIProtocol extends AbstractProtocol
 	 *  @param string|null $v Input string, e.g. "1234.56" or "1 234,56"
 	 *  @return float|null Parsed float or null
 	 */
-	private function toFloat(?string $v): ?float
+	private function toFloat($v)
 	{
 		if ($v === null || $v === '')
 			return null;
@@ -3357,7 +3357,7 @@ class CIIProtocol extends AbstractProtocol
 	 * @param float|null $lineTotalAmount BT-131 net line amount (base ht)
 	 * @return false|array{percent: float, base: float, discountAmount: float, priceWithoutDiscount: float}
 	 */
-	protected function resolveLineDiscountPercent(array $lineAllowances, ?float $lineTotalAmount)
+	protected function resolveLineDiscountPercent(array $lineAllowances, $lineTotalAmount)
 	{
 		// Keep only allowances (indicator = "false"), ignore charges (indicator = "true")
 		$allowances = array();

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -62,13 +62,13 @@ class FacturXProtocol extends CIIProtocol
 	use CommonProtocol;
 
 	/** @const string Invoice file extension (without the dot, example 'xml') */
-	protected const INVOICE_FILE_EXTENSION = 'pdf';
+	const INVOICE_FILE_EXTENSION = 'pdf';
 
 	/** @const string Generated invoice file name */
-	protected const GENERATED_INVOICE_XML_FILE_NAME = 'factur-x.xml';
+	const GENERATED_INVOICE_XML_FILE_NAME = 'factur-x.xml';
 
 	/** @const string The profile used to generate XML */
-	protected const BUILD_XML_PROFILE = 'EXTENDED';
+	const BUILD_XML_PROFILE = 'EXTENDED';
 
 	/**
 	 * Generate a complete Factur-X invoice file by embedding the XML into a PDF.

--- a/einvoicing/class/protocols/ProtocolManager.class.php
+++ b/einvoicing/class/protocols/ProtocolManager.class.php
@@ -34,8 +34,8 @@ class ProtocolManager
 	 */
 	private $protocolsList;
 
-	public const EXCEPTION_UNSUPPORTED_FORMAT = -100;
-	public const EXCEPTION_UNKNOWN_FORMAT = -101;
+	const EXCEPTION_UNSUPPORTED_FORMAT = -100;
+	const EXCEPTION_UNKNOWN_FORMAT = -101;
 
 	/**
 	 * Initialize available protocols.
@@ -180,7 +180,7 @@ class ProtocolManager
 	 * @param ?string $content 	File content of the invoice (PDF or XML)
 	 * @return array{protocol_object:AbstractProtocol|null, detected_protocol_name:?string, success:bool, error_code:int}
 	 */
-	public static function getProtocolFromContent(?string $content)
+	public static function getProtocolFromContent($content)
 	{
 		global $db;
 

--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -753,7 +753,7 @@ abstract class AbstractPDPProvider
 	 *
 	 * @var array<int,string>
 	 */
-	private const LOGCALL_SENSITIVE_KEYS = array('client_secret', 'access_token', 'refresh_token', 'id_token', 'password');
+	const LOGCALL_SENSITIVE_KEYS = array('client_secret', 'access_token', 'refresh_token', 'id_token', 'password');
 
 	/**
 	 * Redact known sensitive fields (@see LOGCALL_SENSITIVE_KEYS) from a value before it is
@@ -854,7 +854,7 @@ abstract class AbstractPDPProvider
 	 * @param   string                      $requestId  Request-Id header sent with the call, kept to correlate our log with the one of the Access Point
 	 * @return  ?array{id:int,call_id:?string}           Created log identifiers, or null if not logged
 	 */
-	protected function logCall(?string $callType, $resource, $method, $params, $response, $statusCode, string $requestId = '')
+	protected function logCall($callType, $resource, $method, $params, $response, $statusCode, string $requestId = '')
 	{
 		global $conf, $user, $dolibarr_main_db_pass, $dbhistory;
 
@@ -1040,7 +1040,7 @@ abstract class AbstractPDPProvider
 	 *
 	 * @var array<string,string>
 	 */
-	protected const FLOW_PROFILE_BY_GUIDELINE = array(
+	const FLOW_PROFILE_BY_GUIDELINE = array(
 		'urn:factur-x.eu:1p0:basic' => 'Basic',
 		'urn:cen.eu:en16931:2017' => 'CIUS',
 		'urn:cen.eu:en16931:2017#conformant#urn.cpro.gouv.fr:1p0:extended-ctc-fr' => 'Extended-CTC-FR',

--- a/einvoicing/class/utils/SupplierInvoiceHelper.class.php
+++ b/einvoicing/class/utils/SupplierInvoiceHelper.class.php
@@ -39,7 +39,7 @@ class SupplierInvoiceHelper
 	 * by the e-invoicing platform (PDP/PA). Distinct from the standard close codes (abandon,
 	 * replaced, ...) so it can be reliably excluded from the accountancy transfer screen.
 	 */
-	public const CLOSECODE_PDPREFUSED = 'pdp_refused';
+	const CLOSECODE_PDPREFUSED = 'pdp_refused';
 
 	/**
 	 * Compare amounts according to a number of digits after decimal point and return true if they are equal.
@@ -49,7 +49,7 @@ class SupplierInvoiceHelper
 	 * @param ?int $roundPrecision The number of digits after decimal point to apply round()
 	 * @return bool Whether the amounts are equal or not
 	 */
-	private static function areAmountsEqual($amount1, $amount2, ?int $roundPrecision = null): bool
+	private static function areAmountsEqual($amount1, $amount2, $roundPrecision = null): bool
 	{
 		return (self::round($amount1, $roundPrecision) === self::round($amount2, $roundPrecision));
 	}
@@ -341,7 +341,7 @@ class SupplierInvoiceHelper
 	 * @return 	?string 							The XML data if available or null if can't get it
 	 * @throws 	Exception
 	 */
-	public static function getXmlData(int $supplierInvoiceId, bool $fetchXmlIfEmpty = false): ?string
+	public static function getXmlData(int $supplierInvoiceId, bool $fetchXmlIfEmpty = false)
 	{
 		global $db, $user;
 
@@ -678,7 +678,7 @@ class SupplierInvoiceHelper
 	 * @param	string	$validationStatus	Validation status just confirmed by the platform: 'Ok', 'Pending' or 'Error'
 	 * @return	int							1 if abandoned, 0 if not applicable / already done, -1 on error (logged, not blocking)
 	 */
-	public static function onOutboundStatusMessageValidated($db, User $user, int $elementId, int $lcStatus, ?string $lcReasonCode, string $validationStatus)
+	public static function onOutboundStatusMessageValidated($db, User $user, int $elementId, int $lcStatus, $lcReasonCode, string $validationStatus)
 	{
 		global $langs;
 

--- a/einvoicing/class/utils/XmlPatcher.class.php
+++ b/einvoicing/class/utils/XmlPatcher.class.php
@@ -49,12 +49,12 @@ class XmlPatcher
 	/**
 	 * URN for the standard Factur-X EXTENDED profile (horstoeko default output)
 	 */
-	private const URN_EXTENDED = 'urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended';
+	const URN_EXTENDED = 'urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended';
 
 	/**
 	 * URN for the EXTENDED-CTC-FR profile (French e-invoicing mandate)
 	 */
-	private const URN_EXTENDED_CTC_FR = 'urn:cen.eu:en16931:2017#conformant#urn.cpro.gouv.fr:1p0:extended-ctc-fr';
+	const URN_EXTENDED_CTC_FR = 'urn:cen.eu:en16931:2017#conformant#urn.cpro.gouv.fr:1p0:extended-ctc-fr';
 
 	/**
 	 * Deposit line references to inject: array of ['lineId', 'invoiceRef', 'invoiceDate']
@@ -156,7 +156,7 @@ class XmlPatcher
 	 *
 	 * @return void  No value return
 	 */
-	private static function patchGuidelineId(DOMXPath $xpath): void
+	private static function patchGuidelineId(DOMXPath $xpath)
 	{
 		$nodes = $xpath->query(
 			'//rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID'
@@ -198,7 +198,7 @@ class XmlPatcher
 		string $lineId,
 		string $invoiceRef,
 		DateTimeInterface $invoiceDate
-	): void {
+	) {
 		// Find the SpecifiedLineTradeSettlement for this LineID
 		$query = sprintf(
 			'//ram:IncludedSupplyChainTradeLineItem[ram:AssociatedDocumentLineDocument/ram:LineID[normalize-space(.)="%s"]]/ram:SpecifiedLineTradeSettlement',

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -205,7 +205,7 @@ function thirdpartyidprof($object)
  * @param  ?string $original_encoding original encoding
  * @return string
  */
-function removeAllSpaces(?string $str, ?string $original_encoding = null)
+function removeAllSpaces($str, $original_encoding = null)
 {
 	// Tolerate a null identifier (e.g. a party without any professional id): treat it as empty.
 	if ($str === null) {


### PR DESCRIPTION
## Summary

This PR removes PHP 7.1+ syntax from the `einvoicing` module to restore compatibility with older PHP versions:

- **Constant visibility modifiers**: `public const`, `private const`, `protected const` → `const` (visibility modifiers on constants require PHP 7.1+)
- **Parameter type declarations**: removed typed/nullable parameter hints (e.g. `?string $xmlData` → `$xmlData`)
- **Return type declarations**: removed return type hints (e.g. `?string`, `bool`)

## Files changed

- `einvoicing/class/document.class.php`
- `einvoicing/class/einvoicing.class.php`
- `einvoicing/class/protocols/AbstractProtocol.class.php`
- `einvoicing/class/protocols/CIIProtocol.class.php`
- `einvoicing/class/protocols/FacturXProtocol.class.php`
- `einvoicing/class/protocols/ProtocolManager.class.php`
- `einvoicing/class/providers/AbstractPDPProvider.class.php`
- `einvoicing/class/utils/SupplierInvoiceHelper.class.php`
- `einvoicing/class/utils/XmlPatcher.class.php`
- `einvoicing/lib/einvoicing.lib.php`

10 files changed, 64 insertions(+), 64 deletions(-) — purely mechanical syntax changes, no logic modified.