### PR TITLE
QUAL [einvoicing] The two not-for-prod options move to the Dev tools page

### DIFF
--- a/einvoicing/admin/setup_devtools.php
+++ b/einvoicing/admin/setup_devtools.php
@@ -77,6 +77,10 @@ require_once "../class/providers/PDPProviderManager.class.php";
 require_once "../class/protocols/ProtocolManager.class.php";
 require_once "../class/einvoicing.class.php";
 
+if (!class_exists('FormSetup')) {
+	require_once DOL_DOCUMENT_ROOT.'/core/class/html.formsetup.class.php';
+}
+
 
 // Translations
 $langs->loadLangs(array("admin", "bills", "einvoicing@einvoicing", "other"));
@@ -121,6 +125,25 @@ $invoice_path = '';
 
 $sellerId = GETPOSTINT('seller_id');
 $buyerId = GETPOSTINT('buyer_id');
+
+$formSetup = new FormSetup($db);
+
+// Allow re-sending / re-editing an invoice already transmitted to the Access Point. Off by default:
+// a transmitted invoice is immutable (correct it with a credit note / corrective invoice), and re-sending
+// makes the PA refuse a duplicate. Turn on only to deliberately test PA retry behaviour.
+$item = $formSetup->newItem('EINVOICING_ALLOW_RESEND_TRANSMITTED')->setAsYesNo();
+$item->nameText = $langs->trans("EINVOICING_ALLOW_RESEND_TRANSMITTED").' <span class="opacitymedium">('.$langs->trans("EINVOICING_TRANSMITTED_NOT_FOR_PROD").')</span>';
+$item->defaultFieldValue = '0';
+$item->helpText = $langs->transnoentities('EINVOICING_ALLOW_RESEND_TRANSMITTED_HELP');
+$item->cssClass = 'minwidth500';
+
+// Dev-only: keep the "Regenerate e-invoice" button/action available on a transmitted-locked invoice
+// (rebuild the CII/Factur-X to inspect the XML). Re-sending stays locked. Off by default.
+$item = $formSetup->newItem('EINVOICING_ALLOW_REGEN_TRANSMITTED')->setAsYesNo();
+$item->nameText = $langs->trans("EINVOICING_ALLOW_REGEN_TRANSMITTED").' <span class="opacitymedium">('.$langs->trans("EINVOICING_TRANSMITTED_NOT_FOR_PROD").')</span>';
+$item->defaultFieldValue = '0';
+$item->helpText = $langs->transnoentities('EINVOICING_ALLOW_REGEN_TRANSMITTED_HELP');
+$item->cssClass = 'minwidth500';
 
 
 /*
@@ -175,6 +198,9 @@ if ($action == 'buildsamplesupplierinvoice') {	// Test on permissions already do
 		setEventMessages('Sample invoice generated with ref '.$ref, null, 'mesgs');
 	}
 }
+
+// Save the options declared with $formSetup (action = 'update')
+include DOL_DOCUMENT_ROOT.'/core/actions_setmoduleoptions.inc.php';
 
 
 /*
@@ -435,6 +461,11 @@ if (getDolGlobalString('EINVOICING_PDP')) {
 }
 
 print '<br>';
+
+if (!empty($formSetup->items)) {
+	print $formSetup->generateOutput(true, true);
+	print '<br>';
+}
 
 print '<div class="neutral">';
 print '<form action="'.$_SERVER["PHP_SELF"].'" method="POST">';

--- a/einvoicing/admin/setup_options.php
+++ b/einvoicing/admin/setup_options.php
@@ -331,26 +331,6 @@ if (!getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP')) {
 	$item->defaultFieldValue = getDolGlobalString('EINVOICING_NAME_OF_MODULESOURCE_THAT_ARE_POS', 'takepos');
 	$item->cssClass = 'minwidth500';
 
-
-	// TODO Move this in the dev setup page ?
-
-	// Allow re-sending / re-editing an invoice already transmitted to the Access Point. Off by default:
-	// a transmitted invoice is immutable (correct it with a credit note / corrective invoice), and re-sending
-	// makes the PA refuse a duplicate. Turn on only to deliberately test PA retry behaviour.
-	$item = $formSetup->newItem('EINVOICING_ALLOW_RESEND_TRANSMITTED')->setAsYesNo();
-	$item->nameText = $langs->trans("EINVOICING_ALLOW_RESEND_TRANSMITTED").' <span class="opacitymedium">('.$langs->trans("EINVOICING_TRANSMITTED_NOT_FOR_PROD").')</span>';
-	$item->defaultFieldValue = '0';
-	$item->helpText = $langs->transnoentities('EINVOICING_ALLOW_RESEND_TRANSMITTED_HELP');
-	$item->cssClass = 'minwidth500';
-
-	// Dev-only: keep the "Regenerate e-invoice" button/action available on a transmitted-locked invoice
-	// (rebuild the CII/Factur-X to inspect the XML). Re-sending stays locked. Off by default.
-	$item = $formSetup->newItem('EINVOICING_ALLOW_REGEN_TRANSMITTED')->setAsYesNo();
-	$item->nameText = $langs->trans("EINVOICING_ALLOW_REGEN_TRANSMITTED").' <span class="opacitymedium">('.$langs->trans("EINVOICING_TRANSMITTED_NOT_FOR_PROD").')</span>';
-	$item->defaultFieldValue = '0';
-	$item->helpText = $langs->transnoentities('EINVOICING_ALLOW_REGEN_TRANSMITTED_HELP');
-	$item->cssClass = 'minwidth500';
-
 	/*
 	$itemtitle->helpText = $langs->trans('EINVOICING_VAT_EXIGIBILITY_HELP').' <b>'
 			.dol_escape_htmltag($vatexigibility)


### PR DESCRIPTION
Follow-up on the `// TODO Move this in the dev setup page ?` left in `admin/setup_options.php`.

## What moves

`EINVOICING_ALLOW_RESEND_TRANSMITTED` and `EINVOICING_ALLOW_REGEN_TRANSMITTED` are test levers: they let a transmitted invoice be re-sent or regenerated, which breaks the immutability the Access Point expects. They were sitting in the Options tab, among the settings a normal administrator is meant to use.

They now live in `admin/setup_devtools.php`, the page shown only when `EINVOICING_ALLOW_DEVTOOLS` is set, so they are out of sight of a normal setup. Labels, help texts and translation keys are unchanged, and so is the code that reads the two constants.

## What it takes on the dev page

That page had no constant handling of its own (hand-printed HTML plus two ad-hoc actions), so it gets:

- a `FormSetup` object and the two items,
- the core `actions_setmoduleoptions.inc.php` include, for the save path used when javascript is off,
- the output block, just before the `MAIN_FORCE_SYSTEM_MESSAGE` form.

Both items are `setAsYesNo()`, so with javascript on they are saved by `core/ajax/constantonoff.php`, as everywhere else; `saveConfFromPost()` skips `yesno` items in that case.

## Test

Loaded over real HTTP with a logged-in admin session on **Dolibarr 18.0.10 and 24.0.0** (the floor and the current stable):

| | 18.0.10 | 24.0.0 |
|---|---|---|
| `setup_devtools.php` | 200, no PHP error, both options rendered | same |
| `setup_options.php` | 200, no trace of the two keys left | same |
| toggling an option | constant written in `llx_const` | same |
| page reloaded | the switch reads back as enabled | same |
