### PR TITLE
FIX #781 [einvoicing] A received invoice is recorded at the totals its document announces

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -1149,6 +1149,10 @@ class CIIProtocol extends AbstractProtocol
 				}
 			}
 
+			// Every line of the invoice exists now, so its totals can be confronted with the ones the
+			// document announces (issue #781).
+			$this->alignInvoiceTotalsWithDocument($supplierInvoiceId, $parsedHeader, $return_messages);
+
 			// Create or update supplier prices for imported products
 			if (!empty($supplierPriceEntries)) {
 				require_once DOL_DOCUMENT_ROOT . '/fourn/class/fournisseur.product.class.php';
@@ -3508,6 +3512,114 @@ class CIIProtocol extends AbstractProtocol
 			'discountAmount'       => $totalDiscountAmount,
 			'priceWithoutDiscount' => (float) $lineTotalAmount - $totalChargeAmount + $totalDiscountAmount,
 		];
+	}
+
+
+	/**
+	 * Record an imported invoice at the totals its document announces, whatever the VAT calculation
+	 * mode of the instance.
+	 *
+	 * Dolibarr computes the VAT of an invoice in one of two conventions, chosen once for the whole
+	 * instance: "total of round" - round the VAT of every line, then add them up - which is what
+	 * update_price() applies when nothing is set, or "round of total" - add the line amounts up, then
+	 * round the VAT once - selected by MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND_SUPPLIER (the core reads the
+	 * generic MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND before Dolibarr 20). The supplier invoice card offers
+	 * the two as the "ReCalculate Mode1 / Mode2" link, and either is a legitimate way to bill.
+	 *
+	 * A received document leaves nothing to choose: BT-110 and BT-112 are given by the issuer, who
+	 * rounded them the way its own system does. Importing under the convention of the instance
+	 * therefore records an invoice that does not total what the document says - two cents on a real
+	 * 46 line invoice (issue #781), which the module then refuses to validate, telling the operator to
+	 * recalculate in the other mode. This does exactly that, on that one invoice, and leaves the
+	 * setting of the instance alone.
+	 *
+	 * The net amounts are never concerned: the core writes a rounding difference back onto the VAT of a
+	 * line, never onto its net amount, so the line net amounts (BT-131) and their sum (BT-106) are the
+	 * same under both conventions. And when neither of the two reproduces the announced totals the
+	 * difference is a real one rather than a rounding convention: the invoice is left exactly as the
+	 * import built it and nothing is said here, checkDolInvoiceAndEInvoiceConsistency() being what
+	 * reports such a gap.
+	 *
+	 * @param	int					$supplierInvoiceId	Id of the invoice the import has just built
+	 * @param	array<string,mixed>	$parsedHeader		Header data of the received document
+	 * @param	array<int,string>	$return_messages	Messages of the import, completed here
+	 * @return	void
+	 */
+	protected function alignInvoiceTotalsWithDocument($supplierInvoiceId, array $parsedHeader, array &$return_messages)
+	{
+		global $db, $langs;
+
+		if (!isset($parsedHeader['taxTotalAmount']) || !isset($parsedHeader['grandTotalAmount'])) {
+			return;
+		}
+		$announcedTva = abs((float) $parsedHeader['taxTotalAmount']);
+		$announcedTtc = abs((float) $parsedHeader['grandTotalAmount']);
+
+		require_once DOL_DOCUMENT_ROOT . '/fourn/class/fournisseur.facture.class.php';
+
+		$invoice = new FactureFournisseur($db);
+		if ($invoice->fetch($supplierInvoiceId) <= 0) {
+			return;
+		}
+		if (self::totalsAgreeWithDocument($invoice, $announcedTva, $announcedTtc)) {
+			return;
+		}
+
+		$importedTtc = (float) $invoice->total_ttc;
+		$invoice->fetch_thirdparty();
+
+		// Mode 2 first: a document announcing a VAT rounded on its total is the case met in the field.
+		// The mode of the instance has already been applied by the lines, so re-applying it costs one
+		// recomputation and keeps the two conventions treated the same way.
+		foreach (array('1' => 2, '0' => 1) as $roundingmode => $modenumber) {
+			// Same exclspec as the import itself used (FactureFournisseur::updateline calls
+			// update_price(1, 'auto')), so the rounding convention is the only thing that changes here.
+			if ($invoice->update_price(1, (string) $roundingmode, 0, $invoice->thirdparty) <= 0) {
+				dol_syslog(__METHOD__ . ' Failed to recalculate invoice ' . $supplierInvoiceId . ' in VAT mode ' . $modenumber . ': ' . $invoice->error, LOG_WARNING);
+				break;
+			}
+			if ($invoice->fetch($supplierInvoiceId) <= 0) {
+				return;
+			}
+			if (self::totalsAgreeWithDocument($invoice, $announcedTva, $announcedTtc)) {
+				// The import runs from a cron job as well as from a page, so the language file of the
+				// module is not necessarily loaded.
+				$langs->load('einvoicing@einvoicing');
+				// Translate::trans() takes four parameters and no more, its fifth argument being the
+				// maximum size of the result: a fifth value would end up there and break the sprintf.
+				$return_messages[] = $langs->trans(
+					'EInvoiceImportVatModeRealigned',
+					$modenumber,
+					price2num($announcedTva, 'MT'),
+					price2num($announcedTtc, 'MT'),
+					price2num($importedTtc, 'MT')
+				);
+				dol_syslog(__METHOD__ . ' Invoice ' . $supplierInvoiceId . ' recalculated in VAT mode ' . $modenumber . ' to match the totals of the received document', LOG_DEBUG);
+				return;
+			}
+		}
+
+		// Neither convention gives the announced totals: leave the invoice as the import built it.
+		$invoice->update_price(1, 'auto', 0, $invoice->thirdparty);
+	}
+
+	/**
+	 * Tell whether an invoice totals what the received document announces.
+	 *
+	 * Compared on the absolute values: a credit note is stored negative by Dolibarr while BT-110 and
+	 * BT-112 are always announced positive, the document type being what carries the sign (BR-CO-13
+	 * applies to a credit note as it does to an invoice). The tolerance is there for the float
+	 * representation, not for a difference: the document carries its totals to the cent.
+	 *
+	 * @param	FactureFournisseur	$invoice		The invoice, with its totals as stored
+	 * @param	float				$announcedTva	BT-110 of the received document, absolute value
+	 * @param	float				$announcedTtc	BT-112 of the received document, absolute value
+	 * @return	bool								True when both totals are the announced ones
+	 */
+	private static function totalsAgreeWithDocument(FactureFournisseur $invoice, $announcedTva, $announcedTtc)
+	{
+		return abs(abs((float) $invoice->total_tva) - $announcedTva) < 0.005
+			&& abs(abs((float) $invoice->total_ttc) - $announcedTtc) < 0.005;
 	}
 
 

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -933,6 +933,10 @@ class FacturXProtocol extends CIIProtocol
 				}
 			}
 
+			// Every line of the invoice exists now, so its totals can be confronted with the ones the
+			// document announces (issue #781).
+			$this->alignInvoiceTotalsWithDocument($supplierInvoiceId, $parsedHeader, $return_messages);
+
 			// Create or update supplier prices for imported products
 			if (!empty($supplierPriceEntries)) {
 				require_once DOL_DOCUMENT_ROOT . '/fourn/class/fournisseur.product.class.php';

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -398,6 +398,7 @@ SupplierInvoiceComparisonVatBasisDifference=Difference in VAT basis amount %s%% 
 SupplierInvoiceComparisonVatRateDifference=Difference in VAT amount %s%% (e-invoice: %s / Dolibarr invoice: %s)
 SupplierInvoiceComparisonVatRateNotFound=VAT rate of %s%% not found in the Dolibarr invoice
 SupplierInvoiceComparisonSuggestVatCalculationMode=Recalculate the invoice using Mode %s to get VAT amounts corresponding to the e-invoice
+EInvoiceImportVatModeRealigned=The invoice was recalculated using VAT calculation Mode %s to carry the totals of the received document, which announces a total VAT (BT-110) of %s and a total including VAT (BT-112) of %s, where the VAT calculation mode of this instance rebuilt a total of %s including VAT.
 EinvoicingCantDeleteADocumentLinkedToAnExistingSupplierInvoice=The flow %s can't be deleted because it is linked to the Dolibarr supplier invoice n° %s
 EinvoicingCantDeleteAValidatedSupplierInvoice=A supplier invoice created from a received e-invoice can no longer be deleted once it has been validated. Only its draft can, and deleting the draft leaves the received document itself in the flow list.
 EinvoicingFailedToDetachTheFlowOfADeletedSupplierInvoice=Failed to detach the received e-invoice from the supplier invoice %s, so the invoice was not deleted.

--- a/einvoicing/test/phpunit/AllTests.php
+++ b/einvoicing/test/phpunit/AllTests.php
@@ -129,6 +129,8 @@ class AllTests
 		$suite->addTestSuite('LineWithoutQuantityTest');
 		require_once dirname(__FILE__).'/NegativeLineAmountTest.php';
 		$suite->addTestSuite('NegativeLineAmountTest');
+		require_once dirname(__FILE__).'/ImportVatCalculationModeTest.php';
+		$suite->addTestSuite('ImportVatCalculationModeTest');
 		require_once dirname(__FILE__).'/PDPProviderManagerTest.php';
 		$suite->addTestSuite('PDPProviderManagerTest');
 		require_once dirname(__FILE__).'/RecipientDirectoryTest.php';

--- a/einvoicing/test/phpunit/ImportVatCalculationModeTest.php
+++ b/einvoicing/test/phpunit/ImportVatCalculationModeTest.php
@@ -1,0 +1,355 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/ImportVatCalculationModeTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for the VAT calculation mode of a received invoice (issue #781).
+ *
+ *                  Dolibarr computes the VAT of an invoice either by rounding it on every line and
+ *                  adding the results up ("total of round", mode 1, the default), or by adding the
+ *                  line amounts up and rounding the VAT once ("round of total", mode 2). A received
+ *                  document does not leave that open: BT-110 and BT-112 are the ones its issuer
+ *                  computed, so the imported invoice has to carry them whatever the instance is set
+ *                  to.
+ *
+ *                  The three line amounts used below are taken from the reported 46 line document:
+ *                  1.09, 7.79 and 1.59 at 20 %, which round to 0.22 + 1.56 + 0.32 = 2.10 line by
+ *                  line, where the document announces 10.47 x 20 % = 2.09.
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+require_once DOL_DOCUMENT_ROOT . '/fourn/class/fournisseur.facture.class.php';
+dol_include_once('einvoicing/class/protocols/CIIProtocol.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+if (empty($user->id)) {
+	$user->fetch(1);
+	// User::loadRights() only exists from Dolibarr 19 on, older versions name it getrights()
+	if (method_exists($user, 'loadRights')) {
+		$user->loadRights();
+	} else {
+		$user->getrights();
+	}
+}
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class ImportVatCalculationModeTest extends CommonClassTest
+{
+	/**
+	 * The line net amounts of the fixture invoice, at 20 %: 2.10 of VAT line by line, 2.09 on the total.
+	 */
+	const LINE_AMOUNTS = array(1.09, 7.79, 1.59);
+
+	/**
+	 * Ids of the invoices created by the tests, deleted at the end.
+	 *
+	 * @var int[]
+	 */
+	private $createdInvoiceIds = array();
+
+	/**
+	 * The two names the core gives that setting: the _SUPPLIER variant only exists from Dolibarr 20 on,
+	 * before that the generic one drives supplier documents as well.
+	 *
+	 * @var array<string,string|null>
+	 */
+	private $savedConstants = array();
+
+	/**
+	 * Remember the rounding setting of the instance, whichever of the two names carries it.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void
+	{
+		global $conf;
+
+		parent::setUp();
+
+		foreach (array('MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND_SUPPLIER', 'MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND') as $name) {
+			$this->savedConstants[$name] = isset($conf->global->$name) ? $conf->global->$name : null;
+		}
+	}
+
+	/**
+	 * Put the setting back and remove the invoices created by the test.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void
+	{
+		global $conf, $db, $user;
+
+		foreach ($this->savedConstants as $name => $value) {
+			if ($value === null) {
+				unset($conf->global->$name);
+			} else {
+				$conf->global->$name = $value;
+			}
+		}
+		$this->savedConstants = array();
+
+		foreach ($this->createdInvoiceIds as $id) {
+			$invoice = new FactureFournisseur($db);
+			if ($invoice->fetch($id) > 0) {
+				$invoice->delete($user);
+			}
+		}
+		$this->createdInvoiceIds = array();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Set the VAT calculation mode of the instance, under both names so the test says the same thing
+	 * on every supported version.
+	 *
+	 * @param	int		$mode	1 for "total of round", 2 for "round of total"
+	 * @return	void
+	 */
+	private function setInstanceVatMode($mode)
+	{
+		global $conf;
+
+		$value = ($mode == 2 ? '1' : '0');
+		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND_SUPPLIER = $value;
+		$conf->global->MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND = $value;
+	}
+
+	/**
+	 * A draft supplier invoice carrying the three lines of the fixture, built the way the import does:
+	 * addline() ends on update_price(1, 'auto'), so the invoice comes out in the mode of the instance.
+	 *
+	 * @return	FactureFournisseur	The created invoice, freshly fetched
+	 */
+	private function createFixtureInvoice()
+	{
+		global $db, $user;
+
+		$invoice = new FactureFournisseur($db);
+		$invoice->initAsSpecimen();
+		$invoice->lines = array();
+		$invoice->ref_supplier = 'PR781' . strtoupper(bin2hex(random_bytes(5)));
+		// addline() reads $this->special_code, a property the class does not declare on Dolibarr 18
+		$invoice->special_code = 0;
+		$id = $invoice->create($user);
+		$this->assertGreaterThan(0, $id, $invoice->errorsToString());
+		$this->createdInvoiceIds[] = $id;
+
+		foreach (self::LINE_AMOUNTS as $amount) {
+			// The first six arguments of addline() are the same from Dolibarr 18 to 24
+			$res = $invoice->addline('Line of ' . $amount, $amount, 20, 0, 0, 1);
+			$this->assertGreaterThan(0, $res, $invoice->errorsToString());
+		}
+
+		$invoice->fetch($id);
+
+		return $invoice;
+	}
+
+	/**
+	 * Run the realignment on an invoice, as the import does once every line exists.
+	 *
+	 * @param	FactureFournisseur	$invoice		The invoice to confront with the document
+	 * @param	float				$announcedTva	BT-110 of the document
+	 * @param	float				$announcedTtc	BT-112 of the document
+	 * @param	string[]			$messages		Messages of the import, completed by the call
+	 * @return	FactureFournisseur					The invoice, re-read from the database
+	 */
+	private function alignWith(FactureFournisseur $invoice, $announcedTva, $announcedTtc, array &$messages)
+	{
+		global $db;
+
+		$method = new ReflectionMethod(CIIProtocol::class, 'alignInvoiceTotalsWithDocument');
+		$method->setAccessible(true);
+		$method->invokeArgs(
+			new CIIProtocol($db),
+			array($invoice->id, array('taxTotalAmount' => $announcedTva, 'grandTotalAmount' => $announcedTtc), &$messages)
+		);
+
+		$reread = new FactureFournisseur($db);
+		$reread->fetch($invoice->id);
+
+		return $reread;
+	}
+
+	/**
+	 * The reported case: an instance left on mode 1, a document whose VAT was rounded on the total.
+	 * The invoice must end up on the totals of the document, and say so.
+	 *
+	 * @return void
+	 */
+	public function testTheInvoiceCarriesTheTotalsTheDocumentAnnounces()
+	{
+		$this->setInstanceVatMode(1);
+
+		$invoice = $this->createFixtureInvoice();
+		$this->assertEquals(10.47, (float) $invoice->total_ht, 'the net amount is the same under both conventions');
+		$this->assertEquals(2.10, (float) $invoice->total_tva, 'mode 1 rounds the VAT line by line');
+		$this->assertEquals(12.57, (float) $invoice->total_ttc);
+
+		$messages = array();
+		$realigned = $this->alignWith($invoice, 2.09, 12.56, $messages);
+
+		$this->assertEquals(10.47, (float) $realigned->total_ht, 'the net amount is untouched');
+		$this->assertEquals(2.09, (float) $realigned->total_tva, 'the VAT is the one of the document');
+		$this->assertEquals(12.56, (float) $realigned->total_ttc);
+		$this->assertCount(1, $messages, 'the import says what it recalculated');
+		$this->assertStringContainsString('Mode 2', $messages[0]);
+	}
+
+	/**
+	 * The net amount of every line stays what the document put on it: the core only ever moves a
+	 * rounding difference onto the VAT of a line, so BT-131 and their sum BT-106 do not move.
+	 *
+	 * @return void
+	 */
+	public function testTheLineNetAmountsAreNotTouched()
+	{
+		$this->setInstanceVatMode(1);
+
+		$invoice = $this->createFixtureInvoice();
+		$before = array();
+		foreach ($invoice->lines as $line) {
+			$before[] = (float) $line->total_ht;
+		}
+		sort($before);
+
+		$messages = array();
+		$realigned = $this->alignWith($invoice, 2.09, 12.56, $messages);
+
+		$after = array();
+		foreach ($realigned->lines as $line) {
+			$after[] = (float) $line->total_ht;
+		}
+		sort($after);
+
+		$expected = self::LINE_AMOUNTS;
+		sort($expected);
+
+		$this->assertEquals($before, $after);
+		$this->assertEquals($expected, $after, 'the line net amounts are the ones of the document');
+	}
+
+	/**
+	 * An invoice that already totals what the document announces is left alone - no recalculation, no
+	 * message.
+	 *
+	 * @return void
+	 */
+	public function testAnInvoiceThatAlreadyAgreesIsLeftAlone()
+	{
+		$this->setInstanceVatMode(1);
+
+		$invoice = $this->createFixtureInvoice();
+
+		$messages = array();
+		$untouched = $this->alignWith($invoice, 2.10, 12.57, $messages);
+
+		$this->assertEquals(2.10, (float) $untouched->total_tva);
+		$this->assertEquals(12.57, (float) $untouched->total_ttc);
+		$this->assertCount(0, $messages, 'nothing to say when the invoice already matches');
+	}
+
+	/**
+	 * A difference neither convention explains is a real one. The invoice is left exactly as the import
+	 * built it, and nothing is said here: the comparison of SupplierInvoiceHelper is what reports it.
+	 *
+	 * @return void
+	 */
+	public function testADifferenceThatIsNotARoundingConventionIsLeftAlone()
+	{
+		$this->setInstanceVatMode(1);
+
+		$invoice = $this->createFixtureInvoice();
+
+		$messages = array();
+		$untouched = $this->alignWith($invoice, 3.00, 13.47, $messages);
+
+		$this->assertEquals(10.47, (float) $untouched->total_ht);
+		$this->assertEquals(2.10, (float) $untouched->total_tva, 'the invoice keeps the mode of the instance');
+		$this->assertEquals(12.57, (float) $untouched->total_ttc);
+		$this->assertCount(0, $messages);
+	}
+
+	/**
+	 * The other direction, which is the reason the mode is not read from the setting: an instance on
+	 * mode 2 receiving a document whose VAT was rounded line by line.
+	 *
+	 * @return void
+	 */
+	public function testAnInstanceOnMode2ReceivingADocumentRoundedLineByLine()
+	{
+		$this->setInstanceVatMode(2);
+
+		$invoice = $this->createFixtureInvoice();
+		$this->assertEquals(2.09, (float) $invoice->total_tva, 'mode 2 rounds the VAT on the total');
+
+		$messages = array();
+		$realigned = $this->alignWith($invoice, 2.10, 12.57, $messages);
+
+		$this->assertEquals(10.47, (float) $realigned->total_ht);
+		$this->assertEquals(2.10, (float) $realigned->total_tva);
+		$this->assertEquals(12.57, (float) $realigned->total_ttc);
+		$this->assertCount(1, $messages);
+		$this->assertStringContainsString('Mode 1', $messages[0]);
+	}
+
+	/**
+	 * A credit note is stored negative by Dolibarr while BT-110 and BT-112 are announced positive, the
+	 * document type being what carries the sign. The comparison is therefore made on absolute values.
+	 *
+	 * @return void
+	 */
+	public function testTheComparisonIsMadeOnAbsoluteValues()
+	{
+		global $db;
+
+		$method = new ReflectionMethod(CIIProtocol::class, 'totalsAgreeWithDocument');
+		$method->setAccessible(true);
+
+		$creditNote = new FactureFournisseur($db);
+		$creditNote->total_tva = -2.09;
+		$creditNote->total_ttc = -12.56;
+		$this->assertTrue($method->invoke(null, $creditNote, 2.09, 12.56));
+
+		$off = new FactureFournisseur($db);
+		$off->total_tva = -2.10;
+		$off->total_ttc = -12.57;
+		$this->assertFalse($method->invoke(null, $off, 2.09, 12.56));
+	}
+}


### PR DESCRIPTION
Fixes #781.

## What the two modes are

Dolibarr computes the VAT of an invoice in one of two conventions, chosen once for the whole instance, and the supplier invoice card offers them as the `ReCalculate  Mode1 / Mode2` link:

* **mode 1, "total of round"** — round the VAT of every line, then add them up. `update_price()` applies it whenever nothing is set, so it is what most instances run.
* **mode 2, "round of total"** — add the line amounts up, then compute and round the VAT once. Selected by `MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND_SUPPLIER` (before Dolibarr 20 the core reads the generic `MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND` for supplier documents as well).

Both are legitimate ways to bill, and the import applied whichever the instance was set to: it builds its lines with `FactureFournisseur::updateline()`, which ends on `update_price(1, 'auto', …)`.

## Why a received document does not leave that open

BT-110 and BT-112 are the totals its issuer computed. On the reported document — a real vendor invoice received through a PA, 46 lines, one rate at 20 %, announcing **146.57 / 29.31 / 175.88** — an instance left on the default recorded **175.90**:

```
Σ round(BT-131 × 20 %)  = 29.33   ← mode 1, what the invoice recorded
round(Σ BT-131 × 20 %)  = 29.31   ← mode 2, what the document announces
```

Two cents, and not on a particular kind of line: it is a property of the set of line amounts, so the same document without its two credit lines gives 29.45 against an announced 29.43. With `EINVOICING_SUPPLIER_INVOICE_CHECK_CONSISTENCY_ON_VALIDATION` enabled the module then **refused the validation** and told the operator to recalculate in mode 2 — so it already computed the answer, and left a human to click it once per received invoice. Without that option, nothing was said and the invoice was booked two cents off.

## The change

Once every line of the imported invoice exists, its totals are confronted with the ones the document announces; when they differ, the invoice is recalculated in the convention that reproduces them — the same call the `ReCalculate` link makes, on that one invoice, leaving the setting of the instance alone. The mode is **not read from the setting**: it is the one that matches, which is what makes the two directions work and makes the version difference on the constant name irrelevant.

Untouched on purpose:

* **the line net amounts** — the core only ever moves a rounding difference onto the VAT of a line, never onto its net amount, so BT-131 and their sum BT-106 are the same under both conventions (a test asserts it);
* **an invoice that already agrees** — nothing is recalculated and nothing is said;
* **a difference neither convention explains** — that is a real gap, not a rounding convention: the invoice is left exactly as the import built it, for `checkDolInvoiceAndEInvoiceConsistency()` to report as it does today.

The import says what it did:

> The invoice was recalculated using VAT calculation Mode 2 to carry the totals of the received document, which announces a total VAT (BT-110) of 29.31 and a total including VAT (BT-112) of 175.88, where the VAT calculation mode of this instance rebuilt a total of 175.9 including VAT.

Both import entry points are covered: `CIIProtocol` and the Factur-X one, which still carries its own copy of the routine.

## Measured

Real imports of the reported document (`createSupplierInvoiceFromSource()`, CII, `urn:cen.eu:en16931:2017`, 46 lines), on seven instances, each with its own database, before and after this PR. Every import starts from a clean state rather than working around the duplicate check.

| Dolibarr | before, instance on mode 1 | before, instance on mode 2 | after, either |
|---|---|---|---|
| 18.0.10 | 146.57 / 29.33 / **175.90** | 146.57 / 29.31 / 175.88 | 146.57 / 29.31 / **175.88** |
| 19.0.4 | 146.57 / 29.33 / **175.90** | 146.57 / 29.31 / 175.88 | 146.57 / 29.31 / **175.88** |
| 20.0.4 | 146.57 / 29.33 / **175.90** | 146.57 / 29.31 / 175.88 | 146.57 / 29.31 / **175.88** |
| 21.0.4 | 146.57 / 29.33 / **175.90** | 146.57 / 29.31 / 175.88 | 146.57 / 29.31 / **175.88** |
| 22.0.5 | 146.57 / 29.33 / **175.90** | 146.57 / 29.31 / 175.88 | 146.57 / 29.31 / **175.88** |
| 23.0.4 | 146.57 / 29.33 / **175.90** | 146.57 / 29.31 / 175.88 | 146.57 / 29.31 / **175.88** |
| 24.0 | 146.57 / 29.33 / **175.90** | 146.57 / 29.31 / 175.88 | 146.57 / 29.31 / **175.88** |

The document announces 146.57 / 29.31 / 175.88. On the seven versions, with the option on, the same invoice now goes from *validation refused, recalculate in mode 2* to `checkDolInvoiceAndEInvoiceConsistency()` answering **identical** and `validate()` returning 1, with nothing to click.

**Non-regression, on documents that already agreed** — the two genuine vendor containers of #772, imported on 18.0.10 and 23.0.4: 118.68 / 142.42 on nine lines and 16.94 / 20.33 on four, exactly as before, and **no realignment message** on either: the invoice already carried the announced totals, so nothing was recalculated.

`test/phpunit/ImportVatCalculationModeTest.php` (6 tests) covers the reported case, the line net amounts staying put, the invoice that already agrees, the difference no convention explains, an instance on mode 2 receiving a document rounded line by line, and the absolute-value comparison a credit note needs. The module suite — 27 files, 245 tests — stays green on **18.0.10, 19.0.4, 20.0.4, 21.0.4, 22.0.5, 23.0.4 and 24.0**; `dolics` is clean.
