### PR TITLE
FIX [einvoicing] Fatal error getCountry() undefined when auto-creating thirdparty in cron context

### DIFF
--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -493,6 +493,7 @@ trait CommonProtocol
 		 */
 		global $db, $langs, $user, $conf;
 		require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
+		require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php'; // needed for getCountry() when running in cron context
 
 		$thirdparty = new Societe($db);
 		$einvoicing = new EInvoicing($db);


### PR DESCRIPTION
## Root cause
When the cron job runs Document::cronSyncFlows() and encounters an unknown supplier with EINVOICING_THIRDPARTIES_AUTO_GENERATION enabled, it calls Societe->create(), which internally calls getCountry() (defined in core/lib/company.lib.php).

In a web context, this library is always loaded — every view file in the einvoicing module includes it explicitly (document_list.php:76, call_list.php:74, etc.).

In a cron context, no view file is loaded. company.lib.php is never included, and getCountry() is undefined → PHP Fatal Error → HTTP 500.

## Evidence
Apache error log (client server, Sept. 4):

```
[proxy_fcgi:error] AH01071: Got error 'PHP Fatal error: Uncaught Error:
Call to undefined function getCountry()
in societe/class/societe.class.php:1014
#0 CommonProtocol->_syncOrCreateThirdpartyFromEInvoiceSeller()
#1 FacturXProtocol->doCreateSupplierInvoiceFromSource()
#2 CIIProtocol.class.php(699)'
referer: cron/list.php?id=13&action=execute
```

The referer confirms this happened during a cron execution, not a manual sync from document_list.php.

The subsequent manual sync from document_list.php succeeded: the Dolibarr einvoicing log shows `syncFlows terminée avec succès `and the third-party (LA POSTE) was created. The same flow was then flagged as "already processed" on the next run.

## Fix
One line added in `_syncOrCreateThirdpartyFromEInvoiceSeller()`, alongside the existing `require_once` for `societe.class.php`:

```
require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php'; // needed for getCountry() in cron context
```
`require_once` is safe in web context where the file is already loaded.

## Scope
Affects only installations with EINVOICING_THIRDPARTIES_AUTO_GENERATION enabled and at least one incoming invoice from an unknown supplier. The error is transient: the flow is retried on the next sync and succeeds once the third-party exists (or in web context where the lib is loaded).