### PR TITLE
FIX #791 Deleting the default product reference

### DIFF
--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -2333,6 +2333,9 @@ class EInvoicing
 			$resprints .= '<td>' . $form->textwithpicto($langs->trans("DefaultProductEBilling"), $langs->trans("DefaultProductEBillingHelp")) . '</td>';
 			$resprints .= '<td'.(empty($parameters['colspanvalue']) ? '' : ' colspan="'.(((int) $parameters['colspanvalue']) - 1).'"').'>';
 			if ($mode == 'edit') {
+				if (preg_match('/^idprod/', $product_id)) {
+					$product_id = (int) str_replace('idprod_', '', $product_id);
+				}
 				$resprints .= $this->selectVendorProduct($form, $object->id, $product_id, 'routing_product_id');
 			} else {
 				if ($product_id != '' && $product_id != '-1') {

--- a/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
+++ b/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
@@ -97,7 +97,7 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 
 			// Default product for import
 			$routingProductId = GETPOST('routing_product_id', 'aZ09');
-			if ($routingProductId !== '' && $routingProductId !== '-1') {
+			if ($routingProductId !== '-1') {
 				$existing = $einvoicing->fetchDefaultRouting($socId, 'product');
 				if (empty($existing)) {
 					$result = $einvoicing->addRouting($socId, $routingProductId, '', 'product');


### PR DESCRIPTION
If the `$routingProductId` is blank, the default product should also be updated to blank.