### PR TITLE
FIX [einvoicing] A received document in a syntax the module cannot read no longer kills the synchronization

### DIFF
--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -1226,7 +1226,7 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 	 */
 	public function syncFlow($flowId, $call_id = null)
 	{
-		global $db, $conf, $user;
+		global $db, $conf, $user, $langs;
 
 		dol_include_once('einvoicing/class/document.class.php');
 		$einvoicing = new EInvoicing($db);
@@ -1375,6 +1375,26 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 				}
 
 				$exchangeProtocol = $tmpProtocolManager->getProtocol($detectedProtocol);
+
+				if (!is_object($exchangeProtocol)) {
+					// The syntax was recognized, but this module has no reader for it: detectProtocolFromContent()
+					// answers 'UBL' on a UBL invoice while ProtocolManager has no UBLProtocol class to build, so
+					// getProtocol() returns null. Calling the import on that null raises an Error, which is not an
+					// Exception: neither the catch below nor the one of syncFlows() takes it, and the whole
+					// synchronization request dies without even reporting the flow it died on.
+					// Nothing has been stored at this point and the flow is still pending at the Access Point, so
+					// it is postponed - it is retried on the next synchronization, the invoices queued behind it
+					// keep coming in, and the user is told which conversion format to set on their account.
+					return array(
+						'res' => -1,
+						'postponeflow' => 1,
+						'message' => "ERROR_FLOW_NOT_SUPPORTED_PROTOCOL The document received for SupplierInvoice flow (flowId: " . $flowId . ") is in the '" . $detectedProtocol . "' syntax, which this module cannot read",
+						'actioncode' => 'CONVERSION_FORMAT_NOT_SUPPORTED',
+						'actionurl' => '',
+						'action' => $langs->trans('SetTheAccessPointConversionFormat'),
+						'actiondata' => array()
+					);
+				}
 
 				$exceptionmessage = '';
 

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -2412,6 +2412,26 @@ class SuperPDPProvider extends AbstractPDPProvider
 
 				$exchangeProtocol = $tmpProtocolManager->getProtocol($detectedProtocol);
 
+				if (!is_object($exchangeProtocol)) {
+					// The syntax was recognized, but this module has no reader for it: detectProtocolFromContent()
+					// answers 'UBL' on a UBL invoice while ProtocolManager has no UBLProtocol class to build, so
+					// getProtocol() returns null. Calling the import on that null raises an Error, which is not an
+					// Exception: neither the catch below nor the one of syncFlows() takes it, and the whole
+					// synchronization request dies without even reporting the flow it died on.
+					// Nothing has been stored at this point and the flow is still pending at the Access Point, so
+					// it is postponed - it is retried on the next synchronization, the invoices queued behind it
+					// keep coming in, and the user is told which conversion format to set on their account.
+					return array(
+						'res' => -1,
+						'postponeflow' => 1,
+						'message' => "ERROR_FLOW_NOT_SUPPORTED_PROTOCOL The document received for SupplierInvoice flow (flowId: " . $flowId . ") is in the '" . $detectedProtocol . "' syntax, which this module cannot read",
+						'actioncode' => 'CONVERSION_FORMAT_NOT_SUPPORTED',
+						'actionurl' => '',
+						'action' => $langs->trans('SetTheAccessPointConversionFormat'),
+						'actiondata' => array()
+					);
+				}
+
 				$exceptionmessage = '';
 
 				// No transaction opened here: createSupplierInvoiceFromSource() owns it. It synchronizes


### PR DESCRIPTION
Found while looking at the invoice @hgy29 attached on #718.

## What happens

`ProtocolManager::detectProtocolFromContent()` recognizes a UBL invoice and answers `'UBL'`, and
`ProtocolManager` declares UBL in `protocolsList`. But its entry in `getProtocol()` has nothing to
build — `UBLProtocol` does not exist and the line is commented out — so the call returns `null`:

```php
case 'UBL':
    //$protocol = new UBLProtocol($this->db);
    break;
```

Both providers go straight from there to the import, with only an emptiness check on the *detected
name*, never on the object:

```php
$detectedProtocol = $tmpProtocolManager->detectProtocolFromContent($receivedFile);
if (empty($detectedProtocol)) { return array('res' => -1, ...); }   // 'UBL' is not empty
...
$exchangeProtocol = $tmpProtocolManager->getProtocol($detectedProtocol);   // null
try {
    $res = $exchangeProtocol->createSupplierInvoiceFromSource($receivedFile, $readableViewFile, $flowId);
} catch (Exception $e) { ... }
```

`Call to a member function createSupplierInvoiceFromSource() on null` is an **`Error`**, not an
`Exception`. Neither the `catch` above nor the one of `syncFlows()` takes it, so this is not the
abort described in #718 — the synchronization request dies on a fatal, with no
"Aborting synchronization due to errors.", no message naming the flow, nothing in the summary. The
whole inbox stays frozen on that flow, run after run, since nothing was stored for it either.

`SuperPDPProvider` used to handle this properly: `fetchImportableFlowDocument()` plus a
`ERROR_FLOW_NOT_SUPPORTED_PROTOCOL` return carrying `postponeflow` and the action to take. That
whole block is commented out today (`SuperPDPProvider.class.php`, `/* ... */` around the
`$importable` code), and the live path is the one above. The lang string it used is still there and
still says exactly the right thing:

> `SetTheAccessPointConversionFormat=On your Access Point account, set the preferred conversion
> format to a syntax supported here (CII or Factur-X, not UBL): it decides in which syntax a
> received invoice is handed over to this module.`

## The fix

Both providers now check that the protocol object was actually built. Nothing has been stored at
that point and the flow is still pending at the Access Point, so it is postponed the way #540 does
it: the flow is retried on the next synchronization, the batch carries on, and the user gets the
message that names the setting to change.

`EsalinkPDPProvider::syncFlow()` had no `$langs` in scope, added.

This does not settle #718 — every other failure still stops the batch, and that is a maintainer
decision. It removes one fatal that #718's mechanism could never have caught anyway.

## Tested on the bench, for real

Driven through the actual `syncFlows()` of each provider against a fake Access Point, with a batch
of two flows: **1.** the UBL invoice from #718 (`SFR.9A0040013195.ubl.xml`, a real SuperPDP
delivery), then **2.** a Factur-X invoice the module reads fine. What matters is whether the second
one still lands.

| | main (55d35ce) | this branch |
|---|---|---|
| SuperPDP, 18.0.10 | `Error: Call to a member function ... on null`, request dies | flow 1 postponed, **flow 2 imported** |
| SuperPDP, 23.0.4 | same fatal | flow 1 postponed, **flow 2 imported** |
| SuperPDP, 24.0.0 | same fatal | flow 1 postponed, **flow 2 imported** |
| Esalink, 18.0.10 | same fatal | flow 1 postponed, **flow 2 imported** |
| Esalink, 23.0.4 | same fatal | flow 1 postponed, **flow 2 imported** |
| Esalink, 24.0.0 | same fatal | flow 1 postponed, **flow 2 imported** |

What the user sees after the fix, instead of a blank page:

```
Synchronization completed successfully
Total number of flows ignored (existing or already processed): 0 - Total new flows synchronized: 1
Total number of postponed flows (not imported, retried on the next synchronization): 1
Recommended action: CONVERSION_FORMAT_NOT_SUPPORTED
  On your Access Point account, set the preferred conversion format to a syntax supported here
  (CII or Factur-X, not UBL) [...]
  The invoice of flow <id> could not be read: none of the documents the Access Point holds for it
  is in a syntax supported here. The flow was not imported and will be retried on the next
  synchronization.
```

and in `llx_einvoicing_document`, only the Factur-X flow is stored — the UBL one is left pending,
so a later run picks it up once the Access Point is set right (or once the module reads UBL).

`dolics` (phpcs 3.x + the ruleset of the repo) and `php -l` clean.

## Unrelated, but noticed while running the suite

`EInvoicingSamplesTest` fails on `main` as of 55d35ce, and it is not this branch: bisected to the
merge of #709. `ApplicableTradeTax/RateApplicablePercent` comes out `0.00` where the sample expects
`20.00`, on all 5 sample cases. `2d2e8ad` (the commit just before the merge) is green, `55d35ce` is
red. Reporting it separately.
