### PR TITLE
FIX [einvoicing] A control character in a description no longer makes the document unreadable

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -2573,6 +2573,14 @@ class CIIProtocol extends AbstractProtocol
 
 		$xml = $doc->saveXML();
 
+		// XML 1.0 admits no C0 control character other than tab, line feed and carriage return -
+		// neither as a character nor as a numeric reference. A description pasted from a PDF or from
+		// a terminal brings them in (0x0B is the usual one), DOM writes them out as they are, and
+		// what leaves is not XML: the platform answers HTTP 400 and the invoice never reaches its
+		// recipient. They carry no meaning in an invoice text, so they go. A byte below 0x80 never
+		// appears inside a UTF-8 sequence, so this cannot cut a character in half.
+		$xml = (string) preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F]/', '', $xml);
+
 		return $xml;
 	}
 

--- a/einvoicing/test/phpunit/ExportImportRoundTripTest.php
+++ b/einvoicing/test/phpunit/ExportImportRoundTripTest.php
@@ -1,0 +1,323 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/ExportImportRoundTripTest.php
+ *      \ingroup    test
+ *      \brief      What the module writes, the module reads back the same.
+ *      \remarks    The two halves of the module are tested apart: the generation against reference
+ *                  documents, the import against documents written by hand. Nothing checks that they
+ *                  agree, and that gap is where a whole family of defects lived - a quantity dropped
+ *                  by updateline() on the way in (#726), a document level charge skipped (#731), a
+ *                  received EXTENDED-CTC-FR document that could not be read at all (#742). Each of
+ *                  them is a term the exporter writes and the importer does not read back.
+ *
+ *                  This generates an invoice, imports the document it produced as a supplier invoice
+ *                  and requires the two to state the same thing: the same lines, the same
+ *                  quantities, unit prices and rates, the same totals. Everything happens in the
+ *                  transaction the test class rolls back.
+ *
+ *                  The seller of a generated document is the company of the instance, so the third
+ *                  party the import resolves to is that same company seen from the other side: it is
+ *                  created here as a supplier carrying the identifiers pinned on $mysoc.
+ */
+
+
+// This script must only be run from the command line.
+if (PHP_SAPI !== 'cli') {
+	echo "Error: this script must be run from the command line (CLI), not through a web server.\n";
+	exit(1);
+}
+
+global $conf, $user, $langs, $db;
+
+// Load Dolibarr environment. Same resolution as the other test files of the module.
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+require_once $dolibarrHtdocs . '/master.inc.php';
+require_once DOL_DOCUMENT_ROOT . '/user/class/user.class.php';
+require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
+require_once DOL_DOCUMENT_ROOT . '/compta/facture/class/facture.class.php';
+require_once DOL_DOCUMENT_ROOT . '/fourn/class/fournisseur.facture.class.php';
+
+/**
+ * @var Conf $conf
+ * @var DoliDB $db
+ * @var Translate $langs
+ * @var User $user
+ */
+
+dol_include_once('einvoicing/class/providers/AbstractPDPProvider.class.php');
+dol_include_once('einvoicing/class/providers/PDPProviderManager.class.php');
+dol_include_once('einvoicing/class/protocols/CIIProtocol.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+
+/**
+ * Class ExportImportRoundTripTest
+ *
+ * Generates an invoice, imports the document back, and compares the two.
+ */
+class ExportImportRoundTripTest extends CommonClassTest
+{
+	/**
+	 * The lines of the invoice: one per shape a document has to survive.
+	 * Each is array(description, unit price, quantity, VAT rate, discount percent, type).
+	 * @var array<int,array{0:string,1:float,2:float,3:float,4:float,5:int}>
+	 */
+	const LINES = array(
+		array('Widget', 12.50, 3, 20.0, 10.0, 0),			// a discounted product line
+		array('Service', 100.00, 1, 5.5, 0.0, 1),			// a service, at another rate
+		array('Nothing done yet', 42.00, 0, 20.0, 0.0, 0),	// a line without a quantity (#726)
+		array('Ampersand & quote " and accents cafe', 10.00, 1, 20.0, 0.0, 0),
+	);
+
+	/**
+	 * The invoice and the supplier invoice read back from its document, built once for the class.
+	 * @var array{invoice:Facture,imported:FactureFournisseur}|null
+	 */
+	private static $roundTrip = null;
+
+	/**
+	 * A code the numbering module of the instance accepts: some of them refuse a third party without
+	 * one, and refuse a short one.
+	 *
+	 * @param	string	$prefix		Three letters telling the two parties apart in a failure message
+	 * @return	string				A code no other third party carries
+	 */
+	private function thirdpartyCode($prefix)
+	{
+		return 'EINV' . $prefix . strtoupper(substr(md5(uniqid('', true)), 0, 6));
+	}
+
+	/**
+	 * A legal identity no other third party of the instance carries.
+	 *
+	 * The import attaches a received document to a third party by structured identifier, and it
+	 * refuses - rightly - to choose between two that carry the same one. The round trip is built
+	 * more than once in a run, so each build gets its own identity rather than leaving the second
+	 * one to fail on a duplicate this file created itself.
+	 *
+	 * @return array{siren:string,siret:string,vat:string}	SIREN, SIRET and VAT number of one party
+	 */
+	private function legalIdentity()
+	{
+		$siren = str_pad((string) random_int(0, 999999999), 9, '0', STR_PAD_LEFT);
+
+		return array(
+			'siren' => $siren,
+			'siret' => $siren . '00010',
+			'vat' => 'FR' . str_pad((string) random_int(0, 99), 2, '0', STR_PAD_LEFT) . $siren,
+		);
+	}
+
+	/**
+	 * Generate an invoice, import the document it produces, and return both.
+	 *
+	 * @return array{invoice:Facture,imported:FactureFournisseur}
+	 */
+	private function roundTrip()
+	{
+		global $conf, $db, $langs, $mysoc, $user;
+
+		if (self::$roundTrip !== null) {
+			return self::$roundTrip;
+		}
+
+		// The import writes as the user who is logged in, and reads that user from the global. A test
+		// process has none: the invoice is then written with an author of 0, which the foreign key of
+		// llx_facture_fourn refuses on the older cores and which makes the update of the third party
+		// fail on others. So the global is the one this acts as, and it is put back at the end.
+		$savUser = $user;
+		$user = new User($db);
+		$this->assertGreaterThan(0, $user->fetch(1), 'the instance has a user to act as');
+
+		$savPdp = getDolGlobalString('EINVOICING_PDP');
+		$conf->global->EINVOICING_PDP = 'SPECIMEN';
+		// A line at 0 % has to say why it is exempt (BT-121), and the reason is a setting of the
+		// instance: without it the generation stops, which says nothing about the round trip. Pinned
+		// here to the French article an instance would name, and restored below.
+		// The lines sent here are free text, as most lines of a real invoice are. An instance either
+		// matches them to a product, creates the product, or takes the line as it comes: the last one
+		// is what this compares, and it is a setting, so it is pinned rather than assumed.
+		$savFreeLines = getDolGlobalString('EINVOICING_IMPORT_AS_FREE_LINES');
+		$conf->global->EINVOICING_IMPORT_AS_FREE_LINES = 1;
+
+		// The identifiers of the seller decide which third party the import attaches the document
+		// to, and a demo company whose SIREN is "123456" stops the generation before that. $mysoc is
+		// a global object: pinning it changes nothing in the database, and it is restored below.
+		$savSeller = array(
+			'idprof1' => $mysoc->idprof1,
+			'idprof2' => $mysoc->idprof2,
+			'tva_intra' => $mysoc->tva_intra,
+			'country_id' => $mysoc->country_id,
+			'country_code' => $mysoc->country_code,
+		);
+		$sellerIdentity = $this->legalIdentity();
+		$buyerIdentity = $this->legalIdentity();
+		$mysoc->idprof1 = $sellerIdentity['siren'];
+		$mysoc->idprof2 = $sellerIdentity['siret'];
+		$mysoc->tva_intra = $sellerIdentity['vat'];
+		$mysoc->country_id = 1;
+		$mysoc->country_code = 'FR';
+
+		try {
+			// The company of the instance, seen from the other side: this is what the import resolves
+			// the seller of the document to, by structured identifier.
+			$supplier = new Societe($db);
+			$supplier->name = 'EINVOICING ROUND TRIP SELLER';
+			$supplier->fournisseur = 1;
+			$supplier->code_fournisseur = $this->thirdpartyCode('RTF');
+			$supplier->address = '1 rue du Test';
+			$supplier->zip = '75000';
+			$supplier->town = 'Paris';
+			$supplier->country_id = 1;
+			$supplier->country_code = 'FR';
+			// Some instances - the demo of Dolibarr 22 among them - make the accountancy code of a
+			// supplier mandatory, and the import updates the third party it attaches the document to.
+			$supplier->accountancy_code_buy = '401EINVCI';
+			$supplier->idprof1 = $sellerIdentity['siren'];
+			$supplier->idprof2 = $sellerIdentity['siret'];
+			$supplier->tva_intra = $sellerIdentity['vat'];
+			$this->assertGreaterThan(0, $supplier->create($user), 'the seller third party is created: ' . $supplier->error . ' ' . implode(', ', (array) $supplier->errors));
+
+			$buyer = new Societe($db);
+			$buyer->name = 'EINVOICING ROUND TRIP BUYER';
+			$buyer->client = 1;
+			$buyer->code_client = $this->thirdpartyCode('RTC');
+			$buyer->address = '2 rue du Test';
+			$buyer->zip = '75000';
+			$buyer->town = 'Paris';
+			$buyer->country_id = 1;
+			$buyer->country_code = 'FR';
+			$buyer->accountancy_code_sell = '411EINVCI';
+			$buyer->idprof1 = $buyerIdentity['siren'];
+			$buyer->idprof2 = $buyerIdentity['siret'];
+			$buyer->tva_intra = $buyerIdentity['vat'];
+			$this->assertGreaterThan(0, $buyer->create($user), 'the buyer third party is created: ' . $buyer->error . ' ' . implode(', ', (array) $buyer->errors));
+
+			$invoice = new Facture($db);
+			$invoice->socid = $buyer->id;
+			$invoice->type = Facture::TYPE_STANDARD;
+			$invoice->date = dol_now();
+			$this->assertGreaterThan(0, $invoice->create($user), 'the invoice is created: ' . $invoice->error);
+
+			foreach (self::LINES as $index => $line) {
+				list($description, $price, $qty, $rate, $discount, $type) = $line;
+				$added = $invoice->addline($description, $price, $qty, $rate, 0, 0, 0, $discount, '', '', 0, 0, 0, 'HT', 0, $type);
+				$this->assertGreaterThan(0, $added, 'line ' . ($index + 1) . ' is added: ' . $invoice->error);
+			}
+
+			$reloaded = new Facture($db);
+			$this->assertGreaterThan(0, $reloaded->fetch($invoice->id), 'the invoice is read back');
+			$reloaded->fetch_lines();
+			$reloaded->fetch_thirdparty();
+
+			$protocol = new CIIProtocol($db);
+			$path = $protocol->generateXML($reloaded, $langs);
+			$this->assertNotEmpty($path, 'the document is generated: ' . $protocol->error . ' ' . implode(', ', (array) $protocol->errors));
+			$this->assertFileExists((string) $path, 'the generated document is written');
+
+			$result = $protocol->createSupplierInvoiceFromSource((string) file_get_contents((string) $path), basename((string) $path));
+			$importedId = is_array($result) ? (int) ($result['res'] ?? 0) : (int) $result;
+			$answer = is_array($result) ? trim(strip_tags((string) ($result['message'] ?? ''))) : '';
+			$this->assertGreaterThan(
+				0,
+				$importedId,
+				'the document the module wrote is read back by the module: ' . $answer . ' ' . $protocol->error . ' ' . implode(', ', (array) $protocol->errors)
+			);
+
+			$imported = new FactureFournisseur($db);
+			$this->assertGreaterThan(0, $imported->fetch($importedId), 'the imported invoice is read back');
+			$imported->fetch_lines();
+
+			self::$roundTrip = array('invoice' => $reloaded, 'imported' => $imported);
+
+			return self::$roundTrip;
+		} finally {
+			$user = $savUser;
+			$conf->global->EINVOICING_PDP = $savPdp;
+			$conf->global->EINVOICING_IMPORT_AS_FREE_LINES = $savFreeLines;
+			foreach ($savSeller as $property => $value) {
+				$mysoc->$property = $value;
+			}
+		}
+	}
+
+	/**
+	 * Every line of the invoice is a line of the document, and comes back.
+	 *
+	 * A line that carries no quantity is the case of #726: it is a line of the invoice like any
+	 * other, and dropping it on the way in makes the two documents disagree without anything saying
+	 * so.
+	 *
+	 * @return void
+	 */
+	public function testEveryLineComesBack()
+	{
+		$roundTrip = $this->roundTrip();
+
+		$this->assertCount(
+			count($roundTrip['invoice']->lines),
+			$roundTrip['imported']->lines,
+			'the imported invoice has as many lines as the one that was sent'
+		);
+	}
+
+	/**
+	 * A line comes back with the quantity, the unit price, the rate and the net amount it left with.
+	 *
+	 * @return void
+	 */
+	public function testALineKeepsItsAmounts()
+	{
+		$roundTrip = $this->roundTrip();
+		$sent = $roundTrip['invoice']->lines;
+		$read = $roundTrip['imported']->lines;
+
+		foreach ($sent as $index => $line) {
+			$this->assertArrayHasKey($index, $read, 'line ' . ($index + 1) . ' is in the imported invoice');
+			$where = 'line ' . ($index + 1) . ' (' . dol_trunc((string) $line->desc, 30) . ')';
+
+			$this->assertEqualsWithDelta((float) $line->qty, (float) $read[$index]->qty, 0.0011, $where . ': the quantity');
+			$this->assertEqualsWithDelta((float) $line->tva_tx, (float) $read[$index]->tva_tx, 0.0011, $where . ': the VAT rate');
+			$this->assertEqualsWithDelta((float) $line->total_ht, (float) $read[$index]->total_ht, 0.011, $where . ': the net amount');
+		}
+	}
+
+	/**
+	 * The totals of the imported invoice are the totals of the invoice that was sent.
+	 *
+	 * @return void
+	 */
+	public function testTheTotalsComeBack()
+	{
+		$roundTrip = $this->roundTrip();
+		$sent = $roundTrip['invoice'];
+		$read = $roundTrip['imported'];
+
+		$this->assertEqualsWithDelta((float) $sent->total_ht, (float) $read->total_ht, 0.011, 'the net total');
+		$this->assertEqualsWithDelta((float) $sent->total_tva, (float) $read->total_tva, 0.011, 'the VAT total');
+		$this->assertEqualsWithDelta((float) $sent->total_ttc, (float) $read->total_ttc, 0.011, 'the gross total');
+	}
+}

--- a/einvoicing/test/phpunit/GeneratedTextIsXmlSafeTest.php
+++ b/einvoicing/test/phpunit/GeneratedTextIsXmlSafeTest.php
@@ -1,0 +1,237 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/GeneratedTextIsXmlSafeTest.php
+ *      \ingroup    test
+ *      \brief      A text typed on an invoice cannot make the document unreadable.
+ *      \remarks    Text is where the generation breaks, because the text is the user's and no
+ *                  validator is consulted before the document leaves. An ampersand in a company name
+ *                  produced an empty element for a while (#695, fixed by #708, and CIITextEscapingTest
+ *                  covers it at the level of the builder).
+ *
+ *                  This file asks the same question of the whole generation path, on an invoice that
+ *                  exists in the database, with the shapes a description really carries: a control
+ *                  character pasted along with text from a PDF, several lines, an ampersand, quotes,
+ *                  accents, and a text longer than the field the document has for it. The document
+ *                  produced has to be XML, and it has to still carry the text.
+ *
+ *                  The control character is not hypothetical: 0x0B travelling with a description
+ *                  made the generation write a document XML 1.0 refuses, which the platform answered
+ *                  with HTTP 400 - a document that never reached its recipient, and nothing in the
+ *                  module noticed. Everything happens in the transaction the test class rolls back.
+ */
+
+
+// This script must only be run from the command line.
+if (PHP_SAPI !== 'cli') {
+	echo "Error: this script must be run from the command line (CLI), not through a web server.\n";
+	exit(1);
+}
+
+global $conf, $user, $langs, $db;
+
+// Load Dolibarr environment. Same resolution as the other test files of the module.
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+require_once $dolibarrHtdocs . '/master.inc.php';
+require_once DOL_DOCUMENT_ROOT . '/user/class/user.class.php';
+require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
+require_once DOL_DOCUMENT_ROOT . '/compta/facture/class/facture.class.php';
+
+/**
+ * @var Conf $conf
+ * @var DoliDB $db
+ * @var Translate $langs
+ * @var User $user
+ */
+
+dol_include_once('einvoicing/class/protocols/CIIProtocol.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+
+/**
+ * Class GeneratedTextIsXmlSafeTest
+ *
+ * Generates one invoice per hostile text and reads the document back.
+ */
+class GeneratedTextIsXmlSafeTest extends CommonClassTest
+{
+	/** @var Societe|null	The buyer every invoice of this class is made for */
+	private static $buyer = null;
+
+	/**
+	 * The texts an invoice line is made to carry, and what has to survive of each.
+	 *
+	 * @return array<string,array{0:string,1:string}>	Case name => text typed, fragment that must remain
+	 */
+	public function hostileTexts()
+	{
+		return array(
+			'a vertical tab pasted from a PDF' => array("Assembly\x0Bkit, ref 4711", 'Assembly'),
+			'a unit separator' => array("Ref\x1F0042 delivered", 'delivered'),
+			'a null byte' => array("Serial\x00number", 'Serial'),
+			'an ampersand' => array('Nuts & bolts', 'Nuts & bolts'),
+			'quotes' => array('The "special" article', 'special'),
+			'accents' => array('Café crème, thé, à l\'unité', 'Café crème'),
+			'several lines' => array("First line\nSecond line", 'Second line'),
+			'a long text' => array(str_repeat('A very long description. ', 40), 'A very long description.'),
+		);
+	}
+
+	/**
+	 * The buyer of every invoice built here, created once.
+	 *
+	 * @return Societe	A customer third party
+	 */
+	private function buyer()
+	{
+		global $db;
+
+		if (self::$buyer !== null) {
+			return self::$buyer;
+		}
+
+		$user = new User($db);
+		$this->assertGreaterThan(0, $user->fetch(1), 'the instance has a user to act as');
+
+		$buyer = new Societe($db);
+		$buyer->name = 'EINVOICING TEXT BUYER';
+		$buyer->client = 1;
+		// Some instances - the demo database among them - number their customers with a module that
+		// refuses a third party without a code, and refuses a short one.
+		$buyer->code_client = 'EINVTX' . strtoupper(substr(md5(uniqid('', true)), 0, 6));
+		$buyer->address = '2 rue du Test';
+		$buyer->zip = '75000';
+		$buyer->town = 'Paris';
+		$buyer->country_id = 1;
+		$buyer->country_code = 'FR';
+		$buyer->idprof1 = '000000002';
+		$buyer->idprof2 = '00000000200010';
+		$buyer->tva_intra = 'FR12000000002';
+		$this->assertGreaterThan(0, $buyer->create($user), 'the buyer is created: ' . $buyer->error . ' ' . implode(', ', (array) $buyer->errors));
+
+		self::$buyer = $buyer;
+
+		return self::$buyer;
+	}
+
+	/**
+	 * Build a one-line invoice carrying the given text and generate its document.
+	 *
+	 * @param	string	$text	The description of the line
+	 * @return	string			The document produced
+	 */
+	private function generateWith($text)
+	{
+		global $conf, $db, $langs, $mysoc;
+
+		$user = new User($db);
+		$user->fetch(1);
+
+		$savPdp = getDolGlobalString('EINVOICING_PDP');
+		$conf->global->EINVOICING_PDP = 'SPECIMEN';
+		// A demo company whose SIREN is "123456" stops the generation before the text is reached.
+		$savSeller = array(
+			'idprof1' => $mysoc->idprof1,
+			'idprof2' => $mysoc->idprof2,
+			'tva_intra' => $mysoc->tva_intra,
+			'country_id' => $mysoc->country_id,
+			'country_code' => $mysoc->country_code,
+		);
+		$mysoc->idprof1 = '000000001';
+		$mysoc->idprof2 = '00000000100010';
+		$mysoc->tva_intra = 'FR12000000001';
+		$mysoc->country_id = 1;
+		$mysoc->country_code = 'FR';
+
+		try {
+			$invoice = new Facture($db);
+			$invoice->socid = $this->buyer()->id;
+			$invoice->type = Facture::TYPE_STANDARD;
+			$invoice->date = dol_now();
+			$this->assertGreaterThan(0, $invoice->create($user), 'the invoice is created: ' . $invoice->error);
+			$this->assertGreaterThan(0, $invoice->addline($text, 10.00, 1, 20), 'the line is added: ' . $invoice->error);
+
+			$reloaded = new Facture($db);
+			$reloaded->fetch($invoice->id);
+			$reloaded->fetch_lines();
+			$reloaded->fetch_thirdparty();
+
+			$protocol = new CIIProtocol($db);
+			$path = $protocol->generateXML($reloaded, $langs);
+			$this->assertNotEmpty($path, 'the document is generated: ' . $protocol->error);
+			$this->assertFileExists((string) $path, 'the generated document is written');
+
+			return (string) file_get_contents((string) $path);
+		} finally {
+			$conf->global->EINVOICING_PDP = $savPdp;
+			foreach ($savSeller as $property => $value) {
+				$mysoc->$property = $value;
+			}
+		}
+	}
+
+	/**
+	 * Whatever the text, the document produced is XML.
+	 *
+	 * @dataProvider hostileTexts
+	 * @param	string	$text		The text typed on the invoice line
+	 * @return	void
+	 */
+	public function testTheDocumentIsWellFormed($text)
+	{
+		$xml = $this->generateWith($text);
+
+		$document = new DOMDocument();
+		$parsed = @$document->loadXML($xml);
+
+		$this->assertTrue(
+			$parsed,
+			'the document generated for this text is not XML: ' . trim((string) (($error = libxml_get_last_error()) ? $error->message : ''))
+		);
+	}
+
+	/**
+	 * And the text is still in it. A document that drops what was typed is as wrong as one that
+	 * cannot be parsed - #695 produced empty elements, which are well formed.
+	 *
+	 * @dataProvider hostileTexts
+	 * @param	string	$text		The text typed on the invoice line
+	 * @param	string	$fragment	What has to remain readable in the document
+	 * @return	void
+	 */
+	public function testTheTextIsStillThere($text, $fragment)
+	{
+		$xml = $this->generateWith($text);
+
+		$document = new DOMDocument();
+		$this->assertTrue(@$document->loadXML($xml), 'the document generated for this text is XML');
+
+		$this->assertStringContainsString(
+			$fragment,
+			(string) $document->textContent,
+			'the document no longer carries "' . $fragment . '"'
+		);
+	}
+}


### PR DESCRIPTION
## Problem

Two things this repository could not see, both found by asking the module questions it had never been
asked.

**A control character makes the document unreadable.** XML 1.0 admits no C0 control character other
than tab, line feed and carriage return. A description pasted from a PDF or from a terminal brings one
in — `0x0B` is the usual one — DOM writes it out as it is, and what leaves is not XML. The platform
answers HTTP 400 and the invoice never reaches its recipient. Nothing in the module notices, because a
document is never parsed after being written.

Measured on the generation path, before this change:

```
vertical tab     wellformed=NO    unit separator   wellformed=NO
newline          wellformed=yes   quotes           wellformed=yes
accents          wellformed=yes   long text        wellformed=yes
```

**The two halves of the module are never compared.** The generation is tested against reference
documents, the import against documents written by hand, and nothing checks that they agree. That gap
is where a quantity dropped by `updateline()` on the way in (#726), a document level charge skipped
(#731) and an unreadable EXTENDED-CTC-FR document (#742) all lived: each is a term the exporter writes
and the importer does not read back.

## Fix

The control characters are removed at the one place the document becomes a string, in
`CIIProtocol::buildXML()`. A byte below `0x80` never appears inside a UTF-8 sequence, so this cannot
cut a character in half, and those characters carry no meaning in an invoice text.

## Test

Two files, on the whole generation path rather than on the builder alone — `CIITextEscapingTest`
already covers the builder.

**`GeneratedTextIsXmlSafeTest`** types eight texts on the line of a real invoice — the two control
characters, an ampersand, quotes, accents, several lines, a very long text — and requires the document
to parse **and** to still carry the text. A document that drops what was typed is as wrong as one that
cannot be parsed: #695 produced empty elements, which are well formed. The two control character cases
are red without the change above and green with it.

**`ExportImportRoundTripTest`** generates an invoice of four lines — a discounted product line, a
service at another rate, a line without a quantity (#726), a description carrying an ampersand and
quotes — imports the document it produced as a supplier invoice, and requires the same lines, the same
quantities, rates and net amounts, and the same totals to come back.

Both run in the transaction the test class rolls back, and both are part of the suite the job of #760
runs. Green on the seven supported cores, 18.0.0 through 24.0.0:
https://github.com/daGrumpf-bxp/dolibarr-community-modules/actions/runs/33827200709

Four things the round trip needs from the instance, pinned in the test rather than assumed, each found
by a core answering differently: the import writes as the logged-in user (an author of 0 is refused by
the foreign key of `llx_facture_fourn` on 18 and 19), free line import (an instance either matches a
product, creates it, or takes the line as it comes), an accountancy code on the supplier, and a legal
identity of its own per run so the importer never has to choose between two third parties carrying the
same one.

## Note

One case is deliberately left out of the round trip: a line at 0 %. Its exemption reason (BT-120/121)
is instance setup that moved between cores — a constant below 24, the VAT dictionary from 24 on — and
pinning both would test the setup, not the round trip.

Separately, and not addressed here: a description holding `a<b AND c>d` reaches the document as `ad`.
`dol_string_nohtmltag()` removes what stands between the angle brackets. It is a loss of content, not
a malformed document, and it deserves its own issue rather than a silent change of what the module
sends.
