### PR TITLE
FIX: 500 error on first synchronization (epoch date sent to API)

### DIFF
--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -796,7 +796,8 @@ abstract class AbstractPDPProvider
 	/**
 	 * Get the last synchronization date with the PDP provider.
 	 * Retrieves the timestamp of the most recent successful flow synchronization
-	 * for this provider. If no sync has occurred yet, returns 0.
+	 * for this provider. If no sync has occurred yet, falls back to the module
+	 * commissioning date (see getFirstUseDate()).
 	 * Optionally applies a margin in hours to the returned timestamp.
 	 *
 	 * @param 	int 		$marginHours 	Optional time margin in hours to go back from the current date of the last synchronization
@@ -837,8 +838,9 @@ abstract class AbstractPDPProvider
 			dol_syslog(__METHOD__ . " SQL warning: Failed to get last sync date: we try to sync all flows from today", LOG_WARNING);
 		}
 
+		// No sync history yet — use the commissioning date so we never call the API with epoch (1970).
 		if ($LastSyncDate === null) {
-			$LastSyncDate = 0;
+			$LastSyncDate = $this->getFirstUseDate();
 		}
 
 		// Apply margin in hours
@@ -847,6 +849,65 @@ abstract class AbstractPDPProvider
 		}
 
 		return $LastSyncDate;
+	}
+
+	/**
+	 * Return a safe start date for the very first synchronization (no history in DB).
+	 *
+	 * Cascade:
+	 *  1. Date the PDP provider was configured (tms of EINVOICING_PDP in llx_const).
+	 *  2. Date the module was activated (tms of MAIN_MODULE_EINVOICING in llx_const).
+	 *  3. French e-invoicing legal mandate date: 2026-09-01.
+	 *
+	 * This prevents passing epoch (1970-01-01) to the PDP API, which most providers reject.
+	 *
+	 * @return int Unix timestamp
+	 */
+	protected function getFirstUseDate()
+	{
+		global $conf, $db;
+
+		// 1. Date the PDP provider was configured
+		$constNames = array('EINVOICING_PDP');
+		foreach ($constNames as $constName) {
+			$sql = "SELECT tms FROM ".MAIN_DB_PREFIX."const";
+			$sql .= " WHERE name = '".$db->escape($constName)."'";
+			$sql .= " AND entity IN (0, ".((int) $conf->entity).")";
+			$sql .= " ORDER BY entity DESC LIMIT 1";
+			$resql = $db->query($sql);
+			if ($resql) {
+				$obj = $db->fetch_object($resql);
+				if ($obj && !empty($obj->tms)) {
+					$ts = strtotime($obj->tms);
+					if ($ts > 0) {
+						dol_syslog(__METHOD__." First sync: using PDP configuration date ".dol_print_date($ts, 'standard'), LOG_DEBUG, 0, "_einvoicing");
+						return $ts;
+					}
+				}
+			}
+		}
+
+		// 2. Date the module was activated
+		$sql = "SELECT tms FROM ".MAIN_DB_PREFIX."const";
+		$sql .= " WHERE name = 'MAIN_MODULE_EINVOICING'";
+		$sql .= " AND entity IN (0, ".((int) $conf->entity).")";
+		$sql .= " ORDER BY entity DESC LIMIT 1";
+		$resql = $db->query($sql);
+		if ($resql) {
+			$obj = $db->fetch_object($resql);
+			if ($obj && !empty($obj->tms)) {
+				$ts = strtotime($obj->tms);
+				if ($ts > 0) {
+					dol_syslog(__METHOD__." First sync: using module activation date ".dol_print_date($ts, 'standard'), LOG_DEBUG, 0, "_einvoicing");
+					return $ts;
+				}
+			}
+		}
+
+		// 3. French e-invoicing legal mandate date
+		$fallback = (int) strtotime('2026-09-01 00:00:00');
+		dol_syslog(__METHOD__." First sync: using legal mandate fallback date 2026-09-01", LOG_DEBUG, 0, "_einvoicing");
+		return $fallback;
 	}
 
 	/**

--- a/einvoicing/document_list.php
+++ b/einvoicing/document_list.php
@@ -853,6 +853,12 @@ if ($provider) {
 		}
 	}
 
+	// First sync (no history in DB) — pre-fill with the commissioning date so the user
+	// is not left with an empty picker that would cause a 500 on submission.
+	if (!$gmtdatetosuggest && isset($provider)) {
+		$gmtdatetosuggest = $provider->getLastSyncDate();
+	}
+
 	//var_dump($last_sync_db, 'last_sync_db gmt = '.dol_print_date($last_sync_db, 'dayhour', 'gmt'));
 	//var_dump($syncfromdate, 'syncfromdate gmt = '.dol_print_date($syncfromdate, 'dayhour', 'gmt'));
 	//var_dump($gmtdatetosuggest, 'gmtdatetosuggest gmt = '.dol_print_date($gmtdatetosuggest, 'dayhour', 'gmt'));
@@ -939,7 +945,7 @@ if ($action == 'sync' && $provider) {
 		$validationFormError++;
 		setEventMessages($langs->trans("InvalidSyncLimit"), array(), 'errors');
 	}
-	if ($syncfromdate === '') {
+	if (!$syncfromdate) {
 		$validationFormError++;
 		setEventMessages($langs->trans("InvalidSyncFromDate"), array(), 'errors');
 	}


### PR DESCRIPTION
## Summary

- Problem: The first synchronization (manual or cron) failed with a 500 error. getLastSyncDate() returned 0 when no sync history existed, causing syncFlows() to call the PDP API with updatedAfter: 1970-01-01T00:00:00.000Z. Most providers reject this date.

- Fix in AbstractPDPProvider: When no history exists in the database, getLastSyncDate() now calls getFirstUseDate(), which returns a meaningful start date through a 3-level cascade: ① date the PDP provider was configured (tms of EINVOICING_PDP in llx_const) → ② date the module was activated (tms of MAIN_MODULE_EINVOICING) → ③ French e-invoicing legal mandate date (2026-09-01). Each step is logged to _einvoicing.

- Fix in document_list.php: Two corrections to the manual sync form: (1) the date picker is now pre-filled via getLastSyncDate() on first sync so the field is never empty, (2) the validation used === '' which did not catch the integer 0 returned by GETPOSTINT — corrected to !$syncfromdate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)