### PR TITLE
FIX [einvoicing] The message about a missing linked document says which of the two is missing

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -937,7 +937,7 @@ class CIIProtocol extends AbstractProtocol
 
 				$refDocInvoiceId = SupplierInvoiceHelper::findIdByRef($refDoc, (int) $socId);
 				if ($refDocInvoiceId < 0) {
-					return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($refDocInvoiceId, $refDoc, 'linked to document ' . ($parsedHeader['documentno'] ?? ''))];
+					return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($refDocInvoiceId, $refDoc, 'required by received document ' . ($parsedHeader['documentno'] ?? ''))];
 				}
 				if ($refDocInvoiceId == 0) {
 					// The invoice references a document this Dolibarr does not hold: the final invoice of a
@@ -956,7 +956,7 @@ class CIIProtocol extends AbstractProtocol
 					return [
 						'res' => -1,
 						'postponeflow' => 1,
-						'message' => 'Document : ' . $refDoc . ' linked to document ' . $parsedHeader['documentno'] . ' not found in Dolibarr',
+						'message' => 'Document ' . $refDoc . ', required by received document ' . $parsedHeader['documentno'] . ', was not found in Dolibarr',
 						'actioncode' => 'LINKED_INVOICE_NOT_FOUND',
 						'actionurl' => 'none',
 						'actiondata' => array('supplierref' => $refDoc, 'linkedref' => ($parsedHeader['documentno'] ?? ''), 'socid' => (int) $socId),
@@ -1076,10 +1076,10 @@ class CIIProtocol extends AbstractProtocol
 
 					$linkedObjectId = SupplierInvoiceHelper::findIdByRef($refDoc, (int) $socId);
 					if ($linkedObjectId < 0) {
-						return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($linkedObjectId, $refDoc, 'linked to document ' . ($parsedHeader['documentno'] ?? ''))];
+						return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($linkedObjectId, $refDoc, 'required by received document ' . ($parsedHeader['documentno'] ?? ''))];
 					}
 					if ($linkedObjectId == 0) {
-						return ['res' => -1, 'message' => 'Document : ' . $refDoc . ' linked to document ' . $parsedHeader['documentno'] . ' not found in Dolibarr'];
+						return ['res' => -1, 'message' => 'Document ' . $refDoc . ', required by received document ' . $parsedHeader['documentno'] . ', was not found in Dolibarr'];
 					}
 
 					// Fetch Object
@@ -1115,7 +1115,10 @@ class CIIProtocol extends AbstractProtocol
 
 						// Other linked document handling can be implemented here based on the type of the linked document for example credit note etc...
 					} else {
-						return ['res' => -1, 'message' => 'Document : ' . $refDoc . ' linked to document ' . $parsedHeader['documentno'] . ' not found in Dolibarr'];
+						// Reached only when fetch() failed on an id findIdByRef() did return, so the reference
+						// was matched and it is the loading that went wrong: saying "not found" here sent the
+						// reader looking for a missing invoice that is in fact there.
+						return ['res' => -1, 'message' => 'Document ' . $refDoc . ', required by received document ' . $parsedHeader['documentno'] . ', matches supplier invoice id ' . ((int) $linkedObjectId) . ' but that invoice could not be loaded'];
 					}
 				}
 			}


### PR DESCRIPTION
`Document : A linked to document B not found in Dolibarr` reads as if **B** were the missing one. It is **A**. B is the invoice that just arrived, A is the document it refers to and that Dolibarr does not hold — so the sentence names as missing the one that is actually there, and sends the reader looking in the wrong place.

It is not a theoretical confusion. On a situation cycle the second invoice refers to the first, and the message names them in the order that invites you to go and create the invoice which already exists, while the one to create keeps being reported at every synchronization. I read it backwards myself before going to the source.

## The change

The five places that build this sentence now say `Document A, required by received document B, was not found in Dolibarr`, which cannot be read the other way round. Three are the sentence itself; the other two are the context handed to `refLookupErrorMessage()` for the duplicate and database-error cases, which read the same way.

The last of the five said something else again: it is reached only when `fetch()` fails on an id that `findIdByRef()` **did** return, so the reference was matched and it is the loading that went wrong. Announcing "not found" there sent the reader after a missing invoice that is in fact in the database, under an id the message did not give. It now names that id and says the load failed.

The user-facing string is untouched: `CantFindLinkedInvoiceOfTheImportedInvoice` already spells out which invoice refers to which. Only the technical message written to the synchronization log was misleading.

## Verified on a real synchronization

A situation invoice n°1 was created on the emitter but never sent, then situation n°2 — which references it — was emitted normally. The receiver logged:

```
Flow i_435016 postponed, it will be retried on the next synchronization:
Failed to create supplier invoice from E-invoice document for flowId: i_435016.
Document DD23-FA-2609-0398, required by received document DD23-FA-2609-0399,
was not found in Dolibarr
```

`0398` is indeed the one that was never sent, `0399` the one that arrived. Recording the missing invoice then let the flow import on the next pass, which is what the message asks for.

Strings only, no behaviour change: same `res`, same `postponeflow`, same `actioncode`, same action link.
