### PR TITLE
FIX [einvoicing] A mandatory extrafield on thirdparties no longer rejects received documents

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -1127,6 +1127,9 @@ class CIIProtocol extends AbstractProtocol
 			if ($supplier->fournisseur != 1) {
 				$supplier->fournisseur = 1;
 				$supplier->code_fournisseur = 'auto';
+				// Flagging a vendor must not rewrite its extrafields, or a mandatory one left empty
+				// makes update() refuse the whole record. See _syncOrCreateThirdpartyFromEInvoiceSeller().
+				$supplier->array_options = array();
 				$supplier->update($supplier->id, $user);
 			}
 

--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -798,6 +798,17 @@ trait CommonProtocol
 				$allowmodcodeclient = 1;
 			}
 
+			// This function never sets an extrafield on a thirdparty, so it must not rewrite them.
+			// It has to say so explicitly: from Dolibarr 20 on, fetch() pre-fills array_options with a
+			// null entry for every declared extrafield, and update() then hands that array to
+			// insertExtraFields(), which refuses the WHOLE update as soon as one of those fields is
+			// mandatory and empty. Every thirdparty this very function created is in that state (a
+			// programmatic create() writes no extrafield row at all), and so is every thirdparty that
+			// predates the mandatory flag - so a mandatory extrafield on the thirdparty rejected every
+			// received document. Emptied, array_options makes insertExtraFields() return 0 without
+			// touching the stored row, so no value is lost either.
+			$thirdparty->array_options = array();
+
 			$result = $thirdparty->update(0, $user, 1, $allowmodcodeclient, $allowmodcodefournisseur);
 			if ($result < 0) {
 				$this->error = $thirdparty->error;

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -916,6 +916,9 @@ class FacturXProtocol extends CIIProtocol
 			if ($supplier->fournisseur != 1) {
 				$supplier->fournisseur = 1;
 				$supplier->code_fournisseur = 'auto';
+				// Flagging a vendor must not rewrite its extrafields, or a mandatory one left empty
+				// makes update() refuse the whole record. See _syncOrCreateThirdpartyFromEInvoiceSeller().
+				$supplier->array_options = array();
 				$supplier->update($supplier->id, $user);
 			}
 

--- a/einvoicing/test/phpunit/AllTests.php
+++ b/einvoicing/test/phpunit/AllTests.php
@@ -129,6 +129,8 @@ class AllTests
 		$suite->addTestSuite('LinePriceBaseQuantityTest');
 		require_once dirname(__FILE__).'/LineWithoutQuantityTest.php';
 		$suite->addTestSuite('LineWithoutQuantityTest');
+		require_once dirname(__FILE__).'/MandatoryThirdpartyExtrafieldTest.php';
+		$suite->addTestSuite('MandatoryThirdpartyExtrafieldTest');
 		require_once dirname(__FILE__).'/NegativeLineAmountTest.php';
 		$suite->addTestSuite('NegativeLineAmountTest');
 		require_once dirname(__FILE__).'/ImportVatCalculationModeTest.php';

--- a/einvoicing/test/phpunit/MandatoryThirdpartyExtrafieldTest.php
+++ b/einvoicing/test/phpunit/MandatoryThirdpartyExtrafieldTest.php
@@ -1,0 +1,207 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/MandatoryThirdpartyExtrafieldTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for the synchronization of the seller of a received document when the
+ *                  base carries a mandatory extrafield on thirdparties.
+ *                  The module never sets an extrafield on a thirdparty, but from Dolibarr 20 on
+ *                  Societe::fetch() pre-fills array_options with a null entry for every declared
+ *                  extrafield, and update() hands that array to insertExtraFields(), which refuses the
+ *                  whole record as soon as one of those fields is mandatory and empty. A thirdparty
+ *                  created programmatically holds no extrafield row at all - which is exactly what the
+ *                  automatic creation of this same function produces - so every received document was
+ *                  then rejected on the seller.
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+// See VatPointDateCodeTest for why DOLIBARR_HTDOCS is honoured before the relative path.
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
+require_once DOL_DOCUMENT_ROOT . '/core/class/extrafields.class.php';
+// Societe::create() calls getCountry() on some cores (Dolibarr 21), and master.inc.php does not
+// load company.lib.php: without this the test errors out on an undefined function, not on the module.
+require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php';
+dol_include_once('einvoicing/class/protocols/CIIProtocol.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class MandatoryThirdpartyExtrafieldTest extends CommonClassTest
+{
+	/** @var string	Name of the mandatory extrafield declared on thirdparties for the test */
+	const ATTRNAME = 'einvmandatorytest';
+
+	/**
+	 * Declare a mandatory extrafield on thirdparties, then open the transaction of the test class.
+	 *
+	 * Order matters: adding an extrafield runs an ALTER TABLE, which is not transactional and commits
+	 * whatever the surrounding transaction holds. Declared before the transaction opens, and removed
+	 * after it is rolled back, it leaves the instance exactly as it was found.
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass(): void
+	{
+		global $db;
+
+		$extrafields = new ExtraFields($db);
+		// A run interrupted before tearDownAfterClass() would leave the field behind, and addExtraField()
+		// refuses an existing name: drop it first so the suite stays runnable.
+		$extrafields->delete(self::ATTRNAME, 'societe');
+		$extrafields->addExtraField(self::ATTRNAME, 'Mandatory field of the test', 'varchar', 100, 32, 'societe', 0, 1);
+
+		parent::setUpBeforeClass();
+	}
+
+	/**
+	 * Roll the transaction back, then remove the extrafield declared for the test.
+	 *
+	 * @return void
+	 */
+	public static function tearDownAfterClass(): void
+	{
+		global $db;
+
+		parent::tearDownAfterClass();
+
+		$extrafields = new ExtraFields($db);
+		$extrafields->delete(self::ATTRNAME, 'societe');
+	}
+
+	/**
+	 * A vendor as the automatic creation of _syncOrCreateThirdpartyFromEInvoiceSeller() leaves it:
+	 * identified by its SIREN, and holding no extrafield row at all, since a programmatic create()
+	 * writes none.
+	 *
+	 * @param	string	$siren	SIREN identifying the vendor
+	 * @return	int				Id of the created thirdparty
+	 */
+	private function createVendor($siren)
+	{
+		global $db, $user;
+
+		$thirdparty = new Societe($db);
+		$thirdparty->name = 'Vendor of the mandatory extrafield test';
+		$thirdparty->country_code = 'FR';
+		$thirdparty->idprof1 = $siren;
+		$thirdparty->fournisseur = 1;
+		$thirdparty->code_fournisseur = 'auto';
+
+		$id = $thirdparty->create($user);
+		$this->assertGreaterThan(0, $id, 'Could not create the vendor of the test: ' . $thirdparty->error . ' ' . implode(', ', $thirdparty->errors));
+
+		return $id;
+	}
+
+	/**
+	 * Seller block of a received document, reduced to what the synchronization reads.
+	 *
+	 * @param	string	$siren	SIREN carried by the document
+	 * @return	array			Seller information, as the protocols parse it
+	 */
+	private function sellerInfo($siren)
+	{
+		return array(
+			'sellername' => 'Vendor of the mandatory extrafield test',
+			'sellerlineone' => '1 rue du Test',
+			'sellerpostcode' => '86000',
+			'sellercity' => 'Poitiers',
+			'sellercountry' => 'FR',
+			'sellerGlobalIds' => array('0002' => $siren),
+		);
+	}
+
+	/**
+	 * Run the seller synchronization, the private step both protocols call on a received document.
+	 *
+	 * @param	array	$sellerInfo	Seller information
+	 * @return	array				Answer of _syncOrCreateThirdpartyFromEInvoiceSeller()
+	 */
+	private function syncSeller($sellerInfo)
+	{
+		global $db;
+
+		// CommonProtocol is a trait: the method belongs to the class that uses it.
+		$method = new ReflectionMethod(CIIProtocol::class, '_syncOrCreateThirdpartyFromEInvoiceSeller');
+		$method->setAccessible(true);
+
+		return $method->invoke(new CIIProtocol($db), $sellerInfo, 'dolibarr', '');
+	}
+
+	/**
+	 * A received document whose seller is already known must be imported even though the base carries
+	 * a mandatory extrafield on thirdparties that this vendor does not fill.
+	 *
+	 * @return void
+	 */
+	public function testSellerSyncSucceedsWithAnEmptyMandatoryExtrafield()
+	{
+		$siren = '000000011';
+		$socid = $this->createVendor($siren);
+
+		$res = $this->syncSeller($this->sellerInfo($siren));
+
+		$this->assertEquals($socid, $res['res'], 'The seller synchronization was refused: ' . $res['message']);
+	}
+
+	/**
+	 * The synchronization must not empty the extrafields it does not set: a vendor whose mandatory
+	 * extrafield is filled keeps its value once the document is imported.
+	 *
+	 * @return void
+	 */
+	public function testStoredExtrafieldValuesSurviveTheSellerSync()
+	{
+		global $db, $user;
+
+		$siren = '000000012';
+		$socid = $this->createVendor($siren);
+
+		$thirdparty = new Societe($db);
+		$thirdparty->fetch($socid);
+		$thirdparty->array_options['options_' . self::ATTRNAME] = 'KEEP ME';
+		$this->assertGreaterThan(0, $thirdparty->update($socid, $user), 'Could not store the extrafield value: ' . implode(', ', $thirdparty->errors));
+
+		$res = $this->syncSeller($this->sellerInfo($siren));
+		$this->assertEquals($socid, $res['res'], 'The seller synchronization was refused: ' . $res['message']);
+
+		$reread = new Societe($db);
+		$reread->fetch($socid);
+		$this->assertEquals('KEEP ME', $reread->array_options['options_' . self::ATTRNAME], 'The synchronization lost the stored extrafield value');
+	}
+}


### PR DESCRIPTION
Reported by a user running the module in production: *"if there is a mandatory extrafield on the thirdparty, the automatic creation of thirdparties fails"*. It is not the creation that fails, it is the update that follows it — and it takes the whole received document with it.

## What happens

Both protocols synchronize the seller before anything else, and roll the document back when that step answers -1. On a base carrying a mandatory extrafield on thirdparties, that step answers:

```
import -> id=-1  Thirdparty sync or creation error: | Thirdparty update error: ,Field 'x' is required.
```

`_syncOrCreateThirdpartyFromEInvoiceSeller()` re-fetches the seller and calls `Societe::update()` on it unconditionally — even with `EINVOICING_THIRDPARTIES_COMPLETE_INFO` off, where it only wants to set `fournisseur = 1` and a vendor code. From Dolibarr 20 on, `Societe::fetch()` pre-fills `array_options` with a `null` entry for **every** declared extrafield; `update()` hands that array to `insertExtraFields()`, which refuses the whole record as soon as one of those entries is mandatory and empty.

Two populations of thirdparties are in exactly that state:

* every thirdparty that predates the day the field was made mandatory;
* every vendor **the module created itself** — a programmatic `create()` leaves `array_options` empty, `insertExtraFields()` returns 0 on the spot, and no row is written to `llx_societe_extrafields` at all.

So the first received document from an unknown vendor creates it and imports fine, and every later document from that same vendor is rejected on it. That is what the report describes as "the automatic creation does not work".

Measured on the bench, one thirdparty created the way the module creates one, then re-fetched and updated the way the synchronization does:

| core | `create()` | extrafield rows written | `update()` after `fetch()` |
|---|---|---|---|
| 18.0.10 | ok | 0 | ok |
| 19.0.4 | ok | 0 | ok |
| 20.0.4 | ok | 0 | **-1, field is required** |
| 21.0.4 | ok | 0 | **-1, field is required** |
| 22.0.5 | ok | 0 | **-1, field is required** |
| 23.0.3 | ok | 0 | **-1, field is required** |
| 24.0.0 | ok | 0 | **-1, field is required** |

18 and 19 escape only because their `fetch()` does not pre-fill `array_options` when the row is absent; a thirdparty that *has* a row with the mandatory field empty fails there too.

There is no usable workaround on the user side, all three measured on 23.0.3:

* giving the extrafield a **default value** changes nothing — no row is ever written, `fetch()` reads `null`, the check still fires;
* backfilling `llx_societe_extrafields` with `''` does not pass `ExtraFields::isEmptyValue()` either;
* only a real non-empty value on every single thirdparty works, and it breaks again on the next vendor the module creates.

## The change

The module never sets an extrafield on a thirdparty. It now says so: `array_options` is emptied before the update, so `insertExtraFields()` returns 0 without touching the stored row. The update goes through, and no extrafield value is lost — the row is left exactly as it was, not deleted and rewritten. The same guard is applied to the two places that only flag a thirdparty as a vendor.

A thirdparty whose mandatory extrafields are filled is updated exactly as before, and re-reading it afterwards gives the same values.

## Measured

Two twin instances built from the same Dolibarr 23.0.3, same database, same document, same mandatory extrafield declared on thirdparties — one on `main`, one on this branch:

| instance | module | result |
|---|---|---|
| control | `main` | `id=-1  Thirdparty update error: Field 'x' is required` |
| this PR | this branch | `id=4785`, invoice imported, 2 lines, 554.67 TTC |

Same A/B on 20.0.4: `id=3808`, imported. And a vendor whose mandatory extrafield holds `KEEP ME` still holds `KEEP ME` after a second document is imported against it.

`test/phpunit/MandatoryThirdpartyExtrafieldTest.php` covers both halves: the synchronization succeeds with an empty mandatory extrafield, and a stored value survives it. It declares the extrafield before the class transaction opens and removes it after the rollback, since `ALTER TABLE` is not transactional — the instance is left as it was found. The test fails on `main` (`Failed asserting that -1 matches expected 52`) and passes here, on **18.0.10, 19.0.4, 20.0.4, 21.0.4, 22.0.5, 23.0.3 and 24.0.0**. The module suite stays green on those same cores.

## What this does not change

The synchronization still issues a full `Societe::update()` on the seller of every received document, so it remains exposed to the other mandatory-field rules of `Societe::verify()` — a mandatory professional id, a mandatory VAT number, a mandatory accounting code. Making it write only what it actually wants to change is a wider behaviour change, and is left out of this fix.
