### PR TITLE
FIX #772 [einvoicing] A received line that subtracts from the invoice is no longer dropped

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -1613,14 +1613,22 @@ class CIIProtocol extends AbstractProtocol
 	 *    header, a subtotal. BR-FREXT-CO-10 sums BT-106 over the DETAIL lines only, so such a line carries
 	 *    no amount of its own and importing it as a priced line would count its amount a second time. It
 	 *    becomes a text line. BR-FREXT-BR-22 is also why it may carry no quantity at all.
-	 * 2. A regular item that announces an amount its quantity cannot rebuild, because that quantity is
-	 *    zero or absent. Such a document is not necessarily wrong: BR-22 only tests the presence of
-	 *    ram:BilledQuantity, so a quantity of zero satisfies it, and nothing in EN 16931 requires BT-131 to
-	 *    equal BT-129 times BT-146. The document of issue #726 is exactly that - EXTENDED CTC-FR, a line
-	 *    carrying <BilledQuantity unitCode="C62">0.0000</BilledQuantity>, no BT-X-8, and a BT-131 of 12.00
-	 *    that BR-FREXT-CO-10 does count into BT-106. It is therefore the import that has to cope: quantity
-	 *    times price makes the line zero and changes the total of the invoice without a word, so the amount
-	 *    is carried as a single unit instead, the way it would be keyed in by hand.
+	 * 2. A regular item whose quantity and unit price cannot express the amount it announces at all. Three
+	 *    shapes reach that state, and the repair is the same for the three: carry BT-131 as a single unit,
+	 *    the way it would be keyed in by hand, so the total of the invoice stays the total of the document.
+	 *    a. The invoiced quantity is zero or absent. Such a document is not necessarily wrong: BR-22 only
+	 *       tests the presence of ram:BilledQuantity, so a quantity of zero satisfies it, and nothing in
+	 *       EN 16931 requires BT-131 to equal BT-129 times BT-146. The document of issue #726 is exactly
+	 *       that - EXTENDED CTC-FR, a line carrying <BilledQuantity unitCode="C62">0.0000</BilledQuantity>,
+	 *       no BT-X-8, and a BT-131 of 12.00 that BR-FREXT-CO-10 does count into BT-106.
+	 *    b. The unit price is zero or absent while the line announces an amount. A free item that is then
+	 *       credited is written that way - issue #772, a vendor invoice whose "free" lines each announce a
+	 *       BT-131 of -0.30 over a BT-146 of 0.00. Quantity times price rebuilds 0.00, so every one of
+	 *       those credits used to be dropped and the invoice came out above the document.
+	 *    c. Quantity times price rebuilds the opposite sign of what the line announces. BT-146 is forbidden
+	 *       to be negative by BR-27, so a line that subtracts from the invoice carries its sign on BT-129
+	 *       alone; a document that puts it on BT-131 only would otherwise be imported as a charge, moving
+	 *       the invoice by twice the amount of the line.
 	 * 3. Everything else: check that what the core is about to compute is what the document announces, and
 	 *    say so when it is not. The tolerance is the one BR-FREXT-CO-10 applies to the totals.
 	 *
@@ -1639,14 +1647,28 @@ class CIIProtocol extends AbstractProtocol
 			return array('qty' => 0.0, 'subprice' => 0.0, 'remise_percent' => 0.0, 'warning' => '');
 		}
 
-		if (empty($qty) && !empty($announced)) {
+		$rebuilt = round($qty * $subprice * (1 - ($remisePercent / 100)), 2);
+
+		// The couple (quantity, unit price) cannot carry the announced amount: it rebuilds nothing, or it
+		// rebuilds it upside down. A line announcing nothing is left alone - a free sample or a heading is
+		// not an anomaly.
+		if (!empty($announced) && ($rebuilt == 0.0 || (($rebuilt > 0) !== ($announced > 0)))) {
+			if (empty($qty)) {
+				$reason = 'its invoiced quantity (BT-129) is zero or absent, so quantity times unit price rebuilds 0.00';
+			} elseif (empty($subprice)) {
+				$reason = 'its unit price (BT-146) is zero or absent, so quantity times unit price rebuilds 0.00';
+			} elseif ($rebuilt == 0.0) {
+				$reason = 'its quantity (BT-129), unit price (BT-146) and discount rebuild 0.00';
+			} else {
+				$reason = 'its quantity (BT-129) and unit price (BT-146) rebuild ' . $rebuilt . ', of the opposite sign';
+			}
+
 			$warning = 'Line ' . $lineid . ' of the received document carries a net amount (BT-131) of ' . $announced
-				. ' while its invoiced quantity (BT-129) is zero or absent, so quantity times unit price rebuilds 0.00. It was imported as a single unit at that amount, so the total of the invoice matches the document.';
+				. ' while ' . $reason . '. It was imported as a single unit at that amount, so the total of the invoice matches the document.';
 
 			return array('qty' => 1.0, 'subprice' => $announced, 'remise_percent' => 0.0, 'warning' => $warning);
 		}
 
-		$rebuilt = round($qty * $subprice * (1 - ($remisePercent / 100)), 2);
 		$warning = '';
 		if (abs($rebuilt - $announced) > 0.01) {
 			$warning = 'Line ' . $lineid . ' of the received document announces a net amount (BT-131) of ' . $announced

--- a/einvoicing/test/phpunit/AllTests.php
+++ b/einvoicing/test/phpunit/AllTests.php
@@ -127,6 +127,8 @@ class AllTests
 		$suite->addTestSuite('LineChargeTest');
 		require_once dirname(__FILE__).'/LineWithoutQuantityTest.php';
 		$suite->addTestSuite('LineWithoutQuantityTest');
+		require_once dirname(__FILE__).'/NegativeLineAmountTest.php';
+		$suite->addTestSuite('NegativeLineAmountTest');
 		require_once dirname(__FILE__).'/PDPProviderManagerTest.php';
 		$suite->addTestSuite('PDPProviderManagerTest');
 		require_once dirname(__FILE__).'/RecipientDirectoryTest.php';

--- a/einvoicing/test/phpunit/NegativeLineAmountTest.php
+++ b/einvoicing/test/phpunit/NegativeLineAmountTest.php
@@ -1,0 +1,272 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/NegativeLineAmountTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for a received line that subtracts from the invoice (issue #772).
+ *
+ *                  BR-27 forbids a negative item net price (BT-146), so a line that takes money off
+ *                  the invoice carries its sign somewhere else: on the invoiced quantity (BT-129), or
+ *                  on the net line amount (BT-131) alone. The reported vendor does the latter on a free
+ *                  item: quantity 1, unit price 0.00, a line allowance (BG-27) of 0.30 and a BT-131 of
+ *                  -0.30. Quantity times price rebuilt 0.00, so every one of those credits was silently
+ *                  dropped and the imported invoice came out above the document.
+ *
+ *                  The line reproduced below is the one of the reported document, translated into the
+ *                  CII the platform hands to the module.
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+dol_include_once('einvoicing/class/protocols/CIIProtocol.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class NegativeLineAmountTest extends CommonClassTest
+{
+	/**
+	 * Call CIIProtocol::resolveLineAmounts() through reflection: pure decision logic, no DB access
+	 * and no side effect, the kind of protected method the project convention allows testing this way
+	 * instead of through a full import.
+	 *
+	 * @param	CIIProtocol		$protocol		Protocol instance
+	 * @param	array			$parsedLine		One line as parseInvoiceLines() returns it
+	 * @param	float			$qty			Quantity read from the document
+	 * @param	float			$subprice		Unit price resolved by the caller
+	 * @param	float			$remisePercent	Discount percent resolved by the caller
+	 * @return	array{qty:float,subprice:float,remise_percent:float,warning:string}	What the import would store
+	 */
+	private function callResolveLineAmounts(CIIProtocol $protocol, array $parsedLine, $qty, $subprice, $remisePercent = 0.0)
+	{
+		$method = new ReflectionMethod(CIIProtocol::class, 'resolveLineAmounts');
+		$method->setAccessible(true);
+
+		return $method->invoke($protocol, $parsedLine, $qty, $subprice, $remisePercent);
+	}
+
+	/**
+	 * The reported case (issue #772), on the line of the real document: a free item, priced at 0.00,
+	 * carrying a line allowance and a net line amount that is a credit. Read and resolved the way
+	 * createSupplierInvoiceLinesFromSource() does it, allowance included, because the discount is part
+	 * of what the core rebuilds.
+	 *
+	 * @return	void
+	 */
+	public function testTheReportedCreditLineReachesTheInvoice()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$xml = $this->documentWithLine('
+      <ram:AssociatedDocumentLineDocument><ram:LineID>475726401</ram:LineID></ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct><ram:Name>Free starter account with domain</ram:Name></ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:NetPriceProductTradePrice><ram:ChargeAmount>0.000000</ram:ChargeAmount></ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery><ram:BilledQuantity unitCode="C62">1.0000</ram:BilledQuantity></ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>20.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeAllowanceCharge>
+          <ram:ChargeIndicator><udt:Indicator>false</udt:Indicator></ram:ChargeIndicator>
+          <ram:ActualAmount>0.30</ram:ActualAmount>
+          <ram:Reason>GIFT - SPECIAL</ram:Reason>
+        </ram:SpecifiedTradeAllowanceCharge>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation><ram:LineTotalAmount>-0.30</ram:LineTotalAmount></ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>');
+
+		$lines = $protocol->parseInvoiceLines($xml);
+		$this->assertCount(1, $lines);
+		$this->assertEquals(-0.30, (float) $lines[0]['lineTotalAmount'], 'BT-131 keeps its sign');
+		$this->assertEquals(0.0, (float) $lines[0]['netpriceamount'], 'BT-146 is zero, BR-27 forbidding it to be negative');
+		$this->assertCount(1, $lines[0]['lineAllowances'], 'the line allowance is read');
+
+		// What createSupplierInvoiceLinesFromSource() resolves before it calls resolveLineAmounts():
+		// a discount of -100 percent, over a price the allowance brings back to 0.00.
+		$discount = $this->callResolveLineDiscountPercent($protocol, $lines[0]['lineAllowances'], $lines[0]['lineTotalAmount']);
+		$this->assertNotFalse($discount);
+		$this->assertSame(-100.0, $discount['percent'], 'an allowance over a negative base gives a discount that means nothing');
+
+		$amounts = $this->callResolveLineAmounts(
+			$protocol,
+			$lines[0],
+			(float) $lines[0]['billedquantity'],
+			round($discount['priceWithoutDiscount'] / (float) $lines[0]['billedquantity'], 8),
+			$discount['percent']
+		);
+
+		$this->assertSame(1.0, $amounts['qty'], 'the amount is carried as a single unit');
+		$this->assertSame(-0.30, $amounts['subprice'], 'the credit of the document reaches the invoice');
+		$this->assertSame(0.0, $amounts['remise_percent'], 'and the meaningless discount goes with it');
+		$this->assertStringContainsString('BT-131', $amounts['warning'], 'the repair is reported, not silent');
+		$this->assertStringContainsString('BT-146', $amounts['warning']);
+	}
+
+	/**
+	 * Build a one-line CII document, with the line body given as a string.
+	 *
+	 * @param	string	$lineBody	The children of ram:IncludedSupplyChainTradeLineItem
+	 * @return	string				A parsable CII document
+	 */
+	private function documentWithLine($lineBody)
+	{
+		return '<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+  <rsm:ExchangedDocument><ram:ID>INV-772</ram:ID></rsm:ExchangedDocument>
+  <rsm:SupplyChainTradeTransaction>
+    <ram:IncludedSupplyChainTradeLineItem>' . $lineBody . '</ram:IncludedSupplyChainTradeLineItem>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>';
+	}
+
+	/**
+	 * Call CIIProtocol::resolveLineDiscountPercent() through reflection.
+	 *
+	 * @param	CIIProtocol		$protocol			Protocol instance
+	 * @param	array			$lineAllowances		Allowances as parseInvoiceLines() returns them
+	 * @param	float			$lineTotalAmount	BT-131 of the line
+	 * @return	false|array{percent:float,base:float,discountAmount:float,priceWithoutDiscount:float}	What the caller would apply
+	 */
+	private function callResolveLineDiscountPercent(CIIProtocol $protocol, array $lineAllowances, $lineTotalAmount)
+	{
+		$method = new ReflectionMethod(CIIProtocol::class, 'resolveLineDiscountPercent');
+		$method->setAccessible(true);
+
+		return $method->invoke($protocol, $lineAllowances, $lineTotalAmount);
+	}
+
+	/**
+	 * The same shape with a positive amount: a priced line whose unit price is missing is repaired the
+	 * same way. Nothing about the fix is specific to a credit.
+	 *
+	 * @return	void
+	 */
+	public function testAnAmountWithoutUnitPriceIsCarriedAsOneUnit()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$parsedLine = array('lineid' => '18', 'lineTotalAmount' => 42.0, 'linestatusreasoncode' => 'DETAIL');
+		$amounts = $this->callResolveLineAmounts($protocol, $parsedLine, 3.0, 0.0);
+
+		$this->assertSame(1.0, $amounts['qty']);
+		$this->assertSame(42.0, $amounts['subprice']);
+		$this->assertNotSame('', $amounts['warning']);
+	}
+
+	/**
+	 * The compliant way to write a credit line - a negative quantity over a non-negative unit price,
+	 * which is what BR-27 leaves an issuer - already added up and must stay exactly as it was.
+	 *
+	 * @return	void
+	 */
+	public function testACreditWrittenOnTheQuantityIsUntouched()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$parsedLine = array('lineid' => '19', 'lineTotalAmount' => -0.30, 'linestatusreasoncode' => '');
+		$amounts = $this->callResolveLineAmounts($protocol, $parsedLine, -1.0, 0.30);
+
+		$this->assertSame(-1.0, $amounts['qty'], 'nothing is rewritten, the line already rebuilds its amount');
+		$this->assertSame(0.30, $amounts['subprice']);
+		$this->assertSame('', $amounts['warning']);
+	}
+
+	/**
+	 * A line that announces a credit while its quantity and price rebuild a charge would move the
+	 * invoice by twice its amount. The sign the document gives on BT-131 wins.
+	 *
+	 * @return	void
+	 */
+	public function testASignThatDisagreesWithTheDocumentIsCorrected()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$parsedLine = array('lineid' => '20', 'lineTotalAmount' => -12.50, 'linestatusreasoncode' => 'DETAIL');
+		$amounts = $this->callResolveLineAmounts($protocol, $parsedLine, 1.0, 12.50);
+
+		$this->assertSame(1.0, $amounts['qty']);
+		$this->assertSame(-12.50, $amounts['subprice']);
+		$this->assertStringContainsString('opposite sign', $amounts['warning']);
+	}
+
+	/**
+	 * A whole credit note line - negative on both sides at once - rebuilds a positive amount and the
+	 * document says positive too, so it is left alone.
+	 *
+	 * @return	void
+	 */
+	public function testTwoNegativesThatRebuildAChargeAreUntouched()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$parsedLine = array('lineid' => '21', 'lineTotalAmount' => 30.0, 'linestatusreasoncode' => '');
+		$amounts = $this->callResolveLineAmounts($protocol, $parsedLine, -2.0, -15.0);
+
+		$this->assertSame(-2.0, $amounts['qty']);
+		$this->assertSame(-15.0, $amounts['subprice']);
+		$this->assertSame('', $amounts['warning']);
+	}
+
+	/**
+	 * A free line - zero on both sides - is not an anomaly and must stay silent, credit or not.
+	 *
+	 * @return	void
+	 */
+	public function testAFreeLineStaysSilent()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$parsedLine = array('lineid' => '22', 'lineTotalAmount' => 0.0, 'linestatusreasoncode' => '');
+		$amounts = $this->callResolveLineAmounts($protocol, $parsedLine, 1.0, 0.0);
+
+		$this->assertSame(1.0, $amounts['qty'], 'nothing to repair, the document announces nothing');
+		$this->assertSame(0.0, $amounts['subprice']);
+		$this->assertSame('', $amounts['warning']);
+	}
+}

--- a/einvoicing/test/phpunit/NegativeLineAmountTest.php
+++ b/einvoicing/test/phpunit/NegativeLineAmountTest.php
@@ -117,18 +117,23 @@ class NegativeLineAmountTest extends CommonClassTest
 		$this->assertEquals(0.0, (float) $lines[0]['netpriceamount'], 'BT-146 is zero, BR-27 forbidding it to be negative');
 		$this->assertCount(1, $lines[0]['lineAllowances'], 'the line allowance is read');
 
-		// What createSupplierInvoiceLinesFromSource() resolves before it calls resolveLineAmounts():
-		// a discount of -100 percent, over a price the allowance brings back to 0.00.
+		// What createSupplierInvoiceLinesFromSource() resolves before it calls resolveLineAmounts().
+		// Whatever the allowance resolves to on such a line - today a discount of -100 percent, over an
+		// amount the allowance brings back to 0.00 - the couple it leaves rebuilds nothing, which is the
+		// state this test is about. The two are read the way the caller reads them, no more.
 		$discount = $this->callResolveLineDiscountPercent($protocol, $lines[0]['lineAllowances'], $lines[0]['lineTotalAmount']);
-		$this->assertNotFalse($discount);
-		$this->assertSame(-100.0, $discount['percent'], 'an allowance over a negative base gives a discount that means nothing');
+		$remisePercent = ($discount === false) ? 0.0 : (float) $discount['percent'];
+		$subprice = ($discount === false)
+			? (float) $lines[0]['netpriceamount']
+			: round($discount['priceWithoutDiscount'] / (float) $lines[0]['billedquantity'], 8);
+		$this->assertSame(0.0, round((float) $lines[0]['billedquantity'] * $subprice * (1 - ($remisePercent / 100)), 2), 'quantity, price and discount rebuild nothing');
 
 		$amounts = $this->callResolveLineAmounts(
 			$protocol,
 			$lines[0],
 			(float) $lines[0]['billedquantity'],
-			round($discount['priceWithoutDiscount'] / (float) $lines[0]['billedquantity'], 8),
-			$discount['percent']
+			$subprice,
+			$remisePercent
 		);
 
 		$this->assertSame(1.0, $amounts['qty'], 'the amount is carried as a single unit');


### PR DESCRIPTION
Fixes #772.

## The document

BR-27 forbids a negative item net price (BT-146), so a line that takes money off a received invoice has to carry its sign somewhere else: on the invoiced quantity (BT-129), or on the net line amount (BT-131) alone. The vendor reported on #772 does the latter, on a free item. Taken from the `factur-x.xml` of a real container, not reconstructed:

```xml
<ram:IncludedSupplyChainTradeLineItem>
  <ram:AssociatedDocumentLineDocument><ram:LineID>475726401</ram:LineID></ram:AssociatedDocumentLineDocument>
  <ram:SpecifiedTradeProduct><ram:Name>Free starter account with domain</ram:Name>...</ram:SpecifiedTradeProduct>
  <ram:SpecifiedLineTradeAgreement>
    <ram:NetPriceProductTradePrice><ram:ChargeAmount>0</ram:ChargeAmount></ram:NetPriceProductTradePrice>
  </ram:SpecifiedLineTradeAgreement>
  <ram:SpecifiedLineTradeDelivery><ram:BilledQuantity unitCode="C62">1</ram:BilledQuantity></ram:SpecifiedLineTradeDelivery>
  <ram:SpecifiedLineTradeSettlement>
    ...
    <ram:SpecifiedTradeAllowanceCharge>
      <ram:ChargeIndicator><udt:Indicator>false</udt:Indicator></ram:ChargeIndicator>
      <ram:ActualAmount>0.3</ram:ActualAmount>
      <ram:Reason>GIFT - SPECIAL</ram:Reason>
    </ram:SpecifiedTradeAllowanceCharge>
    <ram:SpecifiedTradeSettlementLineMonetarySummation><ram:LineTotalAmount>-0.3</ram:LineTotalAmount></ram:SpecifiedTradeSettlementLineMonetarySummation>
  </ram:SpecifiedLineTradeSettlement>
</ram:IncludedSupplyChainTradeLineItem>
```

Quantity 1, unit price 0.00, a line allowance of 0.30, BT-131 of -0.30. Nothing in EN 16931 requires BT-131 to equal BT-129 x BT-146, and the header sums add up, so the document is not wrong.

## What the import did with it

`resolveLineAmounts()` does not store BT-131: it hands quantity and unit price to `FactureFournisseur::updateline()` and lets the core recompute the line, so `qty x price` is what the invoice ends up with. Here that gives 0.00 and the credit vanishes, once per such line — six pages of them on the reported invoice.

The repair that already exists for a line whose *quantity* is zero (#726) did not reach this shape: it was guarded by `empty($qty)` alone.

## The change

The repair now covers the three shapes the couple (quantity, unit price) cannot express at all — the rebuild is zero, or it is of the opposite sign — and carries BT-131 as a single unit, discount cleared, the way it would be keyed in by hand.

A line that rebuilds a different but plausible amount keeps the behaviour it has today, warning included. A line at zero on both sides stays silent. The compliant way to write a credit — a negative BT-129 over a non-negative BT-146 — already added up and is untouched.

The import says what it repaired:

> Line 475726401 of the received document carries a net amount (BT-131) of -0.3 while its unit price (BT-146) is zero or absent, so quantity times unit price rebuilds 0.00. It was imported as a single unit at that amount, so the total of the invoice matches the document.

## Measured, on three platforms

Real imports, the module before and after on the same instance and the same document.

**Platform A** — two genuine Factur-X containers from the same vendor, profile `urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended`, imported as delivered. Dolibarr 22.0.5.

| document | announced | before | after |
|---|---|---|---|
| with a credit line, 9 lines | 118.68 HT / 142.42 TTC | 118.98 / 142.78 | **118.68 / 142.42** |
| without one, 4 lines | 16.94 HT / 20.33 TTC | 16.94 / 20.33 | 16.94 / 20.33 |

On the first, the credit line goes from `qty=1 pu=0.00 remise=-100 ht=0.00` to `qty=1 pu=-0.30 remise=0 ht=-0.30`; the eight other lines are byte for byte identical.

Both were run through **`FacturXProtocol`, the PDF entry point** — the container handed to the import as delivered, the module extracting `factur-x.xml` itself — and through `CIIProtocol` on that same XML extracted beforehand. Identical figures on both paths and the same line count (9 and 4), so the container handling is not part of what this PR changes, and the fix is reached by the route a received document actually takes. Each import is deleted between the two runs, so the second one gets the untouched document rather than working around the duplicate check.

**Platform B** — SuperPDP, the one #772 was opened against. @TDS-France pulled the CII of the same vendor invoice out of production and posted the line and the summation on the issue; the invoice was rebuilt from those and imported on **Dolibarr 23.0.2** and 22.0.5.

| | announced | before | after |
|---|---|---|---|
| 2 lines | 15.92 HT / 19.10 TTC | 16.22 / 19.46 | **15.92 / 19.10** |

16.22 / 19.46 is exactly what they observe in production on module 1.1.0, so it is the same defect. That document differs in three ways, none of which change anything: the profile is plain `urn:cen.eu:en16931:2017`; it is serialised **without `rsm:` / `ram:` / `udt:` prefixes**, the default namespace being redeclared on every element; and the gift is also carried as a `DesignatedProductClassification`. The serialisation was checked rather than assumed — a genuine document re-serialised that way imports identically, 142.78 before and 142.42 after — since XPath prefixes bind to namespace URIs, not to the ones a document happens to use.

**Platform C** — the vendor's own UBL, as it reaches a platform before conversion, translated to CII to bench it. Same figures as platform A; comparing the two documents line by line, the nine lines agree on quantity, BT-146, BT-131 and line allowances, zero difference.

`test/phpunit/NegativeLineAmountTest.php` (6 tests) covers it, the first one replaying the real line of the reported document through the whole chain — parse, allowance, amounts — rather than a reconstruction. The module suite, 199 tests, stays green.

