### PR TITLE
FIX [einvoicing] Say the CDAR temporary directory cannot be written, not that the file is missing

### DIFF
--- a/einvoicing/class/utils/CdarHandler.class.php
+++ b/einvoicing/class/utils/CdarHandler.class.php
@@ -35,6 +35,11 @@ class CdarHandler
 	 */
 	public $db;
 
+	/**
+	 * @var string Reason of the last failure, when a method returns false or a negative result.
+	 */
+	public $error = '';
+
 	// ==================== CONSTANTS ====================
 
 	// DateTime Formats
@@ -212,11 +217,21 @@ class CdarHandler
 	 */
 	public function saveToFile($data, $filename)
 	{
+		$this->error = '';
+
 		$xmlContent = $this->generate($data);
 		if ($xmlContent === false) {
+			$this->error = 'Failed to build the CDAR XML content';
 			return false;
-		} else {
-			file_put_contents($filename, $xmlContent);
+		}
+
+		// Report the write that did not happen, and the one that stopped halfway on a full disk. Without
+		// this, the file is simply missing or truncated further down the road, and the caller can only
+		// say the file does not exist, which points at the wrong cause.
+		$written = file_put_contents($filename, $xmlContent);
+		if ($written === false || $written < strlen($xmlContent)) {
+			$this->error = 'Failed to write the CDAR file ' . $filename;
+			return false;
 		}
 
 		return true;
@@ -493,6 +508,15 @@ class CdarHandler
 		$tempDir = $conf->einvoicing->dir_temp;
 		if (!dol_is_dir($tempDir)) {
 			dol_mkdir($tempDir);
+			if (!dol_is_dir($tempDir)) {
+				return array('res' => -1, 'message' => 'The temporary directory of the module cannot be created: ' . $tempDir);
+			}
+		}
+		// A directory the web server may enter but not write into is a plausible state (it happens when a
+		// command line script running as another user creates it first). Name it here, where the cause is
+		// still visible, rather than let the write fail silently.
+		if (!is_writable($tempDir)) {
+			return array('res' => -1, 'message' => 'The temporary directory of the module is not writable by the web server: ' . $tempDir);
 		}
 
 		// Unique per-call name so two concurrent status sends of the same condition cannot collide (#226).
@@ -501,7 +525,7 @@ class CdarHandler
 
 		$result = $this->saveToFile($data, $filename);
 		if ($result === false) {
-			return array('res' => -1, 'message' => 'Error saving CDAR file');
+			return array('res' => -1, 'message' => $this->error !== '' ? $this->error : 'Error saving CDAR file');
 		}
 		//echo "CDAR file generated: " . $filename;
 


### PR DESCRIPTION
### The problem

Entering a payment on a customer invoice fails with:

```
EInvoicing : CDAR file does not exist: /var/www/<instance>/documents/einvoicing/temp/cdar_<status>_<hex>.xml
```

The message points at a missing file. The real cause is a directory the web server may enter but
not write into — `einvoicing/temp` owned by another user, mode `0771`, so `www-data` falls into
"other" and gets `--x`. Every status message (CDAR) sent from the web then fails, and nothing in
the message says so.

That state is easy to reach: a command line maintenance script run as `root` creates the
temporary directory first, and it stays `root`-owned for good. Seen on a production instance,
where two sibling instances on the same server were fine and only the one whose directory had
been created from a shell was broken.

### Why the message was wrong

`CdarHandler::saveToFile()` dropped the return value of `file_put_contents()`:

```php
$xmlContent = $this->generate($data);
if ($xmlContent === false) {
    return false;
} else {
    file_put_contents($filename, $xmlContent);   // result never looked at
}
return true;
```

So `generateCdarFile()` answered `res = 1`, `CDAR file generated successfully`, and handed back
the path of a file it had not written. Two frames later the provider found no file and produced
the "does not exist" message. The failure was reported one step too late, by the piece of code
that had the least idea why.

### The change

- `generateCdarFile()` checks the temporary directory: it fails if `dol_mkdir()` could not create
  it, and fails naming the directory if the web server cannot write into it.
- `saveToFile()` checks the write itself and records the reason in `$this->error`: a refused
  write, and a write that stopped halfway (a full disk makes `file_put_contents()` return fewer
  bytes than it was given, which would otherwise ship a truncated CDAR).
- `generateCdarFile()` passes that reason up instead of the flat `Error saving CDAR file`.

The callers already prefix `Failed to generate CDAR file:`, so the message now reads as the cause.

### Measured

Dolibarr 23, module temporary directory owned by `root` mode `0771`, PHP running as `www-data`,
same invoice and same status (212) in all four runs:

| handler | temporary directory | res | message | file written |
|---|---|---|---|---|
| before | not writable | `1` | `CDAR file generated successfully` | **no** |
| after | not writable | `-1` | `The temporary directory of the module is not writable by the web server: …` | no |
| before | normal | `1` | `CDAR file generated successfully` | yes |
| after | normal | `1` | `CDAR file generated successfully` | yes |

No behaviour changes when the directory is writable, which is the only path the tests and the
end to end cycle exercise.
