### PR TITLE
NEW [einvoicing] The CI runs the suite, opens the pages and installs the package, on a real Dolibarr

### DIFF
--- a/.github/actions/dolibarr-instance/action.yml
+++ b/.github/actions/dolibarr-instance/action.yml
@@ -1,0 +1,158 @@
+---
+name: Dolibarr instance
+description: >
+  Checks out a Dolibarr release, loads the demo database that release ships and configures it, so a
+  job can run the module against a real instance. Needs a MySQL/MariaDB service declared by the job.
+
+inputs:
+  dolibarr:
+    description: Release tag of the core to run against, e.g. "23.0.4"
+    required: true
+  php:
+    description: PHP version to install
+    required: true
+  db-host:
+    description: Host of the database service
+    required: false
+    default: 127.0.0.1
+  db-port:
+    description: Port of the database service
+    required: false
+    default: "3306"
+  db-name:
+    description: Database the dump is loaded into
+    required: false
+    default: dolibarr
+  db-user:
+    description: Database user
+    required: false
+    default: root
+  db-password:
+    description: Password of that user
+    required: false
+    default: dolibarr
+
+outputs:
+  htdocs:
+    description: The htdocs directory of the instance, also exported as DOLIBARR_HTDOCS
+    value: ${{ steps.configure.outputs.htdocs }}
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout Dolibarr ${{ inputs.dolibarr }}
+      uses: actions/checkout@v6
+      with:
+        repository: Dolibarr/dolibarr
+        ref: ${{ inputs.dolibarr }}
+        path: dolibarr
+
+    - name: Setup PHP ${{ inputs.php }}
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.php }}
+        extensions: mysqli, intl, gd, mbstring, zip, xml, curl
+        tools: phpunit:9.6
+        coverage: none # disable xdebug, pcov
+
+    - name: Load the Dolibarr demo database
+      # The release ships the dump of its own demo database next to the sources; that is what the
+      # core CI loads too. Building the schema out of htdocs/install/mysql by hand would mean
+      # reimplementing the installer, and loading an older dump would mean driving the migration.
+      shell: bash
+      run: |
+        set -euo pipefail
+        major=${DOLIBARR_VERSION%%.*}
+        dump=$(ls dolibarr/dev/initdemo/mysqldump_dolibarr_${major}.*.sql 2>/dev/null | head -1)
+        if [ -z "$dump" ]; then
+          echo "::error::No demo dump for Dolibarr ${major} in dolibarr/dev/initdemo/"
+          ls dolibarr/dev/initdemo/ || true
+          exit 1
+        fi
+        echo "Loading $dump"
+        # Dumps taken with a MySQL client open with "/*!999999\- enable the sandbox mode */", which
+        # the MariaDB client reads as a command it does not know and refuses at line 1. The dumps of
+        # 20 and 21 carry it; those of 23 and 24 use the MariaDB form, which is ignored.
+        sed '1{/enable the sandbox mode/d;}' "$dump" \
+          | mysql --host "$DB_HOST" --port "$DB_PORT" -u"$DB_USER" -p"$DB_PASSWORD" "$DB_NAME"
+        # The tests write documents; the umask of the demo is the one of the machine it was dumped
+        # on, and a stricter one makes the generation fail on a file it cannot read back.
+        mysql --host "$DB_HOST" --port "$DB_PORT" -u"$DB_USER" -p"$DB_PASSWORD" "$DB_NAME" \
+          -e "UPDATE llx_const SET value = '0666' WHERE name = 'MAIN_UMASK';"
+        # Some demo databases are a dump of a real instance, custom fields included: the demo of 22
+        # carries fields of the hosting provider that dumped it, declared mandatory and stored in
+        # NOT NULL columns. Every update of a third party is then refused - "ErrorFieldRequired",
+        # then "Column 'dolicloud' cannot be null" - for a field that has nothing to do with this
+        # module or with Dolibarr. A plain instance has none, so they stop being mandatory here.
+        mysql --host "$DB_HOST" --port "$DB_PORT" -u"$DB_USER" -p"$DB_PASSWORD" "$DB_NAME" \
+          -e "UPDATE llx_extrafields SET fieldrequired = 0 WHERE fieldrequired <> 0;"
+        mysql --host "$DB_HOST" --port "$DB_PORT" -u"$DB_USER" -p"$DB_PASSWORD" "$DB_NAME" -N -B \
+          -e "SELECT CONCAT('ALTER TABLE ', table_name, ' MODIFY ', column_name, ' ', column_type, ' NULL;')
+                FROM information_schema.columns
+               WHERE table_schema = DATABASE() AND table_name LIKE 'llx_%_extrafields'
+                 AND is_nullable = 'NO' AND column_name NOT IN ('rowid', 'fk_object');" \
+          | mysql --host "$DB_HOST" --port "$DB_PORT" -u"$DB_USER" -p"$DB_PASSWORD" "$DB_NAME"
+        # The demo enables supplier invoices but never numbers them, and a numbering module is what
+        # FactureFournisseur::create() asks for first: without it the import of a received document
+        # fails with no message at all. Any instance that receives invoices has one set.
+        mysql --host "$DB_HOST" --port "$DB_PORT" -u"$DB_USER" -p"$DB_PASSWORD" "$DB_NAME" \
+          -e "INSERT INTO llx_const (name, entity, value, type, visible)
+                SELECT 'INVOICE_SUPPLIER_ADDON_NUMBER', 1, 'mod_facture_fournisseur_cactus', 'chaine', 0
+                FROM DUAL WHERE NOT EXISTS (
+                  SELECT 1 FROM llx_const WHERE name = 'INVOICE_SUPPLIER_ADDON_NUMBER' AND entity = 1);"
+      env:
+        DOLIBARR_VERSION: ${{ inputs.dolibarr }}
+        DB_HOST: ${{ inputs.db-host }}
+        DB_PORT: ${{ inputs.db-port }}
+        DB_NAME: ${{ inputs.db-name }}
+        DB_USER: ${{ inputs.db-user }}
+        DB_PASSWORD: ${{ inputs.db-password }}
+
+    - name: Configure that Dolibarr
+      id: configure
+      shell: bash
+      run: |
+        set -euo pipefail
+        htdocs="${GITHUB_WORKSPACE}/dolibarr/htdocs"
+        mkdir -p "${GITHUB_WORKSPACE}/documents/admin/temp" "${htdocs}/custom"
+        chmod -R 777 "${GITHUB_WORKSPACE}/documents"
+        # No web server has run the installer here, and the core refuses to work while it believes it
+        # is mid-installation.
+        touch "${GITHUB_WORKSPACE}/documents/install.lock"
+        # The login of the first user, which the page smoke test logs in as.
+        autouser=$(mysql --host "$DB_HOST" --port "$DB_PORT" -u"$DB_USER" -p"$DB_PASSWORD" "$DB_NAME" \
+          -N -B -e "SELECT login FROM llx_user WHERE rowid = 1;")
+        echo "Pages will be read as: ${autouser}"
+        mysql --host "$DB_HOST" --port "$DB_PORT" -u"$DB_USER" -p"$DB_PASSWORD" "$DB_NAME" \
+          -e "SELECT rowid, login, admin, statut FROM llx_user WHERE rowid = 1;"
+        cat > "${htdocs}/conf/conf.php" <<PHPCONF
+        <?php
+        \$dolibarr_main_url_root='http://127.0.0.1:8080';
+        \$dolibarr_main_document_root='${htdocs}';
+        \$dolibarr_main_url_root_alt='/custom';
+        \$dolibarr_main_document_root_alt='${htdocs}/custom';
+        \$dolibarr_main_data_root='${GITHUB_WORKSPACE}/documents';
+        \$dolibarr_main_db_host='${DB_HOST}';
+        \$dolibarr_main_db_port='${DB_PORT}';
+        \$dolibarr_main_db_name='${DB_NAME}';
+        \$dolibarr_main_db_prefix='llx_';
+        \$dolibarr_main_db_user='${DB_USER}';
+        \$dolibarr_main_db_pass='${DB_PASSWORD}';
+        \$dolibarr_main_db_type='mysqli';
+        \$dolibarr_main_db_character_set='utf8';
+        \$dolibarr_main_db_collation='utf8_unicode_ci';
+        // No password is typed in a CI: the pages are read as the first user of the instance.
+        \$dolibarr_main_authentication='forceuser';
+        \$dolibarr_auto_user='${autouser}';
+        \$dolibarr_main_prod='0';
+        \$dolibarr_main_instance_unique_id='cieinvoicing';
+        PHPCONF
+        cat "${htdocs}/conf/conf.php"
+        echo "htdocs=${htdocs}" >> "$GITHUB_OUTPUT"
+        echo "DOLIBARR_HTDOCS=${htdocs}" >> "$GITHUB_ENV"
+      env:
+        DB_HOST: ${{ inputs.db-host }}
+        DB_PORT: ${{ inputs.db-port }}
+        DB_NAME: ${{ inputs.db-name }}
+        DB_USER: ${{ inputs.db-user }}
+        DB_PASSWORD: ${{ inputs.db-password }}

--- a/.github/actions/dolibarr-smoke/action.yml
+++ b/.github/actions/dolibarr-smoke/action.yml
@@ -1,0 +1,90 @@
+---
+name: Open the pages of the module
+description: >
+  Serves the instance and opens the pages the module adds or hooks into, requiring each one to answer
+  200 and to hold no PHP error. Half of what breaks in this module breaks on a page and not in a
+  computation - the list of flows that died on an older core (#619), a status option rendered as
+  "Array" (#616), the module list turned into a 500 by a package missing a file (#537). None of that
+  is visible to a test that never opens a page.
+
+inputs:
+  htdocs:
+    description: The htdocs directory to serve
+    required: true
+  port:
+    description: Port the built-in server listens on
+    required: false
+    default: "8080"
+
+runs:
+  using: composite
+  steps:
+    - name: Open the pages of the module
+      shell: bash
+      run: |
+        set -uo pipefail
+        htdocs='${{ inputs.htdocs }}'
+        port='${{ inputs.port }}'
+
+        php -S "127.0.0.1:${port}" -t "$htdocs" > "${RUNNER_TEMP}/php-server.log" 2>&1 &
+        server=$!
+        trap 'kill "$server" 2>/dev/null || true' EXIT
+        for _ in $(seq 1 30); do
+          if curl -fsS -o /dev/null "http://127.0.0.1:${port}/index.php"; then break; fi
+          sleep 1
+        done
+
+        # An invoice of the demo database, so the card is opened with the hooks of the module on a
+        # document that has lines.
+        invoice=$(php -r '
+          $htdocs = $argv[1];
+          require $htdocs . "/master.inc.php";
+          $sql = "SELECT rowid FROM " . MAIN_DB_PREFIX . "facture ORDER BY rowid DESC LIMIT 1";
+          $resql = $db->query($sql);
+          $row = $resql ? $db->fetch_object($resql) : null;
+          echo $row ? (int) $row->rowid : 0;
+        ' "$htdocs")
+        echo "Invoice of the demo database: $invoice"
+
+        pages=(
+          "/index.php"
+          "/admin/modules.php"
+          "/custom/einvoicing/einvoicingindex.php"
+          "/custom/einvoicing/document_list.php"
+          "/custom/einvoicing/call_list.php"
+          "/custom/einvoicing/vendorref_list.php"
+          "/custom/einvoicing/admin/setup.php"
+          "/custom/einvoicing/admin/setup_options.php"
+          "/custom/einvoicing/admin/about.php"
+        )
+        if [ "${invoice:-0}" -gt 0 ]; then
+          pages+=("/compta/facture/card.php?id=${invoice}")
+          pages+=("/compta/facture/list.php")
+        fi
+
+        failed=0
+        for page in "${pages[@]}"; do
+          body="${RUNNER_TEMP}/page-$(echo "$page" | tr '/?=&' '____').html"
+          code=$(curl -sS -o "$body" -w '%{http_code}' "http://127.0.0.1:${port}${page}")
+          # The built-in server writes the PHP errors to its own log, and Dolibarr prints them in the
+          # page as well when it is not in production mode: both are read.
+          if [ "$code" != "200" ]; then
+            location=$(curl -sS -o /dev/null -D - "http://127.0.0.1:${port}${page}" | grep -i '^location:' | tr -d '\r')
+            echo "::error::$page answered $code ${location}"
+            failed=1
+          elif grep -qiE '(Fatal error|Parse error|Uncaught [A-Za-z]*(Error|Exception))' "$body"; then
+            echo "::error::$page holds a PHP error"
+            grep -iE -m3 '(Fatal error|Parse error|Uncaught )' "$body" | cut -c1-300
+            failed=1
+          else
+            echo "  200  $page  ($(wc -c < "$body") bytes)"
+          fi
+        done
+
+        if grep -qiE '(PHP Fatal error|PHP Parse error)' "${RUNNER_TEMP}/php-server.log"; then
+          echo "::error::the server log holds a PHP error"
+          grep -iE -m5 '(PHP Fatal error|PHP Parse error)' "${RUNNER_TEMP}/php-server.log" | cut -c1-300
+          failed=1
+        fi
+
+        exit "$failed"

--- a/.github/scripts/activate-einvoicing.php
+++ b/.github/scripts/activate-einvoicing.php
@@ -1,0 +1,53 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    .github/scripts/activate-einvoicing.php
+ * \brief   Activates the einvoicing module of a CI instance, the way Home - Setup - Modules does.
+ * \remarks activateModule() is what plays the sql/ files of the module, so this is also what gives
+ *          the instance the tables the module works on. Reads DOLIBARR_HTDOCS. Run it twice and it
+ *          has to stay green: those files are replayed at every activation.
+ */
+
+if (PHP_SAPI !== 'cli') {
+	echo "Error: this script must be run from the command line.\n";
+	exit(1);
+}
+
+global $conf, $db, $langs, $user, $mysoc;
+
+$htdocs = getenv('DOLIBARR_HTDOCS');
+if (!$htdocs || !file_exists($htdocs . '/master.inc.php')) {
+	fwrite(STDERR, 'DOLIBARR_HTDOCS does not point at an htdocs directory (got "' . $htdocs . '")' . "\n");
+	exit(2);
+}
+
+require_once $htdocs . '/master.inc.php';
+require_once DOL_DOCUMENT_ROOT . '/core/lib/admin.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/user/class/user.class.php';
+
+$user = new User($db);
+$user->fetch(1);
+
+$result = activateModule('modEInvoicing');
+
+if (!empty($result['errors'])) {
+	fwrite(STDERR, 'Activation failed: ' . implode(' | ', $result['errors']) . "\n");
+	exit(1);
+}
+
+echo 'Module activated (' . (int) $result['nbmodules'] . ' module(s), ' . (int) $result['nbperms'] . " permission(s))\n";

--- a/.github/workflows/module_einvoicing_phpunit.yml
+++ b/.github/workflows/module_einvoicing_phpunit.yml
@@ -1,32 +1,44 @@
 ---
-# The einvoicing module ships around twenty PHPUnit test files, and until now the CI ran exactly one
-# of them: the Factur-X container test, the only one that needs neither a Dolibarr nor a database.
-# Everything else - and that includes EInvoicingSamplesTest, which compares the CII of five specimen
-# invoices against committed reference documents - could only be run by hand on a developer bench.
+# The einvoicing module ships more than twenty PHPUnit test files, and until now the CI ran exactly
+# one of them: the Factur-X container test, the only one that needs neither a Dolibarr nor a
+# database. Everything else - and that includes EInvoicingSamplesTest, which compares the CII of five
+# specimen invoices against committed reference documents - could only be run by hand on a developer
+# bench.
 #
 # That is how #709 went in: the merge turned the VAT breakdown rate (BT-119) of every generated
 # document into 0.00, EInvoicingSamplesTest was red on all five samples from the merge commit on, and
 # nothing in the CI was looking. The documents it produced are refused by a conformant platform.
 #
-# This job gives those tests the Dolibarr they need. The core is checked out at a release tag and its
-# own demo dump is loaded, which is how the core CI builds a database too - no installer to drive, no
-# fixture of ours to maintain. The module is symlinked into htdocs/custom and activated the way the
-# "Modules" page does it, then every test file runs on its own, as they are meant to be run, on three
-# cores: the oldest one the module supports, the current stable, and the newest.
+# This gives those tests the Dolibarr they need. The core is checked out at a release tag and its own
+# demo dump is loaded, which is how the core CI builds a database too - no installer to drive, no
+# fixture of ours to maintain. Then three things happen on that instance:
+#
+#   - the whole suite runs, one process per file, as the tests are meant to be run;
+#   - the pages of the module are opened, because half of what breaks in this module breaks on a page
+#     and not in a computation;
+#   - the package a user installs is built by the release script and installed, because what the
+#     tests run against is a symlinked repository and not what ships.
 #
 # Everything the tests read lives in the module or in that core, so a change elsewhere in the
-# repository does not start the job - the exception being this file, which decides how the run goes.
+# repository does not start the job - the exception being this file and what it calls, which decide
+# how the run goes.
 on:
   push:
     branches: [ main ]
     paths:
       - 'einvoicing/**'
+      - 'dev/build/**'
       - '.github/workflows/module_einvoicing_phpunit.yml'
+      - '.github/actions/**'
+      - '.github/scripts/**'
   pull_request:
     branches: [ main ]
     paths:
       - 'einvoicing/**'
+      - 'dev/build/**'
       - '.github/workflows/module_einvoicing_phpunit.yml'
+      - '.github/actions/**'
+      - '.github/scripts/**'
 
   workflow_dispatch:
 
@@ -36,8 +48,42 @@ concurrency:
 
 name: phpunit
 jobs:
+  # Which cores the suite runs on. A pull request answers on three - the floor the module declares,
+  # the current stable and the newest - because that is what a reviewer waits for. What lands on main
+  # is run on all seven supported cores: the version specific traps of this module live in the middle
+  # of the range, and they cost a few runner minutes to cover.
+  cores:
+    name: Cores to run on
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.pick.outputs.matrix }}
+    steps:
+      - id: pick
+        run: |
+          # The release each demo dump belongs to. A later patch of the same series would work for
+          # the tests, which talk to the database directly, but every page would answer a redirect
+          # to the migration screen: the core compares its own version with the one the database
+          # was last upgraded to, and the dump carries the .0 of its series.
+          all='[{"dolibarr":"18.0.0","php":"8.2"},
+                {"dolibarr":"19.0.0","php":"8.2"},
+                {"dolibarr":"20.0.0","php":"8.2"},
+                {"dolibarr":"21.0.0","php":"8.3"},
+                {"dolibarr":"22.0.0","php":"8.3"},
+                {"dolibarr":"23.0.0","php":"8.3"},
+                {"dolibarr":"24.0.0","php":"8.3"}]'
+          review='[{"dolibarr":"18.0.0","php":"8.2"},
+                   {"dolibarr":"23.0.0","php":"8.3"},
+                   {"dolibarr":"24.0.0","php":"8.3"}]'
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            chosen="$review"
+          else
+            chosen="$all"
+          fi
+          echo "matrix=$(echo "$chosen" | tr -d '\n ')" >> "$GITHUB_OUTPUT"
+
   phpunit:
     name: PHPUnit on Dolibarr ${{ matrix.dolibarr }}
+    needs: cores
     runs-on: ubuntu-latest
 
     strategy:
@@ -45,16 +91,7 @@ jobs:
       # which ones fail, so let every version go to the end.
       fail-fast: false
       matrix:
-        include:
-          # The floor the module declares (modEInvoicing::$need_dolibarr_version), the current
-          # stable, and the newest release. The PHP each of them is run with is the one that release
-          # was published for.
-          - dolibarr: '18.0.10'
-            php: '8.2'
-          - dolibarr: '23.0.4'
-            php: '8.3'
-          - dolibarr: '24.0.0'
-            php: '8.3'
+        include: ${{ fromJSON(needs.cores.outputs.matrix) }}
 
     services:
       mariadb:
@@ -70,111 +107,27 @@ jobs:
           --health-timeout=5s
           --health-retries=10
 
-    env:
-      DOLIBARR_HTDOCS: ${{ github.workspace }}/dolibarr/htdocs
-
     steps:
       - name: Checkout the modules repository
         uses: actions/checkout@v6
 
-      - name: Checkout Dolibarr ${{ matrix.dolibarr }}
-        uses: actions/checkout@v6
+      - name: A Dolibarr ${{ matrix.dolibarr }} to run against
+        id: instance
+        uses: ./.github/actions/dolibarr-instance
         with:
-          repository: Dolibarr/dolibarr
-          ref: ${{ matrix.dolibarr }}
-          path: dolibarr
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: mysqli, intl, gd, mbstring, zip, xml, curl
-          tools: phpunit:9.6
-          coverage: none # disable xdebug, pcov
-
-      - name: Load the Dolibarr demo database
-        # The release ships the dump of its own demo database next to the sources; that is what the
-        # core CI loads too. Building the schema out of htdocs/install/mysql by hand would mean
-        # reimplementing the installer, and loading an older dump would mean driving the migration.
-        run: |
-          major=${DOLIBARR_VERSION%%.*}
-          dump=$(ls dolibarr/dev/initdemo/mysqldump_dolibarr_${major}.*.sql 2>/dev/null | head -1)
-          if [ -z "$dump" ]; then
-            echo "::error::No demo dump for Dolibarr ${major} in dolibarr/dev/initdemo/"
-            ls dolibarr/dev/initdemo/ || true
-            exit 1
-          fi
-          echo "Loading $dump"
-          mysql --host 127.0.0.1 --port 3306 -uroot -pdolibarr dolibarr < "$dump"
-          # The tests write documents; the umask of the demo is the one of the machine it was dumped
-          # on, and a stricter one makes the generation fail on a file it cannot read back.
-          mysql --host 127.0.0.1 --port 3306 -uroot -pdolibarr dolibarr \
-            -e "UPDATE llx_const SET value = '0666' WHERE name = 'MAIN_UMASK';"
-          mysql --host 127.0.0.1 --port 3306 -uroot -pdolibarr dolibarr \
-            -e "SELECT name, value FROM llx_const WHERE name IN ('MAIN_VERSION_LAST_UPGRADE','MAIN_VERSION_LAST_INSTALL');"
-        env:
-          DOLIBARR_VERSION: ${{ matrix.dolibarr }}
-
-      - name: Configure that Dolibarr
-        run: |
-          mkdir -p "${GITHUB_WORKSPACE}/documents/admin/temp"
-          chmod -R 777 "${GITHUB_WORKSPACE}/documents"
-          # No web server runs here, but the core still refuses to work while it believes it is
-          # mid-installation.
-          touch "${GITHUB_WORKSPACE}/documents/install.lock"
-          cat > "${DOLIBARR_HTDOCS}/conf/conf.php" <<PHPCONF
-          <?php
-          \$dolibarr_main_url_root='http://127.0.0.1';
-          \$dolibarr_main_document_root='${DOLIBARR_HTDOCS}';
-          \$dolibarr_main_url_root_alt='/custom';
-          \$dolibarr_main_document_root_alt='${DOLIBARR_HTDOCS}/custom';
-          \$dolibarr_main_data_root='${GITHUB_WORKSPACE}/documents';
-          \$dolibarr_main_db_host='127.0.0.1';
-          \$dolibarr_main_db_port='3306';
-          \$dolibarr_main_db_name='dolibarr';
-          \$dolibarr_main_db_prefix='llx_';
-          \$dolibarr_main_db_user='root';
-          \$dolibarr_main_db_pass='dolibarr';
-          \$dolibarr_main_db_type='mysqli';
-          \$dolibarr_main_db_character_set='utf8';
-          \$dolibarr_main_db_collation='utf8_unicode_ci';
-          \$dolibarr_main_authentication='dolibarr';
-          \$dolibarr_main_prod='0';
-          \$dolibarr_main_instance_unique_id='cieinvoicing';
-          PHPCONF
-          cat "${DOLIBARR_HTDOCS}/conf/conf.php"
+          dolibarr: ${{ matrix.dolibarr }}
+          php: ${{ matrix.php }}
 
       - name: Deploy and activate the module
-        # This is how the module is deployed everywhere: a symlink in htdocs/custom, which is what
-        # dolibarr_main_document_root_alt above points at. Activating it plays its sql/ files, so the
-        # tests find the tables of the module and not only those of the core.
+        # This is how the module is deployed by a developer: a symlink in htdocs/custom, which is
+        # what dolibarr_main_document_root_alt points at. Activating it plays its sql/ files, so the
+        # tests find the tables of the module and not only those of the core. It is activated twice
+        # on purpose: those files are replayed at every activation, and a replay that fails is a
+        # module that cannot be turned off and on again.
         run: |
-          mkdir -p "${DOLIBARR_HTDOCS}/custom"
-          ln -sfn "${GITHUB_WORKSPACE}/einvoicing" "${DOLIBARR_HTDOCS}/custom/einvoicing"
-          ls -l "${DOLIBARR_HTDOCS}/custom/"
-          cat > activate-module.php <<'PHPACTIVATE'
-          <?php
-          // Activate the module exactly like Home - Setup - Modules does, so what the tests run
-          // against is an instance the module has really been installed on.
-          global $conf, $db, $langs, $user, $mysoc;
-          $htdocs = getenv('DOLIBARR_HTDOCS');
-          require_once $htdocs . '/master.inc.php';
-          require_once DOL_DOCUMENT_ROOT . '/core/lib/admin.lib.php';
-          require_once DOL_DOCUMENT_ROOT . '/user/class/user.class.php';
-
-          $user = new User($db);
-          $user->fetch(1);
-
-          $result = activateModule('modEInvoicing');
-          if (!empty($result['errors'])) {
-              fwrite(STDERR, "Activation failed: " . implode(' | ', $result['errors']) . "\n");
-              exit(1);
-          }
-          echo "Module activated (" . (int) $result['nbmodules'] . " module(s), " . (int) $result['nbperms'] . " permission(s))\n";
-          PHPACTIVATE
-          php activate-module.php
-          mysql --host 127.0.0.1 --port 3306 -uroot -pdolibarr dolibarr \
-            -e "SELECT name, value FROM llx_const WHERE name LIKE 'MAIN_MODULE_EINVOICING%';"
+          ln -sfn "${GITHUB_WORKSPACE}/einvoicing" "${{ steps.instance.outputs.htdocs }}/custom/einvoicing"
+          php .github/scripts/activate-einvoicing.php
+          php .github/scripts/activate-einvoicing.php
 
       - name: Run the test files, one by one
         # One process per file, the way the module is tested on a bench: a fatal in one file then
@@ -201,6 +154,11 @@ jobs:
             echo "::error::Failed test files:$failed"
             exit 1
           fi
+
+      - name: Open the pages of the module
+        uses: ./.github/actions/dolibarr-smoke
+        with:
+          htdocs: ${{ steps.instance.outputs.htdocs }}
 
       - name: The reference documents, damaged, PHPUnit has to refuse them
         # A green suite says something only once the runner is shown to compare what it claims to
@@ -229,3 +187,88 @@ jobs:
           fi
           mv "$fixture.orig" "$fixture"
           echo "EInvoicingSamplesTest refuses the damaged reference document, as it has to."
+
+  package:
+    name: The package installs and its pages open
+    runs-on: ubuntu-latest
+
+    services:
+      mariadb:
+        image: mariadb:11.4
+        env:
+          MARIADB_ROOT_PASSWORD: dolibarr
+          MARIADB_DATABASE: dolibarr
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - name: Checkout the modules repository
+        uses: actions/checkout@v6
+
+      - name: A Dolibarr to install into
+        id: instance
+        uses: ./.github/actions/dolibarr-instance
+        with:
+          dolibarr: '23.0.0'
+          php: '8.3'
+
+      - name: Build the package with the release script
+        # dev/build/makepack-modules.php is what produces what ships. Building it here with that same
+        # script means the thing installed below is the thing users are given, and not a zip made
+        # another way for the occasion.
+        id: build
+        run: |
+          set -euo pipefail
+          version=$(tr -d '[:space:]' < einvoicing/VERSION)
+          package="dev/build/bin/module_einvoicing-$version.zip"
+          rm -f "$package"
+          php dev/build/makepack-modules.php makezip einvoicing
+          if [ ! -f "$package" ]; then
+            echo "::error::makepack-modules.php produced no $package"
+            ls -l dev/build/bin/ || true
+            exit 1
+          fi
+          echo "package=$package" >> "$GITHUB_OUTPUT"
+          echo "$(unzip -Z1 "$package" | wc -l) entries, $(du -h "$package" | cut -f1)"
+
+      - name: Install it the way the deployment screen does
+        # Everything the package holds is unpacked into htdocs/custom, and nothing else is copied:
+        # what runs from here on is the package alone. A file the builder leaves out makes the module,
+        # and the page listing the modules with it, fatal on the next request - that is what #537 was,
+        # and the page smoke below is where it shows.
+        run: |
+          set -euo pipefail
+          unzip -q '${{ steps.build.outputs.package }}' -d '${{ steps.instance.outputs.htdocs }}/custom'
+          test -d '${{ steps.instance.outputs.htdocs }}/custom/einvoicing'
+          php .github/scripts/activate-einvoicing.php
+
+      - name: Open the pages of the module
+        uses: ./.github/actions/dolibarr-smoke
+        with:
+          htdocs: ${{ steps.instance.outputs.htdocs }}
+
+      - name: A package without its compat directory has to be refused
+        # The check above says something only if it fails when the package is incomplete. #537 is
+        # rebuilt here: the same instance, the same package, minus the one directory whose absence
+        # made the module list fatal - and the page has to stop answering.
+        run: |
+          set -uo pipefail
+          rm -rf '${{ steps.instance.outputs.htdocs }}/custom/einvoicing/compat'
+          php -S 127.0.0.1:8081 -t '${{ steps.instance.outputs.htdocs }}' > server.log 2>&1 &
+          server=$!
+          trap 'kill "$server" 2>/dev/null || true' EXIT
+          for _ in $(seq 1 30); do
+            curl -fsS -o /dev/null "http://127.0.0.1:8081/index.php" && break
+            sleep 1
+          done
+          code=$(curl -sS -o control.html -w '%{http_code}' "http://127.0.0.1:8081/admin/modules.php")
+          if [ "$code" = "200" ] && ! grep -qiE '(Fatal error|Uncaught )' control.html; then
+            echo "::error::the module list still opens without the compat directory of the module - the page check above is not reading what it says it reads"
+            exit 1
+          fi
+          echo "Without compat/, the module list answers $code, as it has to."

--- a/.github/workflows/module_einvoicing_phpunit.yml
+++ b/.github/workflows/module_einvoicing_phpunit.yml
@@ -52,6 +52,12 @@ concurrency:
   group: phpunit-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # The FNFE package that carries the three validation stages, pinned. https://github.com/fnfempe/France_RFE
+  FNFE_TAG: v1.4.0.03
+  # Saxon-HE runs the compiled Schematron XSLT of that package.
+  SAXON_VERSION: 10.9
+
 jobs:
   # Which cores the suite runs on. A pull request answers on three - the floor the module declares,
   # the current stable and the newest - because that is what a reviewer waits for. What lands on main
@@ -277,3 +283,139 @@ jobs:
             exit 1
           fi
           echo "Without compat/, the module list answers $code, as it has to."
+
+  # The suite above proves "what the module generates matches the reference documents", and the
+  # einvoicing_conformance workflow proves "the reference documents are accepted by the rules". Put
+  # end to end those two say what actually matters - that what the module produces would be accepted
+  # by a platform - but only as long as both keep running on the same change, and each is guarded by
+  # its own paths filter: einvoicing_conformance starts on a fixture being committed, not on the
+  # generation being touched. Nothing enforces that the two filters stay in step.
+  #
+  # So the documents are validated here as they come out of the code, on a real core, at this commit.
+  # It is the same claim, made in one step instead of two. What it buys beyond the belt and braces is
+  # the cost of covering a new case: a shape added to generateSampleEInvoicesForTests() is validated
+  # by this job the day it is added, with no reference document to commit first - and the shapes not
+  # covered yet are most of the module (one line, one 20 % rate, one allowance and one charge is all
+  # the five specimens carry between them).
+  conformance:
+    name: What the module generates is accepted by the EN 16931 and CTC-FR rules
+    runs-on: ubuntu-latest
+
+    services:
+      mariadb:
+        image: mariadb:11.4
+        env:
+          MARIADB_ROOT_PASSWORD: dolibarr
+          MARIADB_DATABASE: dolibarr
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - name: Checkout the modules repository
+        uses: actions/checkout@v6
+
+      - name: A Dolibarr to generate on
+        # One core is enough: the suite above already runs the generation on every supported core and
+        # holds all of them to the same reference documents, so a document that differs by version
+        # cannot reach this job unnoticed.
+        id: instance
+        uses: ./.github/actions/dolibarr-instance
+        with:
+          dolibarr: '23.0.0'
+          php: '8.3'
+
+      - name: Deploy and activate the module
+        run: |
+          ln -sfn "${GITHUB_WORKSPACE}/einvoicing" "${{ steps.instance.outputs.htdocs }}/custom/einvoicing"
+          php .github/scripts/activate-einvoicing.php
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Fetch the FNFE rules and Saxon
+        run: |
+          curl -sSL -o france-rfe.tar.gz \
+            "https://github.com/fnfempe/France_RFE/archive/refs/tags/${FNFE_TAG}.tar.gz"
+          mkdir -p france-rfe
+          tar xz -C france-rfe --strip-components=1 -f france-rfe.tar.gz
+          curl -sSL -o saxon.jar \
+            "https://repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar"
+          echo "FNFE_ROOT=${GITHUB_WORKSPACE}/france-rfe/FNFE_RFE_INVOICE" >> "$GITHUB_ENV"
+          echo "SAXON_JAR=${GITHUB_WORKSPACE}/saxon.jar" >> "$GITHUB_ENV"
+
+      - name: Generate the specimen documents on that instance
+        # scripts/regenerate_einvoicing_fixtures.php is the script a developer runs after a change
+        # that alters the XML on purpose - the same entry point, so this job validates what that
+        # developer would be committing. It writes over the reference documents in the workspace,
+        # which is why they are copied out before anything else reads them.
+        run: |
+          set -euo pipefail
+          php einvoicing/scripts/regenerate_einvoicing_fixtures.php
+          mkdir -p generated
+          cp einvoicing/test/phpunit/fixtures/einvoicing_samples/*.xml generated/
+          git checkout -- einvoicing/test/phpunit/fixtures/einvoicing_samples/
+          count=$(ls generated/*.xml | wc -l)
+          if [ "$count" -lt 5 ]; then
+            echo "::error::the generation produced $count documents, expected the five specimens"
+            exit 1
+          fi
+          for file in generated/*.xml; do
+            if [ ! -s "$file" ]; then
+              echo "::error::$(basename "$file") was generated empty"
+              exit 1
+            fi
+          done
+          echo "$count documents generated: $(ls generated/ | tr '\n' ' ')"
+
+      - name: The generated documents are accepted by the rules
+        env:
+          SVRL_DIR: ${{ github.workspace }}/svrl
+        run: python3 einvoicing/test/conformance/validate-cii.py generated/*.xml
+
+      - name: The defect of #709, rebuilt on what was just generated, has to be refused
+        # A green validation says something only once the validators are shown to refuse something.
+        # The something is the regression this job exists for, rebuilt on the very documents that
+        # were just accepted - see einvoicing/test/conformance/damage-vat-rate.php.
+        env:
+          SVRL_DIR: ${{ github.workspace }}/svrl-control
+        run: |
+          php einvoicing/test/conformance/damage-vat-rate.php control generated/*.xml
+          refused=0
+          built=0
+          for file in control/*.xml; do
+            built=$((built + 1))
+            report="control-$(basename "$file").txt"
+            if python3 einvoicing/test/conformance/validate-cii.py "$file" > "$report" 2>&1; then
+              echo "::error::$(basename "$file") is still accepted with a 0.00 VAT rate - the validation above is not checking what it says it checks"
+              cat "$report"
+            elif grep -q 'BR-CO-17' "$report"; then
+              refused=$((refused + 1))
+            else
+              # Refused, but not on the rule the defect lands on: something else changed, and the
+              # control no longer demonstrates what it claims to.
+              echo "::error::$(basename "$file") is refused without BR-CO-17"
+              cat "$report"
+            fi
+          done
+          if [ "$refused" -ne "$built" ]; then
+            echo "::error::the rules refused $refused of the $built damaged documents on BR-CO-17"
+            exit 1
+          fi
+          echo "The rules refuse the $built damaged documents on BR-CO-17, as they have to."
+
+      - uses: actions/upload-artifact@v7
+        if: ${{ always() }}
+        with:
+          name: svrl-reports-generated
+          path: |
+            generated/
+            svrl/
+            svrl-control/
+          retention-days: 2

--- a/.github/workflows/module_einvoicing_phpunit.yml
+++ b/.github/workflows/module_einvoicing_phpunit.yml
@@ -1,0 +1,231 @@
+---
+# The einvoicing module ships around twenty PHPUnit test files, and until now the CI ran exactly one
+# of them: the Factur-X container test, the only one that needs neither a Dolibarr nor a database.
+# Everything else - and that includes EInvoicingSamplesTest, which compares the CII of five specimen
+# invoices against committed reference documents - could only be run by hand on a developer bench.
+#
+# That is how #709 went in: the merge turned the VAT breakdown rate (BT-119) of every generated
+# document into 0.00, EInvoicingSamplesTest was red on all five samples from the merge commit on, and
+# nothing in the CI was looking. The documents it produced are refused by a conformant platform.
+#
+# This job gives those tests the Dolibarr they need. The core is checked out at a release tag and its
+# own demo dump is loaded, which is how the core CI builds a database too - no installer to drive, no
+# fixture of ours to maintain. The module is symlinked into htdocs/custom and activated the way the
+# "Modules" page does it, then every test file runs on its own, as they are meant to be run, on three
+# cores: the oldest one the module supports, the current stable, and the newest.
+#
+# Everything the tests read lives in the module or in that core, so a change elsewhere in the
+# repository does not start the job - the exception being this file, which decides how the run goes.
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'einvoicing/**'
+      - '.github/workflows/module_einvoicing_phpunit.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'einvoicing/**'
+      - '.github/workflows/module_einvoicing_phpunit.yml'
+
+  workflow_dispatch:
+
+concurrency:
+  group: phpunit-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+name: phpunit
+jobs:
+  phpunit:
+    name: PHPUnit on Dolibarr ${{ matrix.dolibarr }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      # One core failing says nothing about the others, and the interesting information is usually
+      # which ones fail, so let every version go to the end.
+      fail-fast: false
+      matrix:
+        include:
+          # The floor the module declares (modEInvoicing::$need_dolibarr_version), the current
+          # stable, and the newest release. The PHP each of them is run with is the one that release
+          # was published for.
+          - dolibarr: '18.0.10'
+            php: '8.2'
+          - dolibarr: '23.0.4'
+            php: '8.3'
+          - dolibarr: '24.0.0'
+            php: '8.3'
+
+    services:
+      mariadb:
+        image: mariadb:11.4
+        env:
+          MARIADB_ROOT_PASSWORD: dolibarr
+          MARIADB_DATABASE: dolibarr
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    env:
+      DOLIBARR_HTDOCS: ${{ github.workspace }}/dolibarr/htdocs
+
+    steps:
+      - name: Checkout the modules repository
+        uses: actions/checkout@v6
+
+      - name: Checkout Dolibarr ${{ matrix.dolibarr }}
+        uses: actions/checkout@v6
+        with:
+          repository: Dolibarr/dolibarr
+          ref: ${{ matrix.dolibarr }}
+          path: dolibarr
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mysqli, intl, gd, mbstring, zip, xml, curl
+          tools: phpunit:9.6
+          coverage: none # disable xdebug, pcov
+
+      - name: Load the Dolibarr demo database
+        # The release ships the dump of its own demo database next to the sources; that is what the
+        # core CI loads too. Building the schema out of htdocs/install/mysql by hand would mean
+        # reimplementing the installer, and loading an older dump would mean driving the migration.
+        run: |
+          major=${DOLIBARR_VERSION%%.*}
+          dump=$(ls dolibarr/dev/initdemo/mysqldump_dolibarr_${major}.*.sql 2>/dev/null | head -1)
+          if [ -z "$dump" ]; then
+            echo "::error::No demo dump for Dolibarr ${major} in dolibarr/dev/initdemo/"
+            ls dolibarr/dev/initdemo/ || true
+            exit 1
+          fi
+          echo "Loading $dump"
+          mysql --host 127.0.0.1 --port 3306 -uroot -pdolibarr dolibarr < "$dump"
+          # The tests write documents; the umask of the demo is the one of the machine it was dumped
+          # on, and a stricter one makes the generation fail on a file it cannot read back.
+          mysql --host 127.0.0.1 --port 3306 -uroot -pdolibarr dolibarr \
+            -e "UPDATE llx_const SET value = '0666' WHERE name = 'MAIN_UMASK';"
+          mysql --host 127.0.0.1 --port 3306 -uroot -pdolibarr dolibarr \
+            -e "SELECT name, value FROM llx_const WHERE name IN ('MAIN_VERSION_LAST_UPGRADE','MAIN_VERSION_LAST_INSTALL');"
+        env:
+          DOLIBARR_VERSION: ${{ matrix.dolibarr }}
+
+      - name: Configure that Dolibarr
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/documents/admin/temp"
+          chmod -R 777 "${GITHUB_WORKSPACE}/documents"
+          # No web server runs here, but the core still refuses to work while it believes it is
+          # mid-installation.
+          touch "${GITHUB_WORKSPACE}/documents/install.lock"
+          cat > "${DOLIBARR_HTDOCS}/conf/conf.php" <<PHPCONF
+          <?php
+          \$dolibarr_main_url_root='http://127.0.0.1';
+          \$dolibarr_main_document_root='${DOLIBARR_HTDOCS}';
+          \$dolibarr_main_url_root_alt='/custom';
+          \$dolibarr_main_document_root_alt='${DOLIBARR_HTDOCS}/custom';
+          \$dolibarr_main_data_root='${GITHUB_WORKSPACE}/documents';
+          \$dolibarr_main_db_host='127.0.0.1';
+          \$dolibarr_main_db_port='3306';
+          \$dolibarr_main_db_name='dolibarr';
+          \$dolibarr_main_db_prefix='llx_';
+          \$dolibarr_main_db_user='root';
+          \$dolibarr_main_db_pass='dolibarr';
+          \$dolibarr_main_db_type='mysqli';
+          \$dolibarr_main_db_character_set='utf8';
+          \$dolibarr_main_db_collation='utf8_unicode_ci';
+          \$dolibarr_main_authentication='dolibarr';
+          \$dolibarr_main_prod='0';
+          \$dolibarr_main_instance_unique_id='cieinvoicing';
+          PHPCONF
+          cat "${DOLIBARR_HTDOCS}/conf/conf.php"
+
+      - name: Deploy and activate the module
+        # This is how the module is deployed everywhere: a symlink in htdocs/custom, which is what
+        # dolibarr_main_document_root_alt above points at. Activating it plays its sql/ files, so the
+        # tests find the tables of the module and not only those of the core.
+        run: |
+          mkdir -p "${DOLIBARR_HTDOCS}/custom"
+          ln -sfn "${GITHUB_WORKSPACE}/einvoicing" "${DOLIBARR_HTDOCS}/custom/einvoicing"
+          ls -l "${DOLIBARR_HTDOCS}/custom/"
+          cat > activate-module.php <<'PHPACTIVATE'
+          <?php
+          // Activate the module exactly like Home - Setup - Modules does, so what the tests run
+          // against is an instance the module has really been installed on.
+          global $conf, $db, $langs, $user, $mysoc;
+          $htdocs = getenv('DOLIBARR_HTDOCS');
+          require_once $htdocs . '/master.inc.php';
+          require_once DOL_DOCUMENT_ROOT . '/core/lib/admin.lib.php';
+          require_once DOL_DOCUMENT_ROOT . '/user/class/user.class.php';
+
+          $user = new User($db);
+          $user->fetch(1);
+
+          $result = activateModule('modEInvoicing');
+          if (!empty($result['errors'])) {
+              fwrite(STDERR, "Activation failed: " . implode(' | ', $result['errors']) . "\n");
+              exit(1);
+          }
+          echo "Module activated (" . (int) $result['nbmodules'] . " module(s), " . (int) $result['nbperms'] . " permission(s))\n";
+          PHPACTIVATE
+          php activate-module.php
+          mysql --host 127.0.0.1 --port 3306 -uroot -pdolibarr dolibarr \
+            -e "SELECT name, value FROM llx_const WHERE name LIKE 'MAIN_MODULE_EINVOICING%';"
+
+      - name: Run the test files, one by one
+        # One process per file, the way the module is tested on a bench: a fatal in one file then
+        # takes that file down and not the whole suite, and the summary below says which ones failed
+        # instead of stopping at the first.
+        run: |
+          failed=""
+          passed=0
+          for file in einvoicing/test/phpunit/*.php; do
+            name=$(basename "$file")
+            case "$name" in
+              AllTests.php|CommonClassTestCompat.inc.php) continue ;;
+            esac
+            echo "::group::$name"
+            if phpunit --no-configuration --testdox "$file"; then
+              passed=$((passed + 1))
+            else
+              failed="$failed $name"
+            fi
+            echo "::endgroup::"
+          done
+          echo "$passed file(s) passed"
+          if [ -n "$failed" ]; then
+            echo "::error::Failed test files:$failed"
+            exit 1
+          fi
+
+      - name: The reference documents, damaged, PHPUnit has to refuse them
+        # A green suite says something only once the runner is shown to compare what it claims to
+        # compare. EInvoicingSamplesTest is the file that would have caught #709, and it is a
+        # comparison against committed documents: change one figure in a reference document and it
+        # has to come back red. One that still passes means the samples are not being compared at
+        # all - a missing fixture, a generation that silently produced nothing, a version that skips.
+        run: |
+          fixture=einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_standard.xml
+          cp "$fixture" "$fixture.orig"
+          # A VAT breakdown rate of 19.00 where the specimen carries 20.00: the exact shape of the
+          # defect #709 shipped, in a document that stays well formed.
+          php -r '
+            $file = "einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_standard.xml";
+            $xml = file_get_contents($file);
+            $damaged = str_replace("<ram:RateApplicablePercent>20.00", "<ram:RateApplicablePercent>19.00", $xml, $count);
+            if ($count < 1) { fwrite(STDERR, "the control cannot be built: no 20.00 rate in the reference document\n"); exit(2); }
+            file_put_contents($file, $damaged);
+            echo "reference document damaged on ", $count, " rate(s)\n";
+          '
+          if phpunit --no-configuration --testdox einvoicing/test/phpunit/EInvoicingSamplesTest.php > control-report.txt 2>&1; then
+            echo "::error::EInvoicingSamplesTest passes against a damaged reference document - the run above is not comparing the generated XML"
+            cat control-report.txt
+            mv "$fixture.orig" "$fixture"
+            exit 1
+          fi
+          mv "$fixture.orig" "$fixture"
+          echo "EInvoicingSamplesTest refuses the damaged reference document, as it has to."

--- a/.github/workflows/module_einvoicing_phpunit.yml
+++ b/.github/workflows/module_einvoicing_phpunit.yml
@@ -22,6 +22,12 @@
 # Everything the tests read lives in the module or in that core, so a change elsewhere in the
 # repository does not start the job - the exception being this file and what it calls, which decide
 # how the run goes.
+name: einvoicing_phpunit
+
+permissions:
+  contents: read
+
+
 on:
   push:
     branches: [ main ]
@@ -46,7 +52,6 @@ concurrency:
   group: phpunit-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-name: phpunit
 jobs:
   # Which cores the suite runs on. A pull request answers on three - the floor the module declares,
   # the current stable and the newest - because that is what a reviewer waits for. What lands on main

--- a/einvoicing/test/conformance/damage-vat-rate.php
+++ b/einvoicing/test/conformance/damage-vat-rate.php
@@ -1,0 +1,91 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    einvoicing/test/conformance/damage-vat-rate.php
+ * \ingroup einvoicing
+ * \brief   Builds the negative control of a conformance run: the same CII documents, with the rate
+ *          of every taxing VAT breakdown set to 0.00.
+ * \remarks This is the exact shape #709 shipped - BT-119 at 0.00 against a non-zero BT-117 - and the
+ *          rules have to refuse it on BR-CO-17. A validation that comes back green says nothing
+ *          until the validators are shown to bite, and this is what they are shown to bite on. The
+ *          documents stay well formed and keep passing the XSD, so what a refusal demonstrates is
+ *          that the semantic stage ran, not that a broken file was rejected.
+ *
+ *          Breakdowns that tax nothing are left alone: a 0.00 rate on a 0.00 tax amount is what an
+ *          exempt document legitimately carries, and damaging one would prove nothing.
+ *
+ *          Usage: php damage-vat-rate.php <output directory> <document> [<document> ...]
+ */
+
+if (PHP_SAPI !== 'cli') {
+	echo "Error: this script must be run from the command line.\n";
+	exit(1);
+}
+
+$args = array_slice($argv, 1);
+if (count($args) < 2) {
+	fwrite(STDERR, "Usage: php damage-vat-rate.php <output directory> <document> [<document> ...]\n");
+	exit(2);
+}
+
+$outdir = rtrim(array_shift($args), '/');
+if (!is_dir($outdir) && !mkdir($outdir, 0755, true)) {
+	fwrite(STDERR, 'cannot create the output directory ' . $outdir . "\n");
+	exit(2);
+}
+
+$ram = 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100';
+$built = 0;
+
+foreach ($args as $file) {
+	$doc = new DOMDocument();
+	if (!$doc->load($file)) {
+		fwrite(STDERR, 'cannot read ' . $file . "\n");
+		exit(2);
+	}
+
+	$xpath = new DOMXPath($doc);
+	$xpath->registerNamespace('ram', $ram);
+
+	$damaged = 0;
+	foreach ($xpath->query('//ram:ApplicableHeaderTradeSettlement/ram:ApplicableTradeTax') as $tax) {
+		$taxes = false;
+		foreach ($xpath->query('ram:CalculatedAmount', $tax) as $amount) {
+			if (abs((float) $amount->textContent) >= 0.005) {
+				$taxes = true;
+			}
+		}
+		if (!$taxes) {
+			continue;
+		}
+		foreach ($xpath->query('ram:RateApplicablePercent', $tax) as $rate) {
+			$rate->nodeValue = '0.00';
+			$damaged++;
+		}
+	}
+
+	if (!$damaged) {
+		fwrite(STDERR, 'the control cannot be built from ' . basename($file) . ": no VAT breakdown that taxes\n");
+		exit(2);
+	}
+
+	$doc->save($outdir . '/' . basename($file));
+	$built++;
+}
+
+echo $built . " damaged documents built in " . $outdir . "\n";


### PR DESCRIPTION
## Problem

The repository runs `phpcs`, `phan` and the Factur-X container job. Of the twenty-odd PHPUnit files of
the module, the CI runs **one**: `FacturxPdfaContainerTest`, the only one that needs neither a Dolibarr
nor a database. The others — `EInvoicingSamplesTest` among them, which compares the CII of five specimen
invoices against committed reference documents — can only be run by hand on a developer bench. And
nothing at all opens a page of the module, or installs the package a user installs.

That is how #709 went in. The merge turned the VAT breakdown rate (BT-119) of every generated document
into `0.00`, and `EInvoicingSamplesTest` was red on all five samples **from the merge commit on**.
Nothing was looking. The bug is described in #749 and fixed by #750; this addresses the other half —
that the test which had already caught it was not being run.

## What the job does

On a Dolibarr checked out at a release tag, with the demo dump that release ships loaded (the way the
core CI builds a database too, so there is no installer to drive and no fixture of ours to maintain):

1. **the suite runs**, one process per file, the module symlinked into `htdocs/custom` and activated
   through `activateModule()` — which plays its `sql/` files, twice on purpose, since those files are
   replayed at every activation;
2. **the pages open**. Half of what breaks in this module breaks on a page and not in a computation:
   the list of flows that died on an older core (#619), a status option rendered as "Array" (#616), a
   module list turned into a 500 by a package missing a file (#537). The instance is served and every
   page of the module — plus the module list and an invoice card, where its hooks run — has to answer
   200 with no PHP error, in the page or in the server log;
3. **the package is built and installed**. What the tests run against is a symlinked repository, not
   what ships. A second job builds with `dev/build/makepack-modules.php` — the script the release runs,
   so the thing installed is the thing users are given — unpacks it into `htdocs/custom` the way the
   deployment screen does, activates it and opens the same pages.

Cores: a pull request answers on three — **18.0.0** (the floor `modEInvoicing::$need_dolibarr_version`
declares), **23.0.0** and **24.0.0** — because that is what a reviewer waits for. What lands on `main`
runs on all seven, 18 through 24, where the version specific traps of this module live. Each core is
taken at the release its demo dump belongs to: a later patch of the same series would send every page
to the migration screen, the database being one version behind the code.

## Two negative controls

A green run says something only once each check is shown to fail when it should.

- **The suite**: a figure of a reference document is changed and `EInvoicingSamplesTest` has to come
  back red — the shape of #709, in a document that stays well formed. If it still passes, the samples
  are not being compared at all.
- **The package**: the `compat/` directory of the installed package is deleted and the module list has
  to stop answering — #537 rebuilt on the same instance.

## Test

- **On `main` as it stands**: 20 files pass on each core and `EInvoicingSamplesTest` fails with
  `-<ram:RateApplicablePercent>20.00 / +<ram:RateApplicablePercent>0.00` — the regression of #709,
  still in `main`: https://github.com/daGrumpf-bxp/dolibarr-community-modules/actions/runs/33808511169
- **With #750 merged in**: everything green, 21 files on three cores:
  https://github.com/daGrumpf-bxp/dolibarr-community-modules/actions/runs/33810782627
- **The whole job as it stands here**, seven cores, pages, package and both controls:
  https://github.com/daGrumpf-bxp/dolibarr-community-modules/actions/runs/33827200709

So the job is **expected to be red on `main` until #750 is merged**, and that is precisely what it is
for. It is red for one file and one reason, both named in the annotation.

## Note

This is one of three layers, and none replaces the others. What each would have caught of the two
halves of #709:

| | BT-119 = 0.00 on every document | a situation invoice claiming 840.00 where Dolibarr bills 480.00 |
|---|---|---|
| this job (PHPUnit on a real Dolibarr) | **caught** — red on all 5 specimens, on every core | not covered: the specimen cycle has no second situation |
| the EN 16931 / CTC-FR schematrons (#762) | **caught** — INVALID on BR-CO-17, BR-S-08, BR-S-09 | **not caught** — the document is consistent with itself, every validator accepts it |
| the amount invariants (tests added to #750) | **caught**, with no reference document to regenerate | **caught** — 700.00 / 840.00 read against an invoice of 400.00 / 480.00 |

This job is also what runs the third row, and #763 adds two more files to the suite it runs.
