### PR TITLE
FIX #761 [einvoicing] A received document is judged on the invoice it carries, not on its envelope

### DIFF
--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -526,6 +526,15 @@ abstract class AbstractPDPProvider
 				continue;
 			}
 
+			// What was recognized above is the syntax of the file, not the syntax of the invoice it
+			// carries. Open the document before accepting it, or a syntax with no reader here is
+			// handed to the reader of another one.
+			$payloadReason = '';
+			if ($this->readableInvoicePayload($content, $protocol, $protocolManager, $payloadReason) === null) {
+				$result['attempts'][] = $docType . ": " . $protocolName . " but " . $payloadReason;
+				continue;
+			}
+
 			if ($docType != 'Converted') {
 				dol_syslog(__METHOD__ . " No usable 'Converted' document for flowId " . $flowId . " (" . implode(' | ', $result['attempts']) . "), reading the '" . $docType . "' one instead", LOG_WARNING, 0, "_einvoicing");
 			}
@@ -538,6 +547,57 @@ abstract class AbstractPDPProvider
 		}
 
 		return $result;
+	}
+
+	/**
+	 * The invoice a document carries, once its container has been opened, when this module can read it.
+	 *
+	 * detectProtocolFromContent() answers on the outside of a file: a PDF is 'FACTURX' on the strength
+	 * of its '%PDF-' header alone, whatever it holds. What it holds is a separate question, because the
+	 * embedded invoice is picked by file name and not by content - 'xrechnung.xml' is one of the names
+	 * accepted, and an XRechnung is commonly UBL, a syntax that has no reader here.
+	 *
+	 * Reading the outside only is how such a payload reaches the reader of another syntax. The CII
+	 * reader then finds none of the elements it expects and reports a business error that names nothing
+	 * the user can act on, which is counted as a failure and stops the whole synchronization batch; and
+	 * on the consistency check, the same document reaches code that dereferences a protocol which was
+	 * never built.
+	 *
+	 * The document is not re-typed on what is found inside: a Factur-X PDF is imported as Factur-X,
+	 * whose reader does the extraction itself. Only the question "can this be read at all" is answered.
+	 *
+	 * @param	string				$content			Raw document, as the access point returned it
+	 * @param	AbstractProtocol	$protocol			Protocol recognized on the container
+	 * @param	ProtocolManager		$protocolManager	Protocol factory used to recognize the payload
+	 * @param	string				$reason				Filled with why the payload was rejected
+	 * @return	?string									The invoice inside, or null when it cannot be read
+	 */
+	protected function readableInvoicePayload($content, $protocol, $protocolManager, &$reason)
+	{
+		$reason = '';
+
+		try {
+			// AbstractProtocol::extractXmlFromFileContent() returns the content unchanged, so a
+			// document that is already an XML is its own payload and this costs nothing there.
+			$payload = (string) $protocol->extractXmlFromFileContent($content);
+		} catch (Throwable $e) {
+			// A PDF with no embedded invoice at all raises ZugferdNoPdfAttachmentFoundException here.
+			$reason = "its container holds no invoice - " . $e->getMessage();
+			return null;
+		}
+
+		$payloadName = $protocolManager->detectProtocolFromContent($payload);
+		if (empty($payloadName)) {
+			$reason = "what it carries is in an unrecognized syntax";
+			return null;
+		}
+
+		if (empty($protocolManager->getProtocol($payloadName))) {
+			$reason = "what it carries is " . $payloadName . ", which is not supported";
+			return null;
+		}
+
+		return $payload;
 	}
 
 	/**
@@ -1122,7 +1182,16 @@ abstract class AbstractPDPProvider
 		if ($resProtocol['success']) {
 			$protocol = $resProtocol['protocol_object'];
 
-			$xmlData = $protocol->extractXmlFromFileContent($receivedFileContent);
+			// getProtocolFromContent() succeeded on the container. The invoice inside may still be in a
+			// syntax with no reader here, and everything downstream - cleanXmlData() first - assumes a
+			// protocol was found for what it is handed. Return nothing rather than that.
+			$payloadReason = '';
+			$xmlData = $this->readableInvoicePayload($receivedFileContent, $protocol, new ProtocolManager($this->db), $payloadReason);
+
+			if ($xmlData === null) {
+				dol_syslog(__METHOD__ . " Flow " . $flowId . " holds no invoice this module can read: " . $payloadReason, LOG_WARNING, 0, "_einvoicing");
+				return null;
+			}
 
 			if ($cleanXml) {
 				$xmlData = Document::cleanXmlData($xmlData);


### PR DESCRIPTION
Fixes #761.

`detectProtocolFromContent()` answers on the outside of a file: anything starting with `%PDF-` is Factur-X, whatever it holds. What it holds is a separate question, because `ZugferdDocumentPdfReaderExt` picks the embedded invoice **by file name** — and `xrechnung.xml` is one of the names it accepts, an XRechnung being commonly UBL, a syntax this module recognizes but has no reader for.

Nobody asked that second question, so an ordinary German hybrid invoice was accepted as Factur-X and its UBL handed to the CII reader. Two consequences:

- **Reception stops.** The CII reader finds none of the elements it expects and answers `Unfounded dolibarr corresponding Invoice code for document type code: NA`. That failure carries no `postponeflow`, so `syncFlows()` counts an error and breaks: one such invoice stops the whole incoming synchronization and every flow queued behind it. This is the failure mode `fetchImportableFlowDocument()` was built to remove, and it survived because the picker never opened the container.
- **The consistency check dies.** `fetchFlowXml()` guards on `getProtocolFromContent()`, but that guard is computed on the PDF while `extractXmlFromFileContent()` then returns the UBL. `cleanXmlData()` detects `UBL`, `getProtocol()` returns `null`, and `get_class(null)` kills the request — inside a trigger, so it takes the validation of the supplier invoice with it.

## The change

Both paths now ask the same question before accepting a document: not "what does this file look like" but "is there an invoice in it this module can read". One helper, `readableInvoicePayload()`, used by the picker and by `fetchFlowXml()`. A document that fails it is skipped like any other unreadable shape, so the other shapes of the flow are still tried and the flow ends up postponed with the action to do, instead of stalling the batch.

The document is deliberately **not** re-typed on what is found inside: a Factur-X PDF is still imported as Factur-X, whose reader does its own extraction. Only reachability is checked. `AbstractProtocol::extractXmlFromFileContent()` returns its input unchanged, so this costs nothing on a document that is already an XML.

Not addressed here, and worth a separate look: `fetchFlowXml()` asks for the **`Original`** document, hardcoded, while the import reads the **`Converted`** one — so the two paths do not necessarily see the same document.

## Measured, before and after

Same bench, same specimen, same harness — a hybrid PDF whose embedded `xrechnung.xml` holds a UBL invoice, which is what a German issuer sending a hybrid XRechnung produces. Only the network answer is stubbed. `before` is this branch's parent.

```
BEFORE  A. accepted as FacturXProtocol, attempts: (none - nothing was noticed)
           import res=-1 'Unfounded dolibarr corresponding Invoice code for document type code: NA'
           postponeflow=NULL  -> syncFlows() breaks the batch
        B. TypeError: get_class(): Argument #1 ($object) must be of type object, null given

AFTER   A. refused, attempts: Converted/Original/ReadableView: FACTURX but what it carries
           is UBL, which is not supported  -> postponeflow=1, the batch carries on
        B. returned null (nothing readable, no fatal)
```

Same on Dolibarr **18, 20, 22, 23 and 24**.

**Control — a real Factur-X must be untouched.** Same harness fed the module's own `INVTEST-dol_ok.facturx.pdf`: accepted, imported (`res=7499`), and `fetchFlowXml()` returns its 13017 bytes of XML. The fix rejects the unreadable payload and leaves the readable one strictly alone.

**Side benefit.** A plain PDF with no embedded invoice — a very ordinary `ReadableView` — used to be accepted as Factur-X too and blew up later in the import. It is now refused with `its container holds no invoice - No PDF attachment found`, and the flow is postponed instead of aborting the batch.

## Where such a document comes from — and where it does not

Measured against a live access point, so the origin of the case is not left to guess: converting a
UBL invoice to Factur-X there produces a PDF whose single attachment is `factur-x.xml` and whose
content is a `CrossIndustryInvoice`. A container that still carries UBL is therefore **not** what a
conversion produces; it is what an issuer's own hybrid document looks like, and that one reaches the
module untouched as the `Original` — the shape read whenever `Converted` is unusable, or first with
`EINVOICING_PREFER_ORIGINAL`.

Related to #718, without settling it: the failure this fixes carries no `postponeflow`, so it stops
the batch exactly the way that issue describes. The **side benefit** above is the part likely to be
met in the wild first — a flow whose `Converted` and `Original` are both in a syntax with no reader
falls through to the `ReadableView`, an ordinary PDF, which main still accepts as Factur-X and then
fails on with no postponement.

## Non-regression

- **PHPUnit**, file by file, on every supported core (18 → 24): `OK=23 KO=0` on each.
- **QA generation matrix**, 7 invoice types × CII and FACTURX = 14 generations: all produced and validated. Expected — this patch touches reception only.
- **Full lifecycle E2E**, every supported version, both directions: **14/14 cycles complete**, each recording `200, 201, 205, 211, 212` — emitted, routed, imported, approved, paid, cashed in. Run against this branch's head on a tree checked to be unchanged before and after.
- Dolibarr 17 shows 2 errors, but the module declares `need_dolibarr_version = array(18, -3)` and those same 2 errors are there with this branch's file reverted to its parent on the same bench.

