### PR TITLE
NEW [einvoicing] Say on the synchronization list how to import a document again

### DIFF
--- a/einvoicing/document_list.php
+++ b/einvoicing/document_list.php
@@ -910,6 +910,17 @@ if ($provider) {
 
 	print "</div>\n";
 
+	// Where the "import a received document again" action lives. This list is where a user lands after
+	// deleting the draft supplier invoice a reception created: the flow is still here, so re-running a
+	// synchronization or deleting the line looks like the way to get the document back, and neither is.
+	// The action is on the flow card, one click away but invisible from here, hence this reminder.
+	if (!getDolGlobalString('EINVOICING_DISABLE_SYNC_AP_TO_DOLI')) {
+		print '<div class="opacitymedium small paddingtop paddingleft">';
+		print img_picto('', 'info', 'class="pictofixedwidth"').' ';
+		print $langs->trans('EInvoiceReimportHint', $langs->transnoentitiesnoconv('EInvoiceReimport'));
+		print '</div>'."\n";
+	}
+
 	print "</div>\n";
 
 	print '<script>'."\n";

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -419,6 +419,7 @@ EInvoiceReimportNoProvider=No access point is configured.
 EInvoiceReimportInvoiceIsNotADraft=The supplier invoice %s is no longer a draft, so it cannot be replaced by a new import.
 EInvoiceReimportOnlyOnADraft=A received e-invoice can only be imported again while the supplier invoice it created is still a draft.
 EInvoiceReimportFailedToDeleteTheDraft=Failed to delete the draft supplier invoice %s.
+EInvoiceReimportHint=A synchronization never imports again a flow that is already in this list. To import a received supplier invoice again - after deleting the draft it created, for example - open its flow, then use the "%s" action on the flow card.
 EInvoiceBuyerOrderReferenceHelp=Order reference (BT-13) carried by the e-invoice received. It is kept as sent by the supplier, whether or not it matched a purchase order of Dolibarr.
 EInvoiceRoutingCodeRejected=The Chorus Pro service code "%s" was not sent as a buyer routing identifier (BT-46, scheme 0224): rules BR-FR-24 and BR-FR-26 only allow letters, digits and the characters + - _ . up to 100 characters. Please correct it, otherwise a public buyer that requires a service code will reject the invoice.
 EInvoiceRoutingCodeNeedsExtendedProfile=The Chorus Pro service code "%s" was not sent as a buyer routing identifier (BT-46, scheme 0224): the %s profile allows a single identifier for the buyer. Select the EXTENDED-CTC-FR profile to send it, as rules BR-FR-CPRO-11 and BR-FR-CPRO-13 require for a public buyer.


### PR DESCRIPTION
Fixes #767

## The problem

The recovery workflow added by #757 lives on the flow card, and nothing on the synchronization list points at it. A user who has just deleted the draft supplier invoice a reception created lands on that list, still sees the flow there, and reasonably tries the two things that do not work: running a synchronization again — a flow already known is not imported a second time — or deleting the line.

## The change

One line under the synchronization box, naming the action and saying where it is:

> A synchronization never imports again a flow that is already in this list. To import a received supplier invoice again - after deleting the draft it created, for example - open its flow, then use the "Import E-invoice doc again" action on the flow card.

- printed only when reception is enabled, i.e. when `EINVOICING_DISABLE_SYNC_AP_TO_DOLI` is not set, so an installation that only emits does not carry the noise;
- the name of the action comes from its own translation key (`EInvoiceReimport`), so the memo and the button cannot drift apart;
- `en_US` only, as agreed for translation keys added in a PR.

## Test

Rendered on the real page, logged in, on **Dolibarr 18.0.10 and 23.0.4**: HTTP 200, no PHP error and no warning, memo in place under the "last synchronized flow" block and above the list. Setting `EINVOICING_DISABLE_SYNC_AP_TO_DOLI` removes it and clearing the constant brings it back.
