### PR TITLE
FIX [einvoicing] The multicompany switch must not take the place of the invoice

### DIFF
--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -797,9 +797,11 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 								setEventMessages($langs->trans('WarningEntityChangedFileMoveFailed'), null, 'warnings');
 							} else {
 								dol_include_once('/multicompany/class/actions_multicompany.class.php');
-								// @phan-suppress-next-line PhanUndeclaredClassMethod DaoMulticompany is an external module class not analyzed by phan
-								$object = new ActionsMulticompany($db);
-								echo $object->switchEntity($newEntity);
+								// ActionsMulticompany comes from the external multicompany module, which phan does not analyze.
+								// It must not be assigned to $object: the supplier invoice is still needed below, to build the
+								// redirect url with its id.
+								$multicompany = new ActionsMulticompany($db); // @phan-suppress-current-line PhanUndeclaredClassMethod
+								echo $multicompany->switchEntity($newEntity); // @phan-suppress-current-line PhanUndeclaredClassMethod
 
 								setEventMessages($langs->trans('EntityChangedSuccess', $newEntity), null, 'mesgs');
 								$redirectto = $_SERVER['PHP_SELF'] . '?id=' . $object->id;


### PR DESCRIPTION
The `phan` workflow is red on `main` since 5e6b1288 ("Try a native swith of entity"), and every open PR rebased on it inherits the failure:

```
einvoicing/class/actions_einvoicing.class.php:802 PhanUndeclaredClassMethod Call to method switchEntity from undeclared class \ActionsMulticompany
einvoicing/class/actions_einvoicing.class.php:805 PhanUndeclaredClassProperty Reference to instance property id from undeclared class \ActionsMulticompany
einvoicing/class/actions_einvoicing.class.php:823 PhanUndeclaredClassProperty Reference to instance property id from undeclared class \ActionsMulticompany
```

Two independent things, one line apart.

**1. `$object` is taken over by the multicompany instance.** In `doActions()`, `$object` is the supplier invoice being moved, and it is still needed right after:

```php
$object = new ActionsMulticompany($db);
echo $object->switchEntity($newEntity);

setEventMessages($langs->trans('EntityChangedSuccess', $newEntity), null, 'mesgs');
$redirectto = $_SERVER['PHP_SELF'] . '?id=' . $object->id;   // <- id of ActionsMulticompany
```

`$redirectto` is used by the `header("Location: ...")` at the end of the method, so on the successful path the user is redirected to the supplier invoice card **without an id**. The two `PhanUndeclaredClassProperty` reports are phan pointing at exactly that. The instance now goes into `$multicompany`, and `$object` keeps being the invoice.

**2. The suppression was one line too high.** `@phan-suppress-next-line` covered `new ActionsMulticompany($db)`, not the `->switchEntity()` call on the line below, which is the one phan reports as an *error*. Both lines now carry a `@phan-suppress-current-line`, the same idiom already used for the class declaration of this file.

### Checked

The CI run is reproduced locally, before and after, with the command of `phan.yml`:

```sh
php phan.phar --allow-polyfill-parser -k dev/tools/phan/config.php \
    -B dev/tools/phan/baseline.txt --analyze-twice --minimum-target-php-version 7.2
```

- on `main` (5e6b1288): the 3 reports above, identical to the CI;
- with this commit: **no report left on `einvoicing`** (the two remaining `helloasso/class/helloassomemberutils.class.php:519` lines are pre-existing noise of the polyfill parser, absent from the CI artifact).

`phpcs` clean with the ruleset of the repo.

⚠️ **Not run live**: `ActionsMulticompany` belongs to the external multicompany module, which is not installed on my test instances, so the branch itself cannot be executed here. What is verified is the static analysis and the reading of the two lines; the behaviour change is limited to which variable holds the new instance.