### PR TITLE
FIX #784 [einvoicing] The consistency check reads the document the invoice was imported from

### DIFF
--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -1120,43 +1120,34 @@ abstract class AbstractPDPProvider
 	}
 
 	/**
-	 * Try to get a flow XML from its id using API
-	 * @param string $flowId 		The id of the flow to fetch
-	 * @param bool	 $cleanXml 		Whether you need to remove (attachments presents in XML content...)
+	 * The invoice of a flow, read from the same document the supplier invoice was imported from.
 	 *
-	 * @return ?string
+	 * It used to ask for the 'Original' while the import reads what fetchImportableFlowDocument()
+	 * picks, so the check compared the invoice against a file it was not built from, and opened a
+	 * PDF reader on installations whose reception path is plain XML.
+	 *
+	 * @param	string	$flowId			The id of the flow to fetch
+	 * @param	bool	$cleanXml		Whether you need to remove (attachments presents in XML content...)
+	 * @return	?string					The invoice XML, or null when no document of the flow can be read
+	 * @throws	Exception				When the access point returned no document at all
 	 */
 	public function fetchFlowXml($flowId, $cleanXml)
 	{
-		$flowResponse = $this->fetchFlowData($flowId, 'Original', 'get_flow_xml');
+		$importable = $this->fetchImportableFlowDocument($flowId, new ProtocolManager($this->db));
 
-		if ($flowResponse['status_code'] != 200) {
+		if (empty($importable['fetched'])) {
 			throw new Exception('Failed to get flow XML for flow id n° ' . $flowId);
 		}
 
-		$xmlData = null;
+		if (empty($importable['protocol'])) {
+			dol_syslog(__METHOD__ . " Flow " . $flowId . " holds no document this module can read: " . implode(' | ', $importable['attempts']), LOG_WARNING, 0, "_einvoicing");
+			return null;
+		}
 
-		// $receivedFileContent may be an XML file (CII, UBL...) or a PDF file (FacturX), or ...
-		$receivedFileContent = $flowResponse['response'];
+		$xmlData = $importable['protocol']->extractXmlFromFileContent((string) $importable['file']);
 
-		$resProtocol = ProtocolManager::getProtocolFromContent($receivedFileContent);
-		if ($resProtocol['success']) {
-			$protocol = $resProtocol['protocol_object'];
-
-			// getProtocolFromContent() succeeded on the container. The invoice inside may still be in a
-			// syntax with no reader here, and everything downstream - cleanXmlData() first - assumes a
-			// protocol was found for what it is handed. Return nothing rather than that.
-			$payloadReason = '';
-			$xmlData = $this->readableInvoicePayload($receivedFileContent, $protocol, new ProtocolManager($this->db), $payloadReason);
-
-			if ($xmlData === null) {
-				dol_syslog(__METHOD__ . " Flow " . $flowId . " holds no invoice this module can read: " . $payloadReason, LOG_WARNING, 0, "_einvoicing");
-				return null;
-			}
-
-			if ($cleanXml) {
-				$xmlData = Document::cleanXmlData($xmlData);
-			}
+		if ($cleanXml) {
+			$xmlData = Document::cleanXmlData($xmlData);
 		}
 
 		return $xmlData;


### PR DESCRIPTION
Fixes #784. Applies on `main` as it stands and needs nothing else.

`fetchFlowXml()` asked the access point for the **`Original`**, hardcoded, while the import reads the shape `fetchImportableFlowDocument()` picks. Two paths, two documents.

> **This description was rewritten after #764 was merged (47cd02cf).** The first version of it reported a `TypeError: get_class(): … null given` on `main`; that fatal is gone, #764 fixed it. What is left is quieter and is what the measurements below are about: on a flow whose `Original` has no reader here, the consistency check is now silently skipped while the import, reading another shape, had no trouble at all.

## The change

`fetchFlowXml()` goes through the same picker. Same shapes, same order, same skipping of a document whose syntax has no reader here. Nothing else moves: the exception on "the access point returned nothing" is kept, and the `null` return is kept for the case where no document can be read.

## Where this code is reached

`fetchFlowXml()` is not the ordinary path, and it is worth saying where it does run. `SupplierInvoiceHelper::getXmlData()` only goes back to the access point when `xml_data` is empty in database, and a successful import fills it — but **the "already exists" branch of the import does not**: `FacturXProtocol` and `CIIProtocol` return `['res' => $supplierInvoiceId, 'message' => '… already exists']`, with no `xml_data` key, so the `einvoicing_document` row is stored with `xml_data = NULL`.

That branch is the ordinary case of **an invoice keyed in by hand before the e-invoice arrived**: same supplier reference and same total, which is exactly what `findIdByRef()` requires to match. Rows inherited from older versions of the module, and an `xml_data` above what the column holds, land in the same place.

So the flow is imported, the supplier invoice is linked, and the first consistency check on it has to fetch the invoice back from the access point — through `fetchFlowXml()`.

## What it changes, measured

Live flow on a real access point, receiving account set to **Factur-X**. The invoice is keyed in first with the right total but the wrong VAT split — 1212 incl. tax, entered as 1212 excl. tax + 0 VAT where the e-invoice says 1010 + 202 — then the flow is synchronised, then the consistency check runs.

```
                                   main                          this PR
syncFlow                           res=1, "already exists"       res=1, "already exists"
xml_data stored by the import      NULL                          NULL
consistency check                  false                         identical=false, 3 differences
                                   NO COMPARISON AT ALL          VAT excl. total 1010 vs 1212
                                                                 VAT total 202 vs 0
                                                                 20% VAT rate missing in Dolibarr
xml_data after the check           still NULL, refetched every   repaired, 18169 bytes stored
                                   time
```

A keying error of 202 € of VAT goes through unnoticed on `main`, on an invoice the module did import.

## Why `main` gets nothing here

The account conversion format is a real setting users have — [#718](https://github.com/Dolibarr/dolibarr-community-modules/issues/718#issuecomment-5536157368). Set to Factur-X, a flow arriving already Factur-X is handed back **byte for byte**, whatever it carries: the platform labels the flow from the container, the same way `detectProtocolFromContent()` does. Measured on the flow above, a hybrid PDF carrying UBL deposited from another account:

| shape asked for | bytes | container | payload |
|---|---|---|---|
| `Original` | 41554 | FACTURX | **UBL**, 7596 bytes — sha256 identical to what the sender deposited |
| `Converted` | 41554 | FACTURX | **UBL**, same bytes again — not converted at all |
| `ReadableView` | 37640 | FACTURX | **CII**, 18120 bytes — built by the platform |

The picker refuses the first two ("FACTURX but what it carries is UBL, which is not supported") and reads the third; that is where the supplier invoice comes from. `fetchFlowXml()`, asking for the `Original`, is handed the one document nothing here can read.

Replay of three recorded deliveries, two of them from an account set to CII, through both trees:

```
                                     main            this PR
CII account, PDF original            null            18126 bytes of CII
Factur-X account, UBL deposited      null            18164 bytes of CII
Factur-X account, pass-through       null            18169 bytes of CII
```

The CII the branch returns is the very document the invoice was imported from: same content as the payload the picker read, `xmllint --c14n` identical, the extra bytes being the XML declaration added on re-serialisation.

## On horstoeko/zugferd

On an account set to **CII** — the value the setup page recommends — this also keeps the check off PDFs: `get_declared_classes()` filtered on `horstoeko\zugferd` gives **3 classes on `main`, none on this branch**, because the `Converted` is plain XML there while the `Original` is the issuer's PDF. That is the #742 argument, and it holds only for that setting: on an account set to Factur-X the only readable shape *is* a PDF, and both trees open it.

## Non-regression

- **PHPUnit**, file by file, on **18.0.10, 23.0.4 and 24.0.1**: `OK=33 KO=0` on each — same result as `main` measured in the same run, on the same three cores.
- The import path is untouched: the picker itself is not modified, only its second caller.
- The `null` return is unchanged for a flow that really holds nothing readable; the caller already treats it as "cannot check".
