### PR TITLE
FIX [einvoicing] A price stated per N units is not a price per unit

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -1335,7 +1335,7 @@ class CIIProtocol extends AbstractProtocol
 				if ($productId > 0 && $productMatchType != 'defaultrouting' && !empty($parsedLine['prodsellerid'])) {
 					$supplierPriceEntries[] = [
 						'productId' => $productId,
-						'unitPrice' => (float) $parsedLine['netpriceamount'],
+						'unitPrice' => $this->resolveLineUnitPrice($parsedLine),
 						'refFourn'  => (string) $parsedLine['prodsellerid'],
 						'tvaTx'     => (float) ($parsedLine['rateApplicablePercent'] ?? 0),
 					];
@@ -1386,13 +1386,13 @@ class CIIProtocol extends AbstractProtocol
 						$line->subprice = round($discount['priceWithoutDiscount'] / $parsedLine['billedquantity'], 8);
 					} else {
 						// Avoid a fatal DivisionByZeroError on a zero/empty billed quantity (e.g. a free
-						// sample line): keep the discount percent, let subprice fall back to netpriceamount below.
+						// sample line): keep the discount percent, let subprice fall back to the line unit price below.
 						dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource line ' . ($parsedLine['lineid'] ?? '?') . ' has a discount but billedquantity is zero/empty, skipping subprice adjustment', LOG_WARNING);
 					}
 				}
 			}
 			$line->qty = (float) $parsedLine['billedquantity'];
-			$line->subprice = $line->subprice ?? (float) $parsedLine['netpriceamount'];
+			$line->subprice = $line->subprice ?? $this->resolveLineUnitPrice($parsedLine);
 			$line->tva_tx = (float) $parsedLine['rateApplicablePercent'];
 			$line->total_ht = (float) $parsedLine['lineTotalAmount'];
 			$line->total_tva = $parsedLine['calculatedAmount'] ?? 0;
@@ -1602,6 +1602,46 @@ class CIIProtocol extends AbstractProtocol
 	}
 
 	/**
+	 * Unit price a received line must carry in Dolibarr: BT-146 brought back to a single unit.
+	 *
+	 * EN 16931 does not state the price of one item. It states BT-146, the item net price, as the price of
+	 * BT-149 units of that item - the item price base quantity. A price of "2.00 per 100" is
+	 * <ram:ChargeAmount>2.00</ram:ChargeAmount> with <ram:BasisQuantity>100</ram:BasisQuantity>, and the
+	 * net amount the document announces for the line, BT-131, is BT-129 / BT-149 x BT-146. UBL says the
+	 * same thing with cbc:PriceAmount and cbc:BaseQuantity. The pattern is ordinary wherever a rate is
+	 * billed rather than an item: a fuel surcharge per 100, a metered consumption per 100 000.
+	 *
+	 * A Dolibarr line has no such divisor. It holds one price for one unit and lets the core multiply it
+	 * by the quantity, so BT-149 has to be folded into the price at import. It was read by the parser and
+	 * then dropped, which multiplied the line - and the total of the whole invoice - by that base
+	 * quantity: a line priced 0.134195 per 100 000 came in at 9 983 012.03 instead of 99.83
+	 * (issues #777 and #778).
+	 *
+	 * BT-149 is optional and means one when absent; BR-64 requires it to be positive when present, and
+	 * BR-65 requires its unit code (BT-150) to be the invoiced quantity unit code (BT-130), so there is no
+	 * unit conversion to make here. Anything else - absent, zero, negative, unreadable - is taken as one,
+	 * which leaves the line exactly as the import built it before.
+	 *
+	 * The division is handed to the core unrounded on purpose: calcul_price_total() computes the total of
+	 * the line from the unit price it receives and only rounds the copy it stores as pu_ht, so a price
+	 * below the display precision still totals what the document announces.
+	 *
+	 * @param	array<string,mixed>		$parsedLine		One line as parseInvoiceLines() returns it
+	 * @return	float									Price of a single unit, to hand to updateline()
+	 */
+	public function resolveLineUnitPrice(array $parsedLine)
+	{
+		$netPrice = (float) ($parsedLine['netpriceamount'] ?? 0);
+		$baseQuantity = (float) ($parsedLine['netpricebasisquantity'] ?? 0);
+
+		if ($baseQuantity <= 0 || $baseQuantity == 1.0) {
+			return $netPrice;
+		}
+
+		return $netPrice / $baseQuantity;
+	}
+
+	/**
 	 * Decide the quantity, unit price and discount a received line must carry in Dolibarr.
 	 *
 	 * The line is written by createSupplierInvoiceLinesIntoDatabase(), which hands those three to
@@ -1630,7 +1670,9 @@ class CIIProtocol extends AbstractProtocol
 	 *       alone; a document that puts it on BT-131 only would otherwise be imported as a charge, moving
 	 *       the invoice by twice the amount of the line.
 	 * 3. Everything else: check that what the core is about to compute is what the document announces, and
-	 *    say so when it is not. The tolerance is the one BR-FREXT-CO-10 applies to the totals.
+	 *    say so when it is not. The tolerance is the one BR-FREXT-CO-10 applies to the totals. A line that
+	 *    does rebuild its amount can still hold a unit price too small for the core to store - see the
+	 *    branch below - and that is reported too.
 	 *
 	 * @param	array<string,mixed>		$parsedLine			One line as parseInvoiceLines() returns it
 	 * @param	float					$qty				Quantity read from the document (BT-129)
@@ -1673,6 +1715,21 @@ class CIIProtocol extends AbstractProtocol
 		if (abs($rebuilt - $announced) > 0.01) {
 			$warning = 'Line ' . $lineid . ' of the received document announces a net amount (BT-131) of ' . $announced
 				. ', but its quantity and unit price rebuild ' . $rebuilt . '. The invoice carries the rebuilt amount.';
+		} elseif ($subprice != 0.0 && (float) price2num($subprice, 'MU') == 0.0) {
+			// calcul_price_total() totals the line from the unit price it is handed and rounds only the copy
+			// it stores as pu_ht, to MAIN_MAX_DECIMALS_UNIT. A price of one unit below that precision -
+			// which is what a price stated per 100 000 comes down to (issue #777) - therefore totals exactly
+			// what the document announces and still reaches the line as 0.00000. The line as imported is
+			// right; it is opening and saving it again that would recompute it to zero, so say so here
+			// rather than let it be found out later.
+			// A price that small is a float PHP writes as 1.34195E-6, which reads as a typo in a message:
+			// spell it out in full, without the trailing zeros of a fixed number of decimals.
+			$spelled = rtrim(rtrim(number_format($subprice, 12, '.', ''), '0'), '.');
+
+			$warning = 'Line ' . $lineid . ' of the received document prices a single unit at ' . $spelled
+				. ', below the unit price precision of this Dolibarr (MAIN_MAX_DECIMALS_UNIT = '
+				. getDolGlobalInt('MAIN_MAX_DECIMALS_UNIT') . '). Its net amount (BT-131) of ' . $announced
+				. ' is imported as announced, but the unit price is stored as zero: editing that line would recompute it to 0.00.';
 		}
 
 		return array('qty' => $qty, 'subprice' => $subprice, 'remise_percent' => $remisePercent, 'warning' => $warning);

--- a/einvoicing/product_mapping.php
+++ b/einvoicing/product_mapping.php
@@ -83,6 +83,27 @@ include_once __DIR__.'/class/document.class.php';
 // Load translation files required by the page
 $langs->loadLangs(array("einvoicing@einvoicing", "products", "companies", "bills", "other"));
 
+
+/**
+ * Price of a single unit of a parsed line, the one this page shows and stores as a buying price.
+ *
+ * EN 16931 states BT-146 as the price of BT-149 units, so a line priced "2.00 per 100" carries a
+ * ChargeAmount of 2.00 - which is not the price of one unit and must not be recorded as one
+ * (issues #777 and #778). The protocol owns that arithmetic; this page only asks it.
+ *
+ * @param	object|null				$protocol	Protocol that parsed the flow, when it knows how to answer
+ * @param	array<string,mixed>		$parsedLine	One line as parseInvoiceLines() returns it
+ * @return	float								Price of a single unit, without tax
+ */
+function einvoicingLineUnitPrice($protocol, array $parsedLine)
+{
+	if (is_object($protocol) && method_exists($protocol, 'resolveLineUnitPrice')) {
+		return (float) $protocol->resolveLineUnitPrice($parsedLine);
+	}
+
+	return (float) ($parsedLine['netpriceamount'] ?? 0);
+}
+
 // Get parameters
 $action = GETPOST('action', 'aZ09');
 $flowid = GETPOST('flowid', 'alphanohtml');
@@ -191,7 +212,7 @@ if ($action == 'savemapping' && $permissiontoadd && !empty($parsedLines) && $soc
 			$productFourn->id = $idprod;
 			$resultbuyprice = $productFourn->update_buyprice(
 				1,															// qty min
-				(float) ($parsedLine['netpriceamount'] ?? 0),				// unit price without tax
+				einvoicingLineUnitPrice($protocol, $parsedLine),			// unit price without tax, BT-146 brought back to one unit
 				$user,
 				'HT',
 				$supplier,
@@ -316,7 +337,7 @@ if (!empty($parsedLines)) {
 		print '<td>'.dol_escape_htmltag((string) ($parsedLine['prodglobalid'] ?? '')).'</td>';
 		print '<td>'.dol_escape_htmltag(dol_trunc((string) ($parsedLine['prodname'] ?? ''), 60)).'</td>';
 		print '<td class="right">'.dol_escape_htmltag((string) ($parsedLine['billedquantity'] ?? '')).' '.dol_escape_htmltag((string) ($parsedLine['billedquantityunitcode'] ?? '')).'</td>';
-		print '<td class="right">'.price((float) ($parsedLine['netpriceamount'] ?? 0)).'</td>';
+		print '<td class="right">'.price(einvoicingLineUnitPrice($protocol, $parsedLine)).'</td>';
 		print '<td class="right">'.price((float) ($parsedLine['rateApplicablePercent'] ?? 0)).'%</td>';
 
 		print '<td>';

--- a/einvoicing/test/phpunit/AllTests.php
+++ b/einvoicing/test/phpunit/AllTests.php
@@ -125,6 +125,8 @@ class AllTests
 		$suite->addTestSuite('InvoicingPeriodTest');
 		require_once dirname(__FILE__).'/LineChargeTest.php';
 		$suite->addTestSuite('LineChargeTest');
+		require_once dirname(__FILE__).'/LinePriceBaseQuantityTest.php';
+		$suite->addTestSuite('LinePriceBaseQuantityTest');
 		require_once dirname(__FILE__).'/LineWithoutQuantityTest.php';
 		$suite->addTestSuite('LineWithoutQuantityTest');
 		require_once dirname(__FILE__).'/NegativeLineAmountTest.php';

--- a/einvoicing/test/phpunit/LinePriceBaseQuantityTest.php
+++ b/einvoicing/test/phpunit/LinePriceBaseQuantityTest.php
@@ -1,0 +1,254 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/LinePriceBaseQuantityTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for a received line priced "per N units" (issues #777 and #778).
+ *
+ *                  EN 16931 gives BT-146, the item net price, as the price of BT-149 units of the
+ *                  item - ram:BasisQuantity in CII, cbc:BaseQuantity in UBL. A Dolibarr line has no
+ *                  such divisor, so BT-149 has to be folded into the unit price at import. It used
+ *                  to be read and dropped, which multiplied the line, and the total of the invoice,
+ *                  by that base quantity.
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+dol_include_once('einvoicing/class/protocols/CIIProtocol.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class LinePriceBaseQuantityTest extends CommonClassTest
+{
+	/**
+	 * Build a one-line CII document, with the line body given as a string.
+	 *
+	 * @param	string	$lineBody	The children of ram:IncludedSupplyChainTradeLineItem
+	 * @return	string				A parsable CII document
+	 */
+	private function documentWithLine($lineBody)
+	{
+		return '<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+  <rsm:ExchangedDocument><ram:ID>INV-778</ram:ID></rsm:ExchangedDocument>
+  <rsm:SupplyChainTradeTransaction>
+    <ram:IncludedSupplyChainTradeLineItem>' . $lineBody . '</ram:IncludedSupplyChainTradeLineItem>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>';
+	}
+
+	/**
+	 * Call CIIProtocol::resolveLineUnitPrice() through reflection: pure decision logic, no DB access
+	 * and no side effect, the kind of protected method the project convention allows testing this way
+	 * instead of through a full import.
+	 *
+	 * @param	array	$parsedLine		One line as parseInvoiceLines() returns it
+	 * @return	float					The unit price the import would store
+	 */
+	private function unitPrice(array $parsedLine)
+	{
+		global $db;
+
+		$method = new ReflectionMethod(CIIProtocol::class, 'resolveLineUnitPrice');
+		$method->setAccessible(true);
+
+		return $method->invoke(new CIIProtocol($db), $parsedLine);
+	}
+
+	/**
+	 * Call CIIProtocol::resolveLineAmounts() through reflection, the same way LineWithoutQuantityTest
+	 * does: it is what tells whether the line the import is about to write rebuilds BT-131.
+	 *
+	 * @param	array	$parsedLine		One line as parseInvoiceLines() returns it
+	 * @param	float	$qty			Quantity read from the document
+	 * @param	float	$subprice		Unit price resolved by the caller
+	 * @param	float	$remisePercent	Discount percent resolved by the caller
+	 * @return	array{qty:float,subprice:float,remise_percent:float,warning:string}	What the import would store
+	 */
+	private function amounts(array $parsedLine, $qty, $subprice, $remisePercent = 0.0)
+	{
+		global $db;
+
+		$method = new ReflectionMethod(CIIProtocol::class, 'resolveLineAmounts');
+		$method->setAccessible(true);
+
+		return $method->invoke(new CIIProtocol($db), $parsedLine, $qty, $subprice, $remisePercent);
+	}
+
+	/**
+	 * BT-149 reaches the parsed line, with its unit code (BT-150).
+	 *
+	 * @return	void
+	 */
+	public function testTheBaseQuantityIsReadFromTheDocument()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$xml = $this->documentWithLine('
+      <ram:AssociatedDocumentLineDocument><ram:LineID>1</ram:LineID></ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct><ram:Name>SURCHARGE</ram:Name></ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>2.000000</ram:ChargeAmount>
+          <ram:BasisQuantity unitCode="C62">100.0000</ram:BasisQuantity>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery><ram:BilledQuantity unitCode="C62">50.0000</ram:BilledQuantity></ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation><ram:LineTotalAmount>1.00</ram:LineTotalAmount></ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>');
+
+		$lines = $protocol->parseInvoiceLines($xml);
+		$this->assertCount(1, $lines);
+		$this->assertEquals(2.0, (float) $lines[0]['netpriceamount'], 'BT-146');
+		$this->assertEquals(100.0, (float) $lines[0]['netpricebasisquantity'], 'BT-149');
+		$this->assertSame('C62', $lines[0]['netpricebasisquantityunitcode'], 'BT-150');
+	}
+
+	/**
+	 * The reported case of issue #778: 2.00 per 100 units, billed on 50. Quantity times the price the
+	 * document states rebuilds 100.00; quantity times the price of a single unit rebuilds the 1.00 the
+	 * document announces as BT-131.
+	 *
+	 * @return	void
+	 */
+	public function testAPricePerHundredIsBroughtBackToOneUnit()
+	{
+		$parsedLine = array(
+			'lineid' => '1',
+			'netpriceamount' => 2.0,
+			'netpricebasisquantity' => 100.0,
+			'billedquantity' => 50.0,
+			'lineTotalAmount' => 1.0,
+		);
+
+		$this->assertEqualsWithDelta(0.02, $this->unitPrice($parsedLine), 0.0000001, 'BT-146 divided by BT-149');
+
+		$amounts = $this->amounts($parsedLine, 50.0, $this->unitPrice($parsedLine));
+		$this->assertSame('', $amounts['warning'], 'the line rebuilds the net amount the document announces');
+		$this->assertEquals(1.0, round($amounts['qty'] * $amounts['subprice'], 2), 'BT-131 is 1.00, not 100.00');
+	}
+
+	/**
+	 * The reported case of issue #777: a metered consumption priced per 100 000. The unit price is far
+	 * below the precision the core stores a unit price with, and the total still has to come out right -
+	 * calcul_price_total() computes the total of the line from the price it is handed, and only rounds
+	 * the copy it stores as pu_ht.
+	 *
+	 * @return	void
+	 */
+	public function testAPricePerHundredThousandRebuildsTheAnnouncedAmount()
+	{
+		$parsedLine = array(
+			'lineid' => '2',
+			'netpriceamount' => 0.134195,
+			'netpricebasisquantity' => 100000.0,
+			'billedquantity' => 74391833.0,
+			'lineTotalAmount' => 99.83,
+		);
+
+		$amounts = $this->amounts($parsedLine, 74391833.0, $this->unitPrice($parsedLine));
+		$this->assertEquals(99.83, round($amounts['qty'] * $amounts['subprice'], 2), 'not 9 983 012.03');
+		$this->assertStringNotContainsString('rebuild', $amounts['warning'], 'the amount the document announces is reached');
+	}
+
+	/**
+	 * A unit price the core cannot store is reported. 99.83 spread over 74 391 833 units is 0.00000134,
+	 * which price2num(..., 'MU') turns into zero: the line totals what the document announces, because
+	 * the core totals it from the unrounded price, but its stored unit price is 0.00000 and editing the
+	 * line would recompute it to zero. That has to be said, not left to be found out.
+	 *
+	 * @return	void
+	 */
+	public function testAUnitPriceBelowTheStoredPrecisionIsReported()
+	{
+		$parsedLine = array(
+			'lineid' => '2',
+			'netpriceamount' => 0.134195,
+			'netpricebasisquantity' => 100000.0,
+			'billedquantity' => 74391833.0,
+			'lineTotalAmount' => 99.83,
+		);
+
+		$amounts = $this->amounts($parsedLine, 74391833.0, $this->unitPrice($parsedLine));
+		$this->assertStringContainsString('MAIN_MAX_DECIMALS_UNIT', $amounts['warning'], 'the import says why');
+		$this->assertStringContainsString('BT-131', $amounts['warning']);
+
+		// A price the core can store says nothing: the tolerable rounding of a unit price is ordinary.
+		$ordinary = array('lineid' => '1', 'lineTotalAmount' => 2.08);
+		$this->assertSame('', $this->amounts($ordinary, 744.0, 0.002796)['warning'], 'nothing to report on a storable price');
+	}
+
+	/**
+	 * Every other shape of BT-149 leaves the price alone. It is optional and means one when absent;
+	 * BR-64 requires it to be positive when it is there, so a zero or a negative one is a broken
+	 * document and the price it states is the best the import can do with it.
+	 *
+	 * @return	void
+	 */
+	public function testAnAbsentOrUnusableBaseQuantityLeavesThePriceAlone()
+	{
+		$this->assertEquals(12.5, $this->unitPrice(array('netpriceamount' => 12.5)), 'BT-149 absent');
+		$this->assertEquals(12.5, $this->unitPrice(array('netpriceamount' => 12.5, 'netpricebasisquantity' => null)));
+		$this->assertEquals(12.5, $this->unitPrice(array('netpriceamount' => 12.5, 'netpricebasisquantity' => 1.0)), 'BT-149 of one is the default');
+		$this->assertEquals(12.5, $this->unitPrice(array('netpriceamount' => 12.5, 'netpricebasisquantity' => 0.0)), 'BR-64 refuses a zero, it is not a divisor');
+		$this->assertEquals(12.5, $this->unitPrice(array('netpriceamount' => 12.5, 'netpricebasisquantity' => -10.0)), 'BR-64 refuses a negative one too');
+	}
+
+	/**
+	 * A fractional base quantity is legal - BR-64 only asks for a positive number - and divides the
+	 * same way, raising the unit price instead of lowering it.
+	 *
+	 * @return	void
+	 */
+	public function testAFractionalBaseQuantityDividesTheSameWay()
+	{
+		$parsedLine = array(
+			'lineid' => '3',
+			'netpriceamount' => 3.0,
+			'netpricebasisquantity' => 0.5,
+			'billedquantity' => 4.0,
+			'lineTotalAmount' => 24.0,
+		);
+
+		$this->assertEquals(6.0, $this->unitPrice($parsedLine));
+
+		$amounts = $this->amounts($parsedLine, 4.0, $this->unitPrice($parsedLine));
+		$this->assertSame('', $amounts['warning']);
+		$this->assertEquals(24.0, round($amounts['qty'] * $amounts['subprice'], 2));
+	}
+}


### PR DESCRIPTION
Fixes #777
Fixes #778

## What the two issues have in common

EN 16931 does not give the price of one item. It gives **BT-146**, the item net price, as the price of **BT-149** units of it — `ram:BasisQuantity` in CII, `cbc:BaseQuantity` in UBL. A carrier billing a fuel surcharge *2.00 per 100*, or a hoster billing a metered consumption per 100 000, states BT-146 = 2.00 and BT-149 = 100, and the net amount of the line, BT-131, is `BT-129 / BT-149 × BT-146`.

A Dolibarr line has no such divisor: it holds one price for one unit and lets the core multiply by the quantity. The parser read BT-149 (`netpricebasisquantity`) and the import then dropped it, so every such line — and the total of the invoice — came in multiplied by that base quantity.

#778 reports it on a surcharge per 100. #777 is the same defect on a consumption invoice priced per 100 000: `0.134195 × 74 391 833` was imported as **9 983 012.03** where the document announces **99.83**, and the invoice totalled **11 979 734.44** instead of **121.00**. The two reports are one bug; the CII import is the only import path the module has today (`ProtocolManager::getProtocol()` still returns null for UBL), and SuperPDP hands the module the *Converted* CII document, which is why a UBL original lands here.

## What changes

- `CIIProtocol::resolveLineUnitPrice()` — one place that brings BT-146 back to a single unit. BT-149 is left alone when it is absent, one, or a value BR-64 refuses (zero, negative): those import exactly as before. BR-65 requires BT-150 to be BT-130, so there is no unit conversion to make.
- The three callers use it: the invoice line, the vendor buying price the import records, and the same buying price on the product mapping page (which also displayed the undivided price in its *U.P. (net)* column).
- The division is handed to the core **unrounded** on purpose: `calcul_price_total()` totals the line from the price it receives and rounds only the copy it stores as `pu_ht`, to `MAIN_MAX_DECIMALS_UNIT`. A price per 100 000 therefore totals what the document announces even though a single unit of it is below what a Dolibarr line can store — and `resolveLineAmounts()` now reports that case, because the line is right as imported but opening and saving it again would recompute it to zero.
- New `LinePriceBaseQuantityTest`, added to `AllTests`.

## Tested

Import of a two-line document — 2.00 per 100 billed on 50 units, and the reported 0.134195 per 100 000 billed on 74 391 833 units — on **18.0.10**, **23.0.4** and **24**, each on its own instance and database:

| | line 1 | line 2 | invoice total HT |
|---|---|---|---|
| before | 100.00 | 9 983 012.03 | 9 983 112.03 |
| after | 1.00 | 99.83 | 100.83 (VAT 20.17, TTC 121.00) |

The document announces 1.00, 99.83 and 100.83.

Product mapping page driven over HTTP on the same document, logged in as a real user: the vendor buying price is stored as **0.02** where it was stored as **2.00**, and the *U.P. (net)* column shows the price of one unit.

`AllTests` green (199 tests, 1094 assertions), phpcs clean on the changed files.
