### PR TITLE
FIX #725 einvoicing: attach the readable invoice, not the CII XML, when the model is an ODT one

### DIFF
--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -279,7 +279,54 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 */
 	public function afterODTCreation($parameters, $object, &$action, $hookmanager)
 	{
+		// The core hands this hook the document model itself, not the invoice (the invoice is in
+		// $parameters['object']). Raise its main-document flag while it can still be read - see the
+		// method for why this is the fix to issue #725 and not a workaround for it.
+		$this->backportUpdateMainDocField($parameters, $object);
+
 		return $this->afterPDFCreation($parameters, $object, $action, $hookmanager);
+	}
+
+	/**
+	 * Make the ODT invoice model maintain last_main_doc on the Dolibarr versions whose core does not.
+	 *
+	 * last_main_doc holds the document Dolibarr considers to be the official readable image of the
+	 * invoice; core/tpl/card_presend.tpl.php attaches it to the email by default. It is only written by
+	 * commonGenerateDocument() when the document model declares ->update_main_doc_field.
+	 * doc_generic_proposal_odt has always declared it, doc_generic_order_odt does since 23, and
+	 * doc_generic_invoice_odt only since 25.0.0 (core commit f9ae68e3). Below that, an invoice built
+	 * from an ODT template leaves last_main_doc empty and card_presend falls back to
+	 * dol_most_recent_file($dir, preg_quote($ref).'[^\-]+'): the newest file whose name starts with the
+	 * ref, with no filter on the type. The <ref>_cii.xml written by this module is then picked over the
+	 * readable document and mailed to the customer (issue #725).
+	 *
+	 * The flag is raised on the model instance the core passes to the hook, which is the one
+	 * commonGenerateDocument() reads it back from once write_file() has returned (verified on 18 to 24).
+	 * So the core keeps doing the indexing itself, including its condition that the file must still
+	 * exist - an ODT converted to PDF and deleted must not be recorded as the main document.
+	 *
+	 * No-op from 25.0.0 on, and for any model that already maintains the field, the built-in PDF ones
+	 * included.
+	 *
+	 * @param	array<string,mixed>	$parameters		Hook parameters ($parameters['object'] holds the invoice)
+	 * @param	object				$generator		Document model that called the hook
+	 * @return	void
+	 */
+	private function backportUpdateMainDocField($parameters, $generator)
+	{
+		if (!is_object($generator) || !property_exists($generator, 'update_main_doc_field')) {
+			return;
+		}
+		if (!empty($generator->update_main_doc_field)) {
+			return;		// Core 25+, or a model that maintains the field on its own
+		}
+		if (empty($parameters['object']) || !($parameters['object'] instanceof Facture)) {
+			return;		// The core fix is about the invoice model; leave the other objects alone
+		}
+
+		$generator->update_main_doc_field = 1;
+
+		dol_syslog(__METHOD__ . " model " . get_class($generator) . " does not maintain last_main_doc on Dolibarr " . DOL_VERSION . ", flag raised so the core indexes the generated document as the main one");
 	}
 
 


### PR DESCRIPTION
Fixes #725, following @eldy's answer there: *"v24 has been fixed so the update_main_doc_field is set to 1 for every document generator that generates a main document. This can be backported on previous version."*

## What this does

`last_main_doc` — the file Dolibarr treats as the official readable image of the invoice, and the one `core/tpl/card_presend.tpl.php` pre-attaches to the email — is only written by `commonGenerateDocument()` when the document model declares `->update_main_doc_field`. `doc_generic_invoice_odt` never declared it; the core commit that adds it (`f9ae68e3`) is on `develop`, i.e. **25.0.0-alpha**, and is not on the `24.0` branch yet.

So on every version the module supports, an invoice built from an ODT template leaves `last_main_doc` empty and `card_presend` falls back to `dol_most_recent_file($dir, preg_quote($ref).'[^\-]+')`: the newest file whose name starts with the ref, **with no filter on the type**. The `<ref>_cii.xml` this module writes then wins and is the file offered for sending.

The backport raises that flag from the `afterODTCreation` hook, on the model instance the core hands the hook — the same instance `commonGenerateDocument()` reads `->update_main_doc_field` back from once `write_file()` has returned (checked on 18, 19, 20, 21, 22, 23, 24). So this is the core fix, not an imitation of it: the core still does the indexing, with its own condition that the file must still exist, which is what keeps an ODT converted to PDF and deleted from being recorded as the main document.

It is a no-op where nothing is broken: from 25.0.0 on, and for any model that already declares the flag — the built-in PDF ones (`sponge`, `crabe`, `octopus`) included. It is scoped to invoices, like the core commit: `doc_generic_order_odt` also lacks the flag before 23, and that is not this module's business.

## Measured

Bench: 18.0.10, 22.0.5, 23.0.3, 24.0.0, same module, same ODT template, invoice cloned then validated, then the choice made by `card_presend.tpl.php` replayed. The `_cii.xml` is made the newest file, which is what happens as soon as the e-invoice is regenerated alone.

| core | `last_main_doc` before / after | file attached before / after |
|---|---|---|
| 18.0.10 | `''` → `facture/…/DD18-FA-2609-0053_invoice.odt` | `…_cii.xml` → `…_invoice.odt` |
| 22.0.5 | `''` → `facture/…/DD22-FA-2609-0062_invoice.odt` | `…_cii.xml` → `…_invoice.odt` |
| 23.0.3 | `''` → `facture/…/DD23-FA-2609-0120_invoice.odt` | `…_cii.xml` → `…_invoice.odt` |
| 24.0.0 | `''` → `facture/…/DD24-FA-2609-0039_invoice.odt` | `…_cii.xml` → `…_invoice.odt` |

Negative control, same patched module, PDF model (`sponge`) on 23.0.3: `last_main_doc` = `facture/…/DD23-FA-2609-0121.pdf` and the PDF is attached — unchanged, the model already declares the flag and the first guard returns.

Not covered by this bench: `MAIN_ODT_AS_PDF` (no LibreOffice on the bench), and the object types other than invoices (the pre-23 instances carry no order at all, and the guard is a plain `instanceof Facture`). Behaviour there is the core's own, by construction.

`phpcs` clean, `phan` clean (only the two pre-existing `helloasso` findings).

## What is left of the issue

@eldy's second suggestion — when both a readable PDF and the `_cii.xml` are official documents, give the readable one priority by updating `last_main_doc` after the Factur-X PDF is written — is deliberately **not** in this PR; it is a behaviour change on all versions rather than a backport, and it deserves its own discussion. Happy to send it separately.
