### PR TITLE
FIX einvoicing: offer "Payment transmitted" only on an answered, payable invoice

### DIFF
--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -907,8 +907,12 @@ class EInvoicing
 	 * the normal order of things is to approve an invoice and then pay it, and "Payment transmitted"
 	 * (211) is precisely what is sent afterwards. An approved invoice can no longer be refused either.
 	 *
-	 * One thing narrows the list beyond that history: a credit note correcting an invoice we refused
-	 * cannot be accepted, since the invoice it credits owes nothing (issue #594, see
+	 * The order matters both ways: "Payment transmitted" is only offered once that approval has been
+	 * accepted by the platform, and never on a draft. Announcing the payment of an invoice nobody has
+	 * answered yet - or of one Dolibarr does not owe anything on - runs the lifecycle backwards.
+	 *
+	 * One last thing narrows the list beyond that history: a credit note correcting an invoice we
+	 * refused cannot be accepted, since the invoice it credits owes nothing (issue #594, see
 	 * SupplierInvoiceHelper::refusedSourceOfCreditNote()). Refusing it stays offered - that is what the
 	 * document is for here - as do the statuses that settle nothing, like "Disputed" or "Suspended".
 	 *
@@ -925,7 +929,9 @@ class EInvoicing
 		}
 
 		$statuses = $this->getEinvoiceStatusOptions(1, 1, 1);
-		if ($this->hasSentStatusMessage($elementId, $elementType, self::STATUS_APPROVED, 1)) {
+		$approved = $this->hasSentStatusMessage($elementId, $elementType, self::STATUS_APPROVED, 1)
+			|| $this->hasSentStatusMessage($elementId, $elementType, self::STATUS_PARTIALLY_APPROVED, 1);
+		if ($approved) {
 			unset($statuses[self::STATUS_REFUSED]);
 		}
 		foreach (array_keys($statuses) as $code) {
@@ -934,12 +940,32 @@ class EInvoicing
 			}
 		}
 
+		// The lifecycle runs in one direction: a received invoice is first answered - approved (205) or
+		// refused (210) - and only then paid, so "Payment transmitted" (211) is offered once that answer
+		// has been given and accepted by the platform, not before. Offering it right away announced the
+		// payment of an invoice we had said nothing about, and let it be sent while the answer was still
+		// pending or had been rejected by the platform - which is when the button is the most tempting,
+		// and the most wrong.
+		if (!$approved) {
+			unset($statuses[self::STATUS_PAYMENT_SENT]);
+		}
+
 		if ($elementType === 'invoice_supplier') {
 			dol_include_once('einvoicing/class/utils/SupplierInvoiceHelper.class.php');
+			dol_include_once('fourn/class/fournisseur.facture.class.php');
 			if (SupplierInvoiceHelper::refusedSourceOfCreditNote((int) $elementId) > 0) {
 				foreach (self::STATUSES_ACCEPTING_A_DOCUMENT as $code) {
 					unset($statuses[$code]);
 				}
+			}
+
+			// A draft owes nothing yet: it is not in the accounts, cannot be paid, and validating it is
+			// precisely the act of accepting it. Telling the vendor that its payment has been transmitted
+			// at that point describes something that cannot have happened. The state comes from the
+			// invoice itself, which is the core's own answer to the question.
+			$supplierInvoice = new FactureFournisseur($this->db);
+			if ($supplierInvoice->fetch((int) $elementId) > 0 && (int) $supplierInvoice->status === FactureFournisseur::STATUS_DRAFT) {
+				unset($statuses[self::STATUS_PAYMENT_SENT]);
 			}
 		}
 

--- a/einvoicing/test/phpunit/ReceivedInvoiceStatusesTest.php
+++ b/einvoicing/test/phpunit/ReceivedInvoiceStatusesTest.php
@@ -23,7 +23,8 @@
  *                  statuses a user may still send by hand on an invoice received through the platform,
  *                  given what the platform already accepted for it. The rule the module got wrong is
  *                  that approving an invoice does not end the exchange - the payment, and the status
- *                  reporting it, come after the approval (issue #548).
+ *                  reporting it, come after the approval (issue #548), and only after it: an invoice
+ *                  nobody has answered yet is not offered the status of its payment.
  *      \remarks    To run this script as CLI: phpunit filename.php
  */
 
@@ -115,17 +116,52 @@ class ReceivedInvoiceStatusesTest extends CommonClassTest
 	}
 
 	/**
-	 * An invoice on which nothing was sent yet offers the whole sendable list.
+	 * An invoice on which nothing was sent yet is waiting for an answer, and only for that: approving
+	 * or refusing it are the two ways of giving it. "Payment transmitted" comes after, so it is not
+	 * part of what is offered at this point.
 	 *
 	 * @return void
 	 */
-	public function testNothingSentYetOffersEverySendableStatus()
+	public function testNothingSentYetOffersTheAnswerButNotThePayment()
 	{
 		$offered = $this->offered();
 
 		$this->assertContains(EInvoicing::STATUS_APPROVED, $offered);
 		$this->assertContains(EInvoicing::STATUS_REFUSED, $offered);
+		$this->assertNotContains(EInvoicing::STATUS_PAYMENT_SENT, $offered, 'nothing is paid before being accepted');
+	}
+
+	/**
+	 * A "Partially approved" accepted by the platform settles the answer just as an approval does: the
+	 * invoice is going to be paid, so the status reporting that payment becomes reachable.
+	 *
+	 * @return void
+	 */
+	public function testPartiallyApprovedAlsoOpensThePaymentStatus()
+	{
+		$this->sent(EInvoicing::STATUS_PARTIALLY_APPROVED);
+
+		$offered = $this->offered();
+
 		$this->assertContains(EInvoicing::STATUS_PAYMENT_SENT, $offered);
+		$this->assertNotContains(EInvoicing::STATUS_REFUSED, $offered, 'an accepted invoice cannot then be refused');
+	}
+
+	/**
+	 * An approval the platform has not confirmed yet settles nothing: it can still be rejected, and
+	 * until it is confirmed the invoice is in the same place as one nobody answered.
+	 *
+	 * @return void
+	 */
+	public function testAPendingApprovalDoesNotOpenThePaymentStatus()
+	{
+		$this->sent(EInvoicing::STATUS_APPROVED, 'Pending');
+
+		$offered = $this->offered();
+
+		$this->assertNotContains(EInvoicing::STATUS_PAYMENT_SENT, $offered);
+		$this->assertContains(EInvoicing::STATUS_APPROVED, $offered, 'the answer is still the thing to send');
+		$this->assertContains(EInvoicing::STATUS_REFUSED, $offered);
 	}
 
 	/**
@@ -187,5 +223,6 @@ class ReceivedInvoiceStatusesTest extends CommonClassTest
 
 		$this->assertContains(EInvoicing::STATUS_APPROVED, $offered);
 		$this->assertContains(EInvoicing::STATUS_REFUSED, $offered, 'nothing was accepted, so the choice is still open');
+		$this->assertNotContains(EInvoicing::STATUS_PAYMENT_SENT, $offered, 'a rejected approval leaves the invoice unanswered');
 	}
 }

--- a/einvoicing/test/phpunit/SupplierInvoiceHelperTest.php
+++ b/einvoicing/test/phpunit/SupplierInvoiceHelperTest.php
@@ -915,6 +915,40 @@ class SupplierInvoiceHelperTest extends CommonClassTest
 	}
 
 	/**
+	 * A draft is not in the accounts and cannot be paid, so "Payment transmitted" has nothing to
+	 * describe on it - even once the answer to the vendor has been given and accepted. Validating the
+	 * invoice is what makes the payment possible, and the status with it.
+	 *
+	 * @return void
+	 */
+	public function testADraftIsNeverOfferedThePaymentStatus()
+	{
+		global $db;
+
+		$invoice = $this->createSpecimenSupplierInvoice();
+		$this->addEInvoicingDocument($invoice->id);
+		// The answer is given and confirmed, so the draft state is the only thing left holding the
+		// payment status back.
+		$this->insertLifecycleMessageFixture($invoice->id, 'invoice_supplier', EInvoicing::STATUS_APPROVED, '', 'Ok');
+
+		$einvoicing = new EInvoicing($db);
+
+		$this->assertSame(FactureFournisseur::STATUS_DRAFT, (int) $invoice->status, 'initAsSpecimen() creates a draft');
+		$offered = array_map('intval', array_keys($einvoicing->getSendableStatusesForReceivedInvoice($invoice->id, 'invoice_supplier')));
+		$this->assertNotContains(EInvoicing::STATUS_PAYMENT_SENT, $offered, 'a draft has not been paid');
+
+		// Validate it the way the card does, without going through validate(): the reference and the
+		// triggers it fires are not what is being tested here, the status column is.
+		$sql = "UPDATE " . MAIN_DB_PREFIX . "facture_fourn";
+		$sql .= " SET fk_statut = " . (int) FactureFournisseur::STATUS_VALIDATED;
+		$sql .= " WHERE rowid = " . (int) $invoice->id;
+		$this->assertNotFalse($db->query($sql), (string) $db->lasterror());
+
+		$offered = array_map('intval', array_keys($einvoicing->getSendableStatusesForReceivedInvoice($invoice->id, 'invoice_supplier')));
+		$this->assertContains(EInvoicing::STATUS_PAYMENT_SENT, $offered, 'a validated and approved invoice is the one that gets paid');
+	}
+
+	/**
 	 * Build a reference no other row of the instance can carry, long enough and not purely numeric,
 	 * so the fixtures of the findIdByRef() tests never collide with real data.
 	 *


### PR DESCRIPTION
## Problem

On a supplier invoice received through the platform, the card offers the sendable lifecycle statuses
as one dropdown: "Approved by customer" (205), "Refused by customer" (210) and "Payment transmitted"
(211). All three were offered at once, from the moment the invoice was imported.

That is the lifecycle read backwards. A received invoice is first answered - approved or refused -
and only then paid. Offering 211 straight away lets a user announce the payment of an invoice
nobody has answered yet, and even of one still in draft: a draft is not in the accounts, cannot be
paid, and validating it is the very act of accepting it. The button also stayed offered while the
answer was still pending at the platform, or after the platform had rejected it - which is exactly
when an invoice looks stuck and that button is the most tempting.

## Fix

`EInvoicing::getSendableStatusesForReceivedInvoice()` now offers "Payment transmitted" only when:

- an approval - 205, or 206 "Partially approved" - has been **accepted** by the platform (a pending
  or rejected send settles nothing, and leaves the answer as the thing to send); and
- the Dolibarr invoice has left the draft state, read from the invoice object itself
  (`FactureFournisseur::fetch()` + `STATUS_DRAFT`).

Nothing else changes: an accepted status is still never offered twice, a confirmed refusal still
ends the exchange, and the credit note of a refused invoice is still restricted to a refusal.

The automatic sending is untouched, and already ran in that order: 205 on validation, 211 on
`BILL_SUPPLIER_PAYED`, which cannot fire on a draft.

| state of the invoice | offered before | offered now |
|---|---|---|
| draft, nothing sent | 205, 210, **211** | 205, 210 |
| draft, 205 pending | 205, 210, **211** | 205, 210 |
| draft, 205 rejected by the platform | 205, 210, **211** | 205, 210 |
| draft, 205 accepted | **211** | *(none)* |
| validated, nothing sent | 205, 210, **211** | 205, 210 |
| validated, 205 accepted | 211 | 211 |

## Tests

Run on Dolibarr 18 (the supported floor) and 24, on a bench instance with the module deployed:

- the whole PHPUnit suite of the module, file by file: **33 files, 0 failure on each of the two
  cores** (66 runs);
- 5 new or reinforced assertions in `ReceivedInvoiceStatusesTest` and `SupplierInvoiceHelperTest`
  (nothing sent, pending approval, approval rejected by the platform, partially approved, draft then
  validated). **All five fail on `main` and pass here**, on a tree carrying the new tests over the
  old classes;
- the table above measured on a real received supplier invoice (a `llx_einvoicing_extlinks` row),
  on both cores, before and after;
- the card itself loaded over HTTP with a real session on both cores: the dropdown links carry
  `pdpstatuscode=205,210` on the draft and `pdpstatuscode=211` once validated and approved, with no
  PHP error on the page.
