### PR TITLE
FIX einvoicing: name the platform in the CDAR send failure message

### DIFF
--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -1952,7 +1952,9 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 				$platformMessage = (string) (!empty($response['response']['message'])
 					? $response['response']['message']
 					: ($response['errorMessage'] ?? 'No message'));
-				$message = 'Failed to send CDAR file to PDP. Status code: ' . $response['status_code'] . '. Message: ' . $platformMessage;
+				// Name the platform that refused: this wording is identical in every provider, so a bug
+				// report quoting it alone never says which platform answered (issue #799).
+				$message = 'Failed to send CDAR file to ' . $this->name . '. Status code: ' . $response['status_code'] . '. Message: ' . $platformMessage;
 				// MDT-73 is the electronic address the status is sent to. The platform refuses the CDAR when
 				// it does not know the vendor under the address the module used, and says nothing about what
 				// to do next - while the received invoice stays impossible to approve or refuse, and so

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -3141,7 +3141,9 @@ class SuperPDPProvider extends AbstractPDPProvider
 				$platformMessage = (string) (!empty($response['response']['message'])
 					? $response['response']['message']
 					: ($response['errorMessage'] ?? 'No message'));
-				$message = 'Failed to send CDAR file to PDP. Status code: ' . $response['status_code'] . '. Message: ' . $platformMessage;
+				// Name the platform that refused: this wording is identical in every provider, so a bug
+				// report quoting it alone never says which platform answered (issue #799).
+				$message = 'Failed to send CDAR file to ' . $this->name . '. Status code: ' . $response['status_code'] . '. Message: ' . $platformMessage;
 				// MDT-73 is the electronic address the status is sent to. The platform refuses the CDAR when
 				// it does not know the vendor under the address the module used, and says nothing about what
 				// to do next - while the received invoice stays impossible to approve or refuse, and so


### PR DESCRIPTION
## Problem

When a lifecycle status (CDAR) is refused by the platform, the module shows:

```
Failed to send CDAR file to PDP. Status code: 400. Message: <the platform's own text>
```

That wording is byte-identical in `SuperPDPProvider` and `EsalinkPDPProvider` — and an external
module may ship a provider carrying the same copy, since `PDPProviderManager` accepts providers
declared by hooks. So a bug report quoting this message does not say which platform refused.

Issue #799 is the concrete case: the platform answered `400 - B2BInt invoices only support payment
received event`, and identifying which access point had answered took reading another issue opened
by the same reporter the same evening. The platform half of the message is the part that matters
for the diagnosis, and it is worthless without knowing who wrote it.

## Fix

The message now names the provider (`$this->name`, i.e. `SuperPDP` or `Esalink`):

```
Failed to send CDAR file to SuperPDP. Status code: 400. Message: <the platform's own text>
```

Nothing else changes: the platform's own text is still relayed verbatim, and the MDT-73 hint added
by #747 still applies on top of it.

## Tests

Bench, Dolibarr 18.0.x to 24.0.x, module on this branch:

- **Real platform refusal through the touched line**: sending a 210 "Refused" without a reason code
  on a received supplier invoice (Dolibarr 23.0.4) gets the expected
  `[BR-FR-CDV-15/MDT-113]` refusal from the access point, and the message now reads
  `Failed to send CDAR file to SuperPDP. Status code: 400. Message: [BR-FR-CDV-15/MDT-113] : ...`.
  The platform text is unchanged, and no lifecycle row is written on failure (unchanged behaviour).
- **PHPUnit**: green on Dolibarr 18, 19, 20, 21, 22, 23 and 24 (33/33 files each).
- The `EsalinkPDPProvider` line is the identical edit and its `$name` is set the same way, but it
  was not exercised live (no Esalink account on the bench).
