### PR TITLE
FIX [einvoicing] Declare the hook contexts the module really uses, not 'all'

### DIFF
--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -58,20 +58,6 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	public $warnings = array();
 
 	/**
-	 * systemMessage
-	 *
-	 * @param array<string,mixed> 	$parameters		Array of parameters
-	 * @param CommonObject			$object			Object invoice
-	 * @param string		 		$action			Code action
-	 * @param Hookmanager			$hookmanager	Hookmanager
-	 * @return int									Result
-	 */
-	public function messageOfTheDay($parameters, $object, &$action, $hookmanager)
-	{
-		return 0;
-	}
-
-	/**
 	 * Hook called after a PDF is created
 	 *
 	 * @param 	array   		$parameters 	Hook parameters

--- a/einvoicing/core/modules/modEInvoicing.class.php
+++ b/einvoicing/core/modules/modEInvoicing.class.php
@@ -118,8 +118,17 @@ class modEInvoicing extends DolibarrModules
 			),
 			// Set here all hooks context managed by module. To find available hook context, make a "grep -r '>initHooks(' *" on source code. You can also set hook context to 'all'
 			/* BEGIN MODULEBUILDER HOOKSCONTEXTS */
+			// The module reacts on the invoice, supplier invoice, thirdparty and product cards, on the lists
+			// that carry its columns, on the document generation, and on the REST API (thirdparty merge and
+			// invoice set back to draft go through hooks there too). Contexts are listed one by one on purpose:
+			// 'all' loads this class into every HookManager of the request, including the ones other modules
+			// build for their own contexts.
 			'hooks' => [
-				'all', 'invoicecard'
+				'invoicecard', 'invoicesuppliercard', 'thirdpartycard', 'thirdpartycomm', 'productcard',
+				'invoicelist', 'supplierinvoicelist', 'thirdpartylist', 'societelist', 'productlist',
+				'productservicelist', 'accountancysupplierlist',
+				'pdfgeneration', 'odtgeneration',
+				'api',
 			],
 			/* END MODULEBUILDER HOOKSCONTEXTS */
 			// Set this to 1 if features of module are opened to external users


### PR DESCRIPTION
## Problem

The module descriptor declares `'hooks' => ['all', 'invoicecard']`, so `HookManager::initHooks()` includes and instantiates `ActionsEInvoicing` (1991 lines, and `PDPProviderManager` is pulled in at file load) **in every context of every request** - including the `HookManager` instances that other modules build for their own contexts.

That is not only a cost. One consequence is visible to any user: `addMoreActionsButtons()` prints

```
Warning: Einvoicing module enabled but no provider defined in setup
```

*before* it looks at `$object->element`. So on an install where the module is enabled but no Access Point has been chosen yet, that warning appeared on **every card page of Dolibarr** - a customer order, a project, a resource, an MRP order - not only on an invoice.

The same declaration is what makes the module land in the `HookManager` of unrelated modules, which is how the `$db` bug fixed in #699 was found in the first place - from the other side of the same door.

## What this changes

`'all'` is replaced by the contexts the hook methods of the module actually answer in, read from the core of 18 to 24:

| group | contexts | why |
|---|---|---|
| cards | `invoicecard`, `invoicesuppliercard`, `thirdpartycard`, `thirdpartycomm`, `productcard` | the element guards of `doActions`, `formConfirm`, `formObjectOptions`, `addMoreActionsButtons`, `isEditable` accept `facture`, `invoice_supplier`, `societe` and `product` |
| lists | `invoicelist`, `supplierinvoicelist`, `thirdpartylist`, `societelist`, `productlist`, `productservicelist`, `accountancysupplierlist` | the contexts named by the `completeArrayFields` and `printFieldList*` guards |
| documents | `pdfgeneration`, `odtgeneration` | every doc model calls `initHooks()` on those two contexts right before executing `afterPDFCreation` / `afterODTCreation` |
| REST API | `api` | `Societe::mergeCompany()` and `CommonInvoice::isEditable()` fire their hook on the request hookmanager without any `initHooks()` of their own, so merging a thirdparty or setting an invoice back to draft through the API needs the context of `api/index.php` to keep moving the routing IDs and to keep refusing the change |

`societelist` is kept although it appears in no core from 18 to 24, so the change stays strictly non-narrowing.

It also removes `messageOfTheDay()`, an empty stub returning 0 left by modulebuilder: that hook exists only in the 24 core, and `executeHooks()` skips a class that does not declare the method.

Note for existing installs: the list lives in `llx_const` as `MAIN_MODULE_EINVOICING_HOOKS`, written at activation, so it is refreshed when the module is re-enabled or upgraded.

## Test

Bench: Dolibarr **18.0.10, 19.0.4, 20.0.4, 21.0.4, 22.0.5, 23.0.4, 24.0** (tip of the 24.0 branch), PHP 8.4, module served by symlink, two trees built with `git archive` - `upstream/main` (before) and this branch (after) - the hooks constant rewritten between swaps exactly the way `insert_module_parts()` does.

**1. Which contexts load the class** - a `HookManager` built per context, `initHooks()` on that context alone, 15 contexts of the module and 15 it has no business in (7/7 versions):

| | contexts of the module | foreign contexts |
|---|---|---|
| before | 15/15 loaded | **15/15 loaded** (`einvoicingproviders`, `einvoicegeneration`, `globalcard`, `main`, `login`, `projectcard`, `mocard`, `resourcecard`, `emailcollectorcard`, `supplier_proposalcard`, `projectlist`, `mrplist`, `ticketlist`, `orderlist`, `propallist`) |
| after | 15/15 loaded | 0/15 |

**2. The hooks that are not driven by `$parameters['context']`**, executed the way the core does and counted with `resNbOfHooks` (18, 22, 23, 24 - side-effect free: an empty draft invoice, and the merge called with ids 0):

| context / method | before | after |
|---|---|---|
| `pdfgeneration` / `afterPDFCreation` | 1 | 1 |
| `odtgeneration` / `afterODTCreation` | 1 | 1 |
| `api` / `replaceThirdparty` | 1 | 1 |
| `invoicecard` / `isEditable` | 1 | 1 |
| `ordercard` / `afterPDFCreation` (control) | 1 | **0** |
| `einvoicingproviders` / `afterPDFCreation` (control) | 1 | **0** |

**3. Real pages over HTTP**, logged in, 9 pages x 4 versions (invoice card and list, supplier invoice card and list, thirdparty card and list, product card and list, and a card of another module): **36/36 byte-identical** before and after, once CSRF tokens, script nonces and timestamps are normalized.
Positive control, so that identity means something: a third tree with `invoicecard` removed from the list makes the invoice card lose its e-invoicing block on the spot (226449 -> 220715 bytes, 11 module references -> 0).

**4. The warning that was leaking** - module enabled, `EINVOICING_PDP` cleared, customer order card vs invoice card:

| | order card | invoice card |
|---|---|---|
| before | warning printed (18, 23, 24) | warning printed |
| after | **nothing** | warning printed |

**5. Generation unchanged**: the CII XML regenerated for the eligible invoice of each instance, timestamp filtered - **7/7 identical** md5 before and after.

**6. Full sandbox cycle on this branch**: the emitting instance sent a new invoice to the Access Point (`send_invoice` -> `flowId i_424937`, acknowledgement `{"status":"Ok"}`, http 200), and the receiving instance picked it up on the first sync as supplier invoice 7612, `ref_supplier=TRI-FA-2609-0475`, 200.00 HT / 240.00 TTC, both lines with their BG-14 / BG-26 periods intact.

`phpcs` (repo ruleset) clean on both files.
