### PR TITLE
CRITICAL FIX #749 [einvoicing] Since #709 every invoice carrying VAT is refused by the platform, and a situation invoice claims more than Dolibarr bills

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -2446,13 +2446,13 @@ class CIIProtocol extends AbstractProtocol
 			}
 
 			// VAT array by rate (tax breakdown)
-			foreach ($invoiceData['taxBreakdown'] as $rate => $vals) {		// $rate is 0, 20.0, ..., $vals is an array
+			foreach ($invoiceData['taxBreakdown'] as $vals) {		// $vals is one VAT breakdown group (BG-23)
 				// Add comment
 				$comment = $doc->createComment('VAT rate: '.$vals['tva_tx'].', VAT src code: '.$vals['vat_src_code'].', ExemptionReasonCode: '.$vals['ExemptionReasonCode']);
 				$settlement->appendChild($comment);
 
 				$settlement->appendChild(
-					$this->buildTaxNode($doc, $rate, $vals, $invoiceData['invoiceCurrency'], $invoiceData['vatDueDateTypeCode'] ?? '') 	// ApplicableTradeTax
+					$this->buildTaxNode($doc, $vals, $invoiceData['invoiceCurrency'], $invoiceData['vatDueDateTypeCode'] ?? '') 	// ApplicableTradeTax
 				);
 			}
 
@@ -3005,13 +3005,12 @@ class CIIProtocol extends AbstractProtocol
 	 * Build a tax node.
 	 *
 	 * @param \DOMDocument 		$doc 		Document to create nodes in
-	 * @param float|string      $rate 		Tax rate
-	 * @param array       		$vals 		Array containing tax values
+	 * @param array       		$vals 		One VAT breakdown group (BG-23): rate, category, exemption and totals
 	 * @param string       		$currency 	Currency code
 	 * @param string       		$dueDateTypeCode 	BT-8, VAT point date code ('5', '29' or '72'), empty to omit it
 	 * @return \DOMElement
 	 */
-	private function buildTaxNode($doc, $rate, $vals, $currency, $dueDateTypeCode = '')
+	private function buildTaxNode($doc, $vals, $currency, $dueDateTypeCode = '')
 	{
 		$tax = $doc->createElement('ram:ApplicableTradeTax');
 
@@ -3035,9 +3034,9 @@ class CIIProtocol extends AbstractProtocol
 			$tax->appendChild($doc->createElement('ram:DueDateTypeCode', htmlspecialchars((string) $dueDateTypeCode)));
 		}
 
-		$floatrate = preg_replace('/\(.*\)/', '', (string) $rate);		// If $rate is 'x.x (CODE)', we change it into 'x.x'
-
-		$tax->appendChild($doc->createElement('ram:RateApplicablePercent', number_format((float) $floatrate, 2, '.', '')));
+		// BT-119 comes from the group itself, never from the key it is filed under: that key identifies
+		// the group (category, rate and exemption reason together) and is not a number.
+		$tax->appendChild($doc->createElement('ram:RateApplicablePercent', number_format((float) $vals['tva_tx'], 2, '.', '')));
 
 		return $tax;
 	}

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -437,7 +437,7 @@ foreach ($object->lines as $line) {
 	// Keying the breakdown by vat_src_code split otherwise identical "S"/rate lines into two
 	// ApplicableTradeTax groups (e.g. products carrying code TVAFR20 vs services without code), which
 	// the PDP rejects (BR-FXEXT-S08b / BR-S-08: duplicate breakdown, taxable base does not reconcile).
-	$vatBreakdownKey = $categoryVAT.'|'.$line->tva_tx.'|'.$exemptionReasonCode.'|'.$exemptionReason;
+	$vatBreakdownKey = einvoicingVatBreakdownKey($categoryVAT, $line->tva_tx, $exemptionReasonCode, $exemptionReason);
 
 	// if ($line->subprice < 0 || $line->subprice_ttc < 0) {
 	// 	throw new Exception("NEGATIVE_UNIT_PRICE_NOT_ALLOWED: Unit price in lines can't be negative. Try to edit the line with ID " . $line->id);
@@ -766,9 +766,12 @@ if (!empty($object->situation_counter) && $object->situation_counter > 1
 			continue;
 		}
 
-		// The allowance reduces the basis of a VAT rate of THIS invoice, so it is filed under the rate
-		// of the line as it stands now, which is the one the breakdown knows.
-		$keyforvatrate = $line->tva_tx . ($line->vat_src_code ? ' (' . $line->vat_src_code . ')' : '');
+		// The allowance reduces the basis of a VAT breakdown group of THIS invoice, so it is filed under
+		// the group of the line as it stands now, which is the one the breakdown knows. The key has to be
+		// built exactly the way the breakdown above built it, hence the shared helper: filed under any
+		// other shape, the deduction lands on a group that does not exist and is silently dropped.
+		$tmpcategory = $this->getCategoryRate($line, $mysoc, $object);
+		$keyforvatrate = einvoicingVatBreakdownKey($tmpcategory['categoryVAT'], $line->tva_tx, $tmpcategory['ExemptionReasonCode'], $tmpcategory['ExemptionReason']);
 		if (!isset($taxBreakdown[$keyforvatrate])) {
 			continue;
 		}

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -965,3 +965,25 @@ function einvoicingCheckoutCommit($repodir)
 
 	return (preg_match('/^[0-9a-f]{40,}$/', $commit) ? substr($commit, 0, 7) : '');
 }
+
+/**
+ * Key identifying the VAT breakdown group (BG-23) a line belongs to.
+ *
+ * EN 16931 identifies a breakdown group by its VAT category code (BT-118), its rate (BT-119) and its
+ * exemption reason (BT-120/BT-121), and by nothing else - in particular not by the Dolibarr
+ * vat_src_code, which used to split otherwise identical groups in two and had the platform reject the
+ * document (BR-S-08: the taxable base does not reconcile).
+ *
+ * It exists as a function because the same key is built in more than one place: a breakdown filled
+ * under one shape and read back under another silently loses what was filed under it.
+ *
+ * @param	string		$categoryVAT			VAT category code of the line (BT-118)
+ * @param	float|string	$rate				VAT rate of the line (BT-119)
+ * @param	string		$exemptionReasonCode	Exemption reason code (BT-121), empty when there is none
+ * @param	string		$exemptionReason		Exemption reason text (BT-120), empty when there is none
+ * @return	string								Key of the group in the breakdown accumulator
+ */
+function einvoicingVatBreakdownKey($categoryVAT, $rate, $exemptionReasonCode = '', $exemptionReason = '')
+{
+	return $categoryVAT.'|'.$rate.'|'.$exemptionReasonCode.'|'.$exemptionReason;
+}

--- a/einvoicing/test/phpunit/SituationInvoiceTotalsTest.php
+++ b/einvoicing/test/phpunit/SituationInvoiceTotalsTest.php
@@ -1,0 +1,367 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/SituationInvoiceTotalsTest.php
+ *      \ingroup    test
+ *      \brief      A generated document states the amount Dolibarr bills, not one of its own.
+ *      \remarks    No validator can catch this. A document that overstates its amounts is
+ *                  arithmetically consistent with itself - the lines, the breakdown and the totals
+ *                  all agree - so the CEN, Factur-X and CTC-FR schematrons answer VALID on it. The
+ *                  only thing it contradicts is the invoice it came from, and that is outside every
+ *                  one of them.
+ *
+ *                  #709 did exactly that: it filed the deduction of the previous situations (#674)
+ *                  under one key shape and read it back under another, so the document level
+ *                  allowance (BT-107) was silently dropped. A second situation of 70 % on a 1000.00
+ *                  line announced 840.00 where Dolibarr bills 480.00 - 360.00 too much, on a
+ *                  document that goes to the platform and to the customer, and every validator said
+ *                  the document was fine.
+ *
+ *                  This builds that very cycle - two situations, in the database, in the transaction
+ *                  the test class rolls back - and requires the totals of the document to be the
+ *                  totals of the invoice.
+ */
+
+
+// This script must only be run from the command line.
+if (PHP_SAPI !== 'cli') {
+	echo "Error: this script must be run from the command line (CLI), not through a web server.\n";
+	exit(1);
+}
+
+global $conf, $user, $langs, $db;
+
+// Load Dolibarr environment. Same resolution as the other test files of the module.
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+require_once $dolibarrHtdocs . '/master.inc.php';
+require_once DOL_DOCUMENT_ROOT . '/user/class/user.class.php';
+require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
+require_once DOL_DOCUMENT_ROOT . '/compta/facture/class/facture.class.php';
+
+/**
+ * @var Conf $conf
+ * @var DoliDB $db
+ * @var Translate $langs
+ * @var User $user
+ */
+
+dol_include_once('einvoicing/class/protocols/CIIProtocol.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+
+/**
+ * Class SituationInvoiceTotalsTest
+ *
+ * Builds a situation cycle of two invoices and checks the document generated for the second one
+ * against what the core says the customer owes.
+ */
+class SituationInvoiceTotalsTest extends CommonClassTest
+{
+	const RAM = 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100';
+
+	/** @var float	Net amount of the single line of the cycle */
+	const LINE_HT = 1000.00;
+	/** @var float	VAT rate of that line */
+	const VAT_RATE = 20.0;
+	/** @var float	Progress of the first situation, in percent */
+	const FIRST_PROGRESS = 30.0;
+	/** @var float	Cumulative progress stated by the second situation, in percent */
+	const SECOND_PROGRESS = 70.0;
+
+	/**
+	 * Build the cycle once for the whole class: the transaction opened by CommonClassTest is rolled
+	 * back at the end, so nothing of this reaches the database of a real instance.
+	 *
+	 * @return array{invoice:Facture,xml:string}		The second situation and the document generated for it
+	 */
+	private function buildSecondSituation()
+	{
+		global $conf, $db, $langs, $mysoc;
+
+		$user = new User($db);
+		$this->assertGreaterThan(0, $user->fetch(1), 'the instance has a user to act as');
+
+		// The seller of the document is the company of the instance, and this file is about amounts,
+		// not about whose identifiers the instance carries: a demo database whose SIREN is "123456"
+		// would stop the generation before the first total is read. $mysoc is a global object, so
+		// pinning it here changes nothing in the database and is undone below.
+		$savSeller = array(
+			'idprof1' => $mysoc->idprof1,
+			'idprof2' => $mysoc->idprof2,
+			'tva_intra' => $mysoc->tva_intra,
+			'country_id' => $mysoc->country_id,
+			'country_code' => $mysoc->country_code,
+		);
+		$mysoc->idprof1 = '000000001';
+		$mysoc->idprof2 = '00000000100010';
+		$mysoc->tva_intra = 'FR12000000001';
+		$mysoc->country_id = 1;
+		$mysoc->country_code = 'FR';
+
+		// Mode 1 is the one the interface writes: the lines carry the cumulative progress and the
+		// core deducts what the previous situations already invoiced. Mode 2 has nothing to deduct,
+		// so the case this file is about does not exist there.
+		$savUseSituation = getDolGlobalString('INVOICE_USE_SITUATION');
+		$savPdp = getDolGlobalString('EINVOICING_PDP');
+		$conf->global->INVOICE_USE_SITUATION = 1;
+		$conf->global->EINVOICING_PDP = 'SPECIMEN';
+
+		try {
+			$buyer = new Societe($db);
+			$buyer->name = 'EINVOICING TEST SITUATION BUYER';
+			$buyer->client = 1;
+			// Some instances - the demo database among them - number their customers with a module
+			// that refuses a third party without a code. Giving one costs nothing where the code is
+			// generated instead, and it makes the test independent of that setting.
+			$buyer->code_client = 'EINVCI' . strtoupper(substr(md5(uniqid('', true)), 0, 6));
+			$buyer->address = '2 rue du Test';
+			$buyer->zip = '75000';
+			$buyer->town = 'Paris';
+			$buyer->country_id = 1;			// France
+			$buyer->country_code = 'FR';
+			$buyer->idprof1 = '000000002';
+			$buyer->idprof2 = '00000000200010';
+			$buyer->tva_intra = 'FR12000000002';
+			$this->assertGreaterThan(0, $buyer->create($user), 'the buyer of the cycle is created: ' . $buyer->error);
+
+			// First situation: 30 % of the line.
+			$first = new Facture($db);
+			$first->socid = $buyer->id;
+			$first->type = Facture::TYPE_SITUATION;
+			$first->date = dol_now();
+			$first->situation_counter = 1;
+			$first->situation_final = 0;
+			$this->assertGreaterThan(0, $first->create($user), 'the first situation is created: ' . $first->error);
+
+			// The cycle is named after its first invoice, the way the core names it. It has to be in
+			// the database and not only on the object: get_prev_sits() reads it back with a query.
+			$this->assertGreaterThan(
+				0,
+				$db->query('UPDATE ' . MAIN_DB_PREFIX . 'facture SET situation_cycle_ref = ' . ((int) $first->id) . ' WHERE rowid = ' . ((int) $first->id)) ? 1 : 0,
+				'the cycle reference is stored on the first situation'
+			);
+			$first->situation_cycle_ref = $first->id;
+
+			$firstLineId = $first->addline(
+				'Situation line',
+				self::LINE_HT,		// unit price
+				1,					// quantity
+				self::VAT_RATE,
+				0,					// localtax1
+				0,					// localtax2
+				0,					// fk_product
+				0,					// discount
+				'',					// date start
+				'',					// date end
+				0,					// ventilation
+				0,					// info bits
+				0,					// fk_remise_except
+				'HT',
+				0,					// pu_ttc
+				0,					// type: product
+				-1,					// rank
+				0,					// special code
+				'',					// origin
+				0,					// origin id
+				0,					// parent line
+				null,				// fk_fournprice
+				0,					// pa_ht
+				'',					// label
+				array(),			// extrafields
+				self::FIRST_PROGRESS,
+				0					// fk_prev_id: nothing before the first situation
+			);
+			$this->assertGreaterThan(0, $firstLineId, 'the line of the first situation is added: ' . $first->error);
+
+			// Second situation: 70 % of the same line, which is what its line states, while the core
+			// bills the difference.
+			$second = new Facture($db);
+			$second->socid = $buyer->id;
+			$second->type = Facture::TYPE_SITUATION;
+			$second->date = dol_now();
+			$second->situation_counter = 2;
+			$second->situation_cycle_ref = $first->id;
+			$second->situation_final = 0;
+			$this->assertGreaterThan(0, $second->create($user), 'the second situation is created: ' . $second->error);
+
+			$secondLineId = $second->addline(
+				'Situation line',
+				self::LINE_HT,
+				1,
+				self::VAT_RATE,
+				0,
+				0,
+				0,
+				0,
+				'',
+				'',
+				0,
+				0,
+				0,
+				'HT',
+				0,
+				0,
+				-1,
+				0,
+				'',
+				0,
+				0,
+				null,
+				0,
+				'',
+				array(),
+				self::SECOND_PROGRESS,
+				$firstLineId		// the line this one continues
+			);
+			$this->assertGreaterThan(0, $secondLineId, 'the line of the second situation is added: ' . $second->error);
+
+			$reloaded = new Facture($db);
+			$this->assertGreaterThan(0, $reloaded->fetch($second->id), 'the second situation is read back');
+			$reloaded->fetch_lines();
+			$reloaded->fetch_thirdparty();
+
+			$protocol = new CIIProtocol($db);
+			$path = $protocol->generateXML($reloaded, $langs);
+			$this->assertNotEmpty($path, 'the document of the second situation is generated: ' . $protocol->error . ' ' . implode(', ', (array) $protocol->errors));
+			$this->assertFileExists((string) $path, 'the generated document is written');
+
+			return array('invoice' => $reloaded, 'xml' => (string) file_get_contents((string) $path));
+		} finally {
+			$conf->global->INVOICE_USE_SITUATION = $savUseSituation;
+			$conf->global->EINVOICING_PDP = $savPdp;
+			foreach ($savSeller as $property => $value) {
+				$mysoc->$property = $value;
+			}
+		}
+	}
+
+	/**
+	 * Read one amount of the document settlement.
+	 *
+	 * @param	string	$xml	The generated document
+	 * @param	string	$name	Element name, under ram:SpecifiedTradeSettlementHeaderMonetarySummation
+	 * @return	float			The amount, 0 when the element is absent
+	 */
+	private function summation($xml, $name)
+	{
+		$doc = new DOMDocument();
+		$this->assertTrue($doc->loadXML($xml), 'the generated document is well formed XML');
+
+		$xpath = new DOMXPath($doc);
+		$xpath->registerNamespace('ram', self::RAM);
+
+		$found = $xpath->query('//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:' . $name);
+
+		return ($found->length > 0) ? (float) $found->item(0)->textContent : 0.0;
+	}
+
+	/**
+	 * The core deducts the first situation, so the second one bills the difference. If this fails the
+	 * premise of the whole file is gone and the assertions below would be checking nothing.
+	 *
+	 * @return void
+	 */
+	public function testTheCoreBillsTheInstalment()
+	{
+		$built = $this->buildSecondSituation();
+		$invoice = $built['invoice'];
+
+		$expectedHt = self::LINE_HT * (self::SECOND_PROGRESS - self::FIRST_PROGRESS) / 100;
+
+		$this->assertEqualsWithDelta(
+			$expectedHt,
+			(float) $invoice->total_ht,
+			0.011,
+			'the second situation of ' . self::SECOND_PROGRESS . ' % after one of ' . self::FIRST_PROGRESS
+				. ' % bills the difference'
+		);
+	}
+
+	/**
+	 * The totals of the document are the totals of the invoice.
+	 *
+	 * On the code of #709 this reads 700.00 / 840.00 against an invoice of 400.00 / 480.00.
+	 *
+	 * @return void
+	 */
+	public function testTheDocumentStatesWhatDolibarrBills()
+	{
+		$built = $this->buildSecondSituation();
+		$invoice = $built['invoice'];
+		$xml = $built['xml'];
+
+		$this->assertEqualsWithDelta(
+			(float) $invoice->total_ht,
+			$this->summation($xml, 'TaxBasisTotalAmount'),
+			0.011,
+			'BT-109 states the net amount the invoice bills'
+		);
+		$this->assertEqualsWithDelta(
+			(float) $invoice->total_tva,
+			$this->summation($xml, 'TaxTotalAmount'),
+			0.011,
+			'BT-110 states the VAT the invoice bills'
+		);
+		$this->assertEqualsWithDelta(
+			(float) $invoice->total_ttc,
+			$this->summation($xml, 'GrandTotalAmount'),
+			0.011,
+			'BT-112 states the gross amount the invoice bills'
+		);
+		$this->assertEqualsWithDelta(
+			(float) $invoice->total_ttc,
+			$this->summation($xml, 'DuePayableAmount'),
+			0.011,
+			'BT-115 asks for what the invoice asks for'
+		);
+	}
+
+	/**
+	 * What the previous situations already invoiced is carried as a document level allowance, which
+	 * is what brings the lines - which state the cumulative work - back onto the instalment (#674).
+	 *
+	 * @return void
+	 */
+	public function testWhatWasAlreadyInvoicedIsDeductedInTheDocument()
+	{
+		$built = $this->buildSecondSituation();
+		$xml = $built['xml'];
+
+		$expectedDeduction = self::LINE_HT * self::FIRST_PROGRESS / 100;
+
+		$this->assertEqualsWithDelta(
+			self::LINE_HT * self::SECOND_PROGRESS / 100,
+			$this->summation($xml, 'LineTotalAmount'),
+			0.011,
+			'BT-106 sums the lines, which state the work done since the beginning of the cycle'
+		);
+		$this->assertEqualsWithDelta(
+			$expectedDeduction,
+			$this->summation($xml, 'AllowanceTotalAmount'),
+			0.011,
+			'BT-107 deducts what the previous situations already invoiced'
+		);
+	}
+}

--- a/einvoicing/test/phpunit/VatBreakdownStatesItsRateTest.php
+++ b/einvoicing/test/phpunit/VatBreakdownStatesItsRateTest.php
@@ -1,0 +1,215 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/VatBreakdownStatesItsRateTest.php
+ *      \ingroup    test
+ *      \brief      The VAT breakdown (BG-23) of a generated document has to hold together on its own.
+ *      \remarks    EInvoicingSamplesTest compares the generated documents against committed reference
+ *                  documents, which answers "did the output change" - a question whose answer is
+ *                  legitimately "yes" every time a reference is regenerated on purpose. It does not
+ *                  answer "is the output still arithmetically true", and a regenerated reference
+ *                  makes it green again whatever it now contains.
+ *
+ *                  This file asks the second question, on the documents as they are generated now:
+ *                  a VAT breakdown states the rate it taxes, the tax amount it announces follows
+ *                  from its own basis and rate (BR-CO-17), and two breakdowns of the same category
+ *                  and rate never coexist (BR-S-08, the defect #709 set out to fix).
+ *
+ *                  On the merge of #709 every one of these documents carried a rate of 0.00 against
+ *                  a non-zero tax amount: this file is red on that code with no reference document
+ *                  to regenerate, and the three rules it checks are the three the FNFE validators
+ *                  answered INVALID with.
+ */
+
+
+// This script must only be run from the command line.
+if (PHP_SAPI !== 'cli') {
+	echo "Error: this script must be run from the command line (CLI), not through a web server.\n";
+	exit(1);
+}
+
+global $conf, $user, $langs, $db;
+
+// Load Dolibarr environment. Same resolution as the other test files of the module: DOLIBARR_HTDOCS
+// points at the instance to test against, and the relative path is the fallback when the module is
+// reached through the htdocs/custom/einvoicing symlink.
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+require_once $dolibarrHtdocs . '/master.inc.php';
+
+/**
+ * @var Conf $conf
+ * @var DoliDB $db
+ * @var Translate $langs
+ * @var User $user
+ */
+
+dol_include_once('einvoicing/class/einvoicing.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+
+/**
+ * Class VatBreakdownStatesItsRateTest
+ *
+ * Checks the VAT breakdown of the five specimen documents (deposit, standard, replacement, credit
+ * note, situation) against the rules that make it exploitable, whatever the reference documents say.
+ */
+class VatBreakdownStatesItsRateTest extends CommonClassTest
+{
+	const RAM = 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100';
+
+	/**
+	 * The five specimen documents, generated once for the whole class.
+	 * @var array<string,string>|null
+	 */
+	private static $generated = null;
+
+	/**
+	 * Generate the specimen chain once and return it.
+	 *
+	 * @return array<string,string>	One CII document per invoice type
+	 */
+	private function getGenerated()
+	{
+		if (self::$generated === null) {
+			self::$generated = EInvoicing::generateSampleEInvoicesForTests();
+		}
+
+		return self::$generated;
+	}
+
+	/**
+	 * Read the VAT breakdowns (BG-23) of a document.
+	 *
+	 * @param	string	$xml	A CII document
+	 * @return	array<int,array{basis:float,tax:float,rate:float,category:string,exemption:string}>	One entry per ram:ApplicableTradeTax of the settlement
+	 */
+	private function vatBreakdowns($xml)
+	{
+		$doc = new DOMDocument();
+		$this->assertTrue($doc->loadXML($xml), 'the generated document is well formed XML');
+
+		$xpath = new DOMXPath($doc);
+		$xpath->registerNamespace('ram', self::RAM);
+
+		$breakdowns = array();
+		foreach ($xpath->query('//ram:ApplicableHeaderTradeSettlement/ram:ApplicableTradeTax') as $node) {
+			$read = function ($name) use ($xpath, $node) {
+				$found = $xpath->query('ram:' . $name, $node);
+				return ($found->length > 0) ? trim($found->item(0)->textContent) : '';
+			};
+
+			$breakdowns[] = array(
+				'basis' => (float) $read('BasisAmount'),					// BT-116
+				'tax' => (float) $read('CalculatedAmount'),				// BT-117
+				'rate' => (float) $read('RateApplicablePercent'),		// BT-119
+				'category' => $read('CategoryCode'),					// BT-118
+				'exemption' => $read('ExemptionReasonCode') . '|' . $read('ExemptionReason'),	// BT-121, BT-120
+			);
+		}
+
+		return $breakdowns;
+	}
+
+	/**
+	 * A breakdown that announces a tax amount states the rate that produced it.
+	 *
+	 * This is the shape #709 shipped: the rate was read from an array key that had become
+	 * "S|20.0000||", and (float) of that is 0, so every document declared 0.00 % against a non-zero
+	 * VAT amount.
+	 *
+	 * @return void
+	 */
+	public function testABreakdownThatTaxesStatesItsRate()
+	{
+		foreach ($this->getGenerated() as $type => $xml) {
+			$breakdowns = $this->vatBreakdowns($xml);
+			$this->assertNotEmpty($breakdowns, 'the ' . $type . ' specimen has a VAT breakdown');
+
+			foreach ($breakdowns as $index => $breakdown) {
+				$where = 'specimen ' . $type . ', VAT breakdown ' . ($index + 1) . ' (' . $breakdown['category'] . ')';
+
+				if (abs($breakdown['tax']) < 0.005) {
+					continue;		// An exempt or reverse charged breakdown legitimately taxes nothing.
+				}
+
+				$this->assertGreaterThan(
+					0,
+					$breakdown['rate'],
+					$where . ': BT-119 is ' . $breakdown['rate'] . ' % while BT-117 announces ' . $breakdown['tax']
+				);
+			}
+		}
+	}
+
+	/**
+	 * The tax amount of a breakdown follows from its own basis and its own rate (BR-CO-17).
+	 *
+	 * @return void
+	 */
+	public function testTheTaxAmountFollowsFromTheBasisAndTheRate()
+	{
+		foreach ($this->getGenerated() as $type => $xml) {
+			foreach ($this->vatBreakdowns($xml) as $index => $breakdown) {
+				$expected = round($breakdown['basis'] * $breakdown['rate'] / 100, 2);
+				$where = 'specimen ' . $type . ', VAT breakdown ' . ($index + 1) . ' (' . $breakdown['category'] . ')';
+
+				$this->assertEqualsWithDelta(
+					$expected,
+					$breakdown['tax'],
+					0.011,		// The tolerance BR-CO-17 itself grants.
+					$where . ': BT-117 = ' . $breakdown['tax'] . ' where BT-116 ' . $breakdown['basis']
+						. ' x BT-119 ' . $breakdown['rate'] . ' % gives ' . $expected
+				);
+			}
+		}
+	}
+
+	/**
+	 * A document carries one breakdown per category, rate and exemption reason, never two.
+	 *
+	 * That is what #709 was about - a national VAT source code was splitting one 20 % breakdown into
+	 * two, and the access point refused the document - so it is checked here rather than left to the
+	 * reference documents, which would not say why they changed.
+	 *
+	 * @return void
+	 */
+	public function testTwoBreakdownsNeverShareACategoryAndARate()
+	{
+		foreach ($this->getGenerated() as $type => $xml) {
+			$seen = array();
+			foreach ($this->vatBreakdowns($xml) as $breakdown) {
+				$key = $breakdown['category'] . '|' . number_format($breakdown['rate'], 4, '.', '') . '|' . $breakdown['exemption'];
+
+				$this->assertArrayNotHasKey(
+					$key,
+					$seen,
+					'specimen ' . $type . ': two VAT breakdowns for category ' . $breakdown['category']
+						. ' at ' . $breakdown['rate'] . ' %, which BR-S-08 and its siblings refuse'
+				);
+				$seen[$key] = true;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #749. Found while running the suite on another branch: `EInvoicingSamplesTest` is red on `main`.

@Pichinov-Jose — #709 itself is right, and this keeps what it fixed. It rekeyed the breakdown on what
identifies a BG-23 group in EN 16931 (category, rate, exemption reason) instead of the Dolibarr
`vat_src_code`. What it could not see is that the old key was being read back **as data** in two other
places.

## 1. BT-119 was emitted from the array key

`CIIProtocol.class.php`:

```php
foreach ($invoiceData['taxBreakdown'] as $rate => $vals) {   // $rate is 0, 20.0, ...
    $settlement->appendChild($this->buildTaxNode($doc, $rate, $vals, ...));
}
```

```php
$floatrate = preg_replace('/\(.*\)/', '', (string) $rate);   // 'x.x (CODE)' -> 'x.x'
$tax->appendChild($doc->createElement('ram:RateApplicablePercent', number_format((float) $floatrate, 2, '.', '')));
```

`(float) "S|20.0000||"` is `0`, so every generated document declared `RateApplicablePercent = 0.00`
against a non-zero `CalculatedAmount`. The rate now comes from `$vals['tva_tx']`, which the group has
always carried; the `preg_replace` that stripped the ` (CODE)` suffix of the former key goes away with
it, and so does the `$rate` parameter.

## 2. The deduction of previous situations filed under the old key

`buildinvoicelines.inc.php`, the block added for #674:

```php
$keyforvatrate = $line->tva_tx . ($line->vat_src_code ? ' (' . $line->vat_src_code . ')' : '');
if (!isset($taxBreakdown[$keyforvatrate])) {
    continue;                      // always true now
}
```

The document level allowance (BT-107) that brings a situation invoice back onto its instalment was
silently dropped.

Both places now build the key through `einvoicingVatBreakdownKey()`. A key that identifies a group is
easy to fill under one shape and read back under another — that is exactly what happened twice here,
so it gets one definition.

## Tested on the bench, for real

Three trees compared on the same instance, symlink swapped between each run: `2d2e8ad` (just before
the merge of #709), `55d35ce` (`main` today) and this branch.

**The case #709 is about** — two lines, same category and same rate, one carrying `vat_src_code`
`TVAFR20` and one without:

| | `2d2e8ad` | `55d35ce` (main) | this branch |
|---|---|---|---|
| BG-23 groups | **2** (the bug #709 fixed) | 1 | 1 |
| RateApplicablePercent | 20.00 | **0.00** | 20.00 |
| BasisAmount | 100.00 + 50.00 | 150.00 | 150.00 |

**A situation invoice** — situation 1 at 30 %, situation 2 at 70 % of a 1000.00 line:

| | `2d2e8ad` | `55d35ce` (main) | this branch |
|---|---|---|---|
| Dolibarr `total_ttc` | 480.00 | 480.00 | 480.00 |
| BT-119 rate | 20.00 | **0.00** | 20.00 |
| BG-20 allowance (BT-107) | 1, 300.00 | **0** | 1, 300.00 |
| BT-109 `TaxBasisTotalAmount` | 400.00 | **700.00** | 400.00 |
| BT-112 `GrandTotalAmount` | 480.00 | **840.00** | 480.00 |
| BT-115 `DuePayableAmount` | 480.00 | **840.00** | 480.00 |

Reproduced identically on **18.0.10**, **23.0.4** and **24.0.0**, and both cases come back to the
`2d2e8ad` values on this branch while the single-group merge of #709 is kept.

PHPUnit of the module, file by file (never `AllTests.php`), on 18.0.10 and 23.0.4:
**21 OK / 0 KO** — against 20 OK / 1 KO (`EInvoicingSamplesTest`) on `main` at 55d35ce.

`dolics` (phpcs 3.x + the ruleset of the repo) and `php -l` clean.
