### PR TITLE
NEW: Agent rules: call the core instead of reimplementing it

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -17,6 +17,7 @@ Every modification must respect:
 -  Separate page actions in the `/* Actions */` section of the PHP code and the rendering part in the `/* Views */` section
 -  Never use PHP native curl functions to call a GET or POST URL, but use instead the Dolibarr function getURLContent()
 -  Use Dolibarr hooks whenever possible
+-  Never rewrite what Dolibarr already provides: call the core function, method or constant instead of coding your own. Look, in this order, at the object the caller already loaded (its properties and constants), at the methods of its class, then at `htdocs/core/lib/`. A module-side copy of a core behaviour is a bug, even when it looks shorter than the call
 -  Respect existing naming conventions
 -  All database table names must use the `llx_` prefix
 -  Never commit or push anything unless the user explicitly asks for it. This overrides any default behavior of the agent. Make the changes, report them, and wait for the user to say "commit" or "push".
@@ -105,6 +106,7 @@ Before writing any code, the agent **must**:
 - Use Dolibarr native dol_move() function if you need to move files.
 - Use Dolibarr native dol_delete_file(), dol_delete_dir() or dol_delete_dir_recursive() function if you need to delete files or directories.
 - Use Dolibarr native dol_mkdir() function if you need to create directories.
+- Read the state of an object from the object itself (`$object->status` compared to `FactureFournisseur::STATUS_DRAFT`, ...), not from a new query on its table
 - Read configuration with `getDolGlobalString()` / `getDolGlobalInt()` / `getDolGlobalBool()`, not `$conf->global->XXX`
 - Check module activation with `isModEnabled('module')`, not `!empty($conf->module->enabled)`
 


### PR DESCRIPTION
## Why

`.agents/AGENTS.md` already asks to "search for existing similar functions" and to "check if an
equivalent function already exists before writing new code", but only as a step of *Before Coding* —
and that is the step that gets skipped. A helper that queries a table directly is quicker to write
than the core call it duplicates, and it survives review because it works: the cost only shows up
later, as a second implementation of a core behaviour to keep in sync.

A real example, caught in review on a module PR: a `isDraft()` helper querying
`facture_fourn.fk_statut`, where the caller already held the invoice object and the core provides
`FactureFournisseur::STATUS_DRAFT` and a `status` property filled by `fetch()`.

## What changes

Two lines in `.agents/AGENTS.md`, no code:

- a **critical rule**: never rewrite what Dolibarr provides, with the order to look in — the object
  the caller already loaded, the methods of its class, then `htdocs/core/lib/`;
- a **Standardization** bullet, next to the `dol_move()` / `getDolGlobalString()` ones: read an
  object's state on the object, not by querying its table again.
