### PR TITLE
NEW [einvoicing] Export the selected flows or API calls for support

### DIFF
--- a/einvoicing/call_list.php
+++ b/einvoicing/call_list.php
@@ -258,6 +258,29 @@ if (empty($reshook)) {
 
 	// You can add more action here
 	// if ($action == 'xxx' && $permissiontoxxx) ...
+
+	// Mass action of the module: pack the selection into one archive a maintainer can read without
+	// walking the user through four screens (issue #799). The archive is built by a class of its
+	// own, because page code cannot be exercised by PHPUnit and the redaction it performs has to be
+	// covered by a test; the page only reads the selection and hands the file over.
+	if (empty($error) && ($massaction == 'supportexport' || ($action == 'supportexport' && $confirm == 'yes')) && $permissiontoread) {
+		dol_include_once('einvoicing/class/utils/SupportExport.class.php');
+
+		$supportexport = new SupportExport($db);
+		$supportarchive = $supportexport->build(SupportExport::TYPE_CALL, $toselect, $diroutputmassaction);
+
+		if ($supportarchive == '') {
+			setEventMessages($supportexport->error, null, 'errors');
+			$massaction = '';
+			$action = 'list';
+		} else {
+			// Nothing has been printed yet at this point of the page, so the archive can be sent
+			// as the answer to this very request.
+			SupportExport::deliver($supportarchive);
+			$db->close();
+			exit;
+		}
+	}
 }
 
 
@@ -521,10 +544,13 @@ $arrayofmassactions = array(
 	//'builddoc'=>img_picto('', 'pdf', 'class="pictofixedwidth"').$langs->trans("PDFMerge"),
 	//'presend'=>img_picto('', 'email', 'class="pictofixedwidth"').$langs->trans("SendByMail"),
 );
+if (!empty($permissiontoread)) {
+	$arrayofmassactions['presupportexport'] = img_picto('', 'download', 'class="pictofixedwidth"').$langs->trans("EInvoicingSupportExport");
+}
 if (!empty($permissiontodelete)) {
 	$arrayofmassactions['predelete'] = img_picto('', 'delete', 'class="pictofixedwidth"').$langs->trans("Delete");
 }
-if (GETPOSTINT('nomassaction') || in_array($massaction, array('presend', 'predelete'))) {
+if (GETPOSTINT('nomassaction') || in_array($massaction, array('presend', 'predelete', 'presupportexport'))) {
 	$arrayofmassactions = array();
 }
 $massactionbutton = $form->selectMassAction('', $arrayofmassactions);
@@ -562,6 +588,14 @@ $modelmail = "call";
 $objecttmp = new Call($db);
 $trackid = 'xxxx'.$object->id;
 include DOL_DOCUMENT_ROOT.'/core/tpl/massactions_pre.tpl.php';
+
+// Confirmation of the support export, in the shape the core uses for its own mass actions: no ajax
+// and no form tag of its own, so that the buttons submit the list form and the selection survives.
+// The ajax variant jumps to a GET url instead, which would drop toselect[].
+if ($massaction == 'presupportexport') {
+	$formquestion = array('text' => $langs->trans("EInvoicingSupportExportPrivacy"));
+	print $form->formconfirm($_SERVER["PHP_SELF"], $langs->trans("EInvoicingSupportExport"), $langs->trans("EInvoicingSupportExportQuestion", count($toselect)), "supportexport", $formquestion, '', 0, 250, 500, 1);
+}
 
 if ($search_all) {
 	$setupstring = '';

--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -922,10 +922,14 @@ abstract class AbstractPDPProvider
 	 * persisted in the API call log, whatever its shape: PHP array, application/x-www-form-urlencoded
 	 * string (OAuth token requests), JSON string, or plain text (left untouched in that last case).
 	 *
+	 * Public because the redaction has a second caller outside the write path: SupportExport
+	 * replays it on everything it puts in a support archive, so that rows written before this
+	 * method existed do not carry their tokens out of the instance.
+	 *
 	 * @param  array<mixed>|string|null $value Value to redact
 	 * @return array<mixed>|string|null Redacted value, same shape as the input
 	 */
-	private static function redactSensitiveData($value)
+	public static function redactSensitiveData($value)
 	{
 		if (is_array($value)) {
 			$redacted = array();

--- a/einvoicing/class/utils/SupportExport.class.php
+++ b/einvoicing/class/utils/SupportExport.class.php
@@ -1,0 +1,521 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    einvoicing/class/utils/SupportExport.class.php
+ * \ingroup einvoicing
+ * \brief   Build the archive a maintainer needs to instruct a platform refusal.
+ */
+
+dol_include_once('einvoicing/class/document.class.php');
+dol_include_once('einvoicing/class/call.class.php');
+dol_include_once('einvoicing/class/providers/AbstractPDPProvider.class.php');
+dol_include_once('einvoicing/lib/einvoicing.lib.php');
+require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
+
+
+/**
+ * Build a support archive out of a selection of flows (llx_einvoicing_document) or of API calls
+ * (llx_einvoicing_call).
+ *
+ * Diagnosing a refusal today means walking the user through four screens - the flow, the API call,
+ * the setup constants, the versions - and having them turn an option on, because the two most
+ * useful columns (llx_einvoicing_call.response and llx_einvoicing_document.response_for_debug) are
+ * only written when EINVOICING_DEBUG_MODE is set. This class packs all of that into one file.
+ *
+ * It lives apart from the two list pages on purpose: page code cannot be exercised by PHPUnit, and
+ * the redaction this class performs is exactly what has to be covered by a test.
+ */
+class SupportExport
+{
+	/** Export of rows of llx_einvoicing_document (the synchronization list). */
+	const TYPE_FLOW = 'flow';
+
+	/** Export of rows of llx_einvoicing_call (the API call log). */
+	const TYPE_CALL = 'call';
+
+	/**
+	 * Records one archive may carry, unless EINVOICING_SUPPORT_EXPORT_MAX says otherwise.
+	 *
+	 * An e-invoice XML weighs 100 to 200 kB, so this default already builds an archive of some
+	 * 10 MB. Going much further is how a support export turns into a timeout or into a memory
+	 * limit reached, which is a far worse answer than being told the selection is too wide.
+	 */
+	const DEFAULT_MAX_RECORDS = 50;
+
+	/**
+	 * Fragments of constant name whose VALUE never leaves the instance: the manifest only says
+	 * whether such a constant is set. Matched anywhere in the name, so the OAuth tokens the module
+	 * stores as <PREFIX>_PROD_TOKEN / _REFRESH are covered as well as the credentials of the setup
+	 * page (EINVOICING_SUPERPDP_CLIENT_SECRET, EINVOICING_ESALINK_PASSWORD, ...).
+	 *
+	 * @var string[]
+	 */
+	const SENSITIVE_CONST_FRAGMENTS = array('SECRET', 'TOKEN', 'REFRESH', 'PASSWORD', 'PASSWD', 'CLIENT_ID', 'API_KEY', 'CREDENTIAL', 'PRIVATE');
+
+	/** Value written in the manifest in place of a secret that is set. */
+	const CONST_SET = '[SET, NOT EXPORTED]';
+
+	/** Value written in the manifest in place of a secret that is not set. */
+	const CONST_NOT_SET = '[NOT SET]';
+
+	/** @var DoliDB Database handler */
+	private $db;
+
+	/** @var string Error message of the last failed build() */
+	public $error = '';
+
+	/**
+	 * Counters of the last build(), for the message shown to the user.
+	 *
+	 * @var array{requested:int,exported:int,skipped:int,files:int,size:int}
+	 */
+	public $report = array('requested' => 0, 'exported' => 0, 'skipped' => 0, 'files' => 0, 'size' => 0);
+
+	/**
+	 * Constructor
+	 *
+	 * @param DoliDB $db Database handler
+	 */
+	public function __construct($db)
+	{
+		$this->db = $db;
+	}
+
+	/**
+	 * Number of records one export may carry.
+	 *
+	 * @return int Always at least 1
+	 */
+	public static function maxRecords()
+	{
+		$max = getDolGlobalInt('EINVOICING_SUPPORT_EXPORT_MAX', self::DEFAULT_MAX_RECORDS);
+
+		return ($max > 0 ? $max : self::DEFAULT_MAX_RECORDS);
+	}
+
+	/**
+	 * Build the archive of a selection.
+	 *
+	 * @param	string		$type		self::TYPE_FLOW or self::TYPE_CALL
+	 * @param	int[]		$ids		Rowids of the selected records
+	 * @param	string		$destdir	Directory the archive is written into (created if needed)
+	 * @return	string					Full path of the archive, '' when nothing could be built
+	 */
+	public function build($type, $ids, $destdir)
+	{
+		global $conf, $langs, $errormsg;
+
+		// The two module messages, plus the ones dol_compress_dir() and dol_mkdir() answer with.
+		$langs->loadLangs(array('errors', 'einvoicing@einvoicing'));
+
+		$this->error = '';
+		$this->report = array('requested' => count($ids), 'exported' => 0, 'skipped' => 0, 'files' => 0, 'size' => 0);
+
+		if (!in_array($type, array(self::TYPE_FLOW, self::TYPE_CALL), true)) {
+			$this->error = 'Unsupported export type '.$type;
+			return '';
+		}
+		if (empty($ids)) {
+			$this->error = $langs->trans('NoRecordSelected');
+			return '';
+		}
+		// ZipArchive is a PHP extension, not something the module can require: say so plainly
+		// rather than letting dol_compress_dir() answer "no handler found".
+		if (!class_exists('ZipArchive')) {
+			$this->error = $langs->trans('EInvoicingSupportExportNoZip');
+			return '';
+		}
+		if (count($ids) > self::maxRecords()) {
+			$this->error = $langs->trans('EInvoicingSupportExportTooMany', count($ids), self::maxRecords());
+			return '';
+		}
+
+		$stamp = dol_print_date(dol_now(), '%Y%m%d-%H%M%S', 'tzuser');
+		$basename = 'einvoicing-support-'.((int) $conf->entity).'-'.$stamp;
+
+		if (dol_mkdir($destdir) < 0) {
+			$this->error = $langs->trans('ErrorFailedToCreateDir', $destdir);
+			return '';
+		}
+		// The archive is built from a directory, so the content is staged next to it and removed
+		// as soon as dol_compress_dir() has read it.
+		$stagingdir = $destdir.'/'.$basename.'.build';
+		if (dol_mkdir($stagingdir) < 0) {
+			$this->error = $langs->trans('ErrorFailedToCreateDir', $stagingdir);
+			return '';
+		}
+
+		$records = ($type == self::TYPE_FLOW ? $this->stageFlows($ids, $stagingdir) : $this->stageCalls($ids, $stagingdir));
+
+		$this->writeFile($stagingdir.'/manifest.json', $this->encodeJson($this->manifest($type, $records)));
+
+		$zipfile = $destdir.'/'.$basename.'.zip';
+		$res = dol_compress_dir($stagingdir, $zipfile, 'zip');
+
+		dol_delete_dir_recursive($stagingdir);
+
+		if ($res <= 0) {
+			$this->error = (empty($errormsg) ? $langs->trans('ErrorFailedToBuildArchive', $zipfile) : $errormsg);
+			return '';
+		}
+
+		$this->report['size'] = (int) dol_filesize($zipfile);
+
+		return $zipfile;
+	}
+
+	/**
+	 * Send the archive to the browser, then remove it from the server.
+	 *
+	 * Handing the file over straight away rather than leaving it for the "generated documents" box
+	 * of the list is deliberate. That box downloads through document.php with the modulepart
+	 * massfilesarea_einvoicing, and dol_check_secure_access_document() grants that modulepart on
+	 * hasRight(<module>, 'lire') up to Dolibarr 21 (it moved to 'read' in 22): the module declares
+	 * 'read', like every module builder module, so the link would answer "access forbidden" on the
+	 * whole lower half of the supported range. Deleting the file afterwards also keeps archives
+	 * full of invoice XML - names, addresses, contact details - from piling up in the temporary
+	 * area of the instance.
+	 *
+	 * Headers are sent here, so the caller must have written nothing yet and must exit right after.
+	 *
+	 * @param	string	$zipfile	Archive returned by build()
+	 * @return	void
+	 */
+	public static function deliver($zipfile)
+	{
+		top_httphead('application/zip');
+		header('Content-Disposition: attachment; filename="'.basename($zipfile).'"');
+		header('Content-Length: '.dol_filesize($zipfile));
+
+		readfile($zipfile);
+
+		dol_delete_file($zipfile, 0, 1);
+	}
+
+	/**
+	 * Context of the export: everything needed to read the rest of the archive without asking the
+	 * user a single further question - which core, which module build, which platform, which
+	 * entity, and whether the debug columns could have been written at all.
+	 *
+	 * @param	string					$type		self::TYPE_FLOW or self::TYPE_CALL
+	 * @param	array<int,string>		$records	Identifiers of the records actually exported
+	 * @return	array<string,mixed>					Content of manifest.json
+	 * @phan-suppress PhanPluginMoreSpecificActualReturnType
+	 *  MoreSpecificElementTypePlugin asks the documented type to repeat the union of the literal
+	 *  value types of this very array, which would have to be rewritten at every added field.
+	 */
+	public function manifest($type, $records = array())
+	{
+		global $conf;
+
+		return array(
+			'export_type' => $type,
+			'generated_at' => dol_print_date(dol_now(), 'standard', 'gmt').' GMT',
+			'dolibarr_version' => DOL_VERSION,
+			'einvoicing_version' => einvoicingModuleStamp(),
+			'php_version' => PHP_VERSION,
+			'entity' => (int) $conf->entity,
+			'provider' => getDolGlobalString('EINVOICING_PDP'),
+			'protocol' => getDolGlobalString('EINVOICING_PROTOCOL'),
+			// Without this flag a reader cannot tell an API call that answered nothing from a call
+			// whose answer was simply never stored.
+			// The providers gate the two debug columns on getDolGlobalString(), so read it the
+			// same way rather than answering something the write path would not agree with.
+			'debug_mode' => (getDolGlobalString('EINVOICING_DEBUG_MODE') ? true : false),
+			'requested_count' => $this->report['requested'],
+			'exported_count' => $this->report['exported'],
+			'skipped_count' => $this->report['skipped'],
+			'records' => array_values($records),
+			'constants' => self::exportedConstants(),
+		);
+	}
+
+	/**
+	 * The EINVOICING_* constants of the current entity, secrets replaced by whether they are set.
+	 *
+	 * Read from $conf->global rather than from llx_const: that is the very object the module reads
+	 * its options from, so the manifest shows what the code saw, entity resolution and decryption
+	 * (dolDecrypt) included - which is also why the values have to be filtered here.
+	 *
+	 * @return array<string,string> Constant name => value or placeholder, sorted by name
+	 * @phan-suppress PhanPluginMoreSpecificActualReturnType
+	 *  MoreSpecificElementTypePlugin reads the array as non-empty because it is filled in a loop.
+	 *  It is empty when nothing matched, and callers have to keep handling that.
+	 */
+	public static function exportedConstants()
+	{
+		global $conf;
+
+		$out = array();
+		foreach ((array) $conf->global as $name => $value) {
+			if (strpos($name, 'EINVOICING') !== 0) {
+				continue;
+			}
+			if (self::isSensitiveConstant($name)) {
+				$out[$name] = (($value === '' || $value === null) ? self::CONST_NOT_SET : self::CONST_SET);
+				continue;
+			}
+			$out[$name] = (string) $value;
+		}
+		ksort($out);
+
+		return $out;
+	}
+
+	/**
+	 * Whether the value of a constant must stay on the instance.
+	 *
+	 * @param	string	$name	Constant name
+	 * @return	bool			True when only the "set / not set" state may be exported
+	 */
+	public static function isSensitiveConstant($name)
+	{
+		foreach (self::SENSITIVE_CONST_FRAGMENTS as $fragment) {
+			if (strpos($name, $fragment) !== false) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Write the selected flows under flows/<identifier>/.
+	 *
+	 * @param	int[]				$ids		Rowids of the selected flows
+	 * @param	string				$stagingdir	Directory being staged
+	 * @return	array<int,string>				Identifier of each exported flow
+	 * @phan-suppress PhanPluginMoreSpecificActualReturnType
+	 *  MoreSpecificElementTypePlugin reads the array as non-empty because it is filled in a loop.
+	 *  It is empty when nothing matched, and callers have to keep handling that.
+	 */
+	private function stageFlows($ids, $stagingdir)
+	{
+		$records = array();
+		$reachable = $this->reachableIds(new Document($this->db), $ids);
+
+		foreach ($reachable as $id) {
+			$flow = new Document($this->db);
+			if ($flow->fetch($id) <= 0) {
+				$this->report['skipped']++;
+				continue;
+			}
+
+			$identifier = $this->identifierOf($flow, 'flow_id');
+			$dir = $stagingdir.'/flows/'.$identifier;
+			dol_mkdir($dir);
+
+			// The bodies go to files of their own: they are what a maintainer opens in an editor,
+			// and an XML escaped inside a JSON string is unreadable.
+			$this->writeFile($dir.'/flow.json', $this->encodeJson($this->rowOf($flow, array('document_body', 'xml_data', 'response_for_debug'))));
+
+			$xml = (empty($flow->document_body) ? $flow->xml_data : $flow->document_body);
+			if (!empty($xml)) {
+				$this->writeFile($dir.'/document.xml', self::redact($xml));
+			}
+			if (!empty($flow->response_for_debug)) {
+				$this->writeFile($dir.'/metadata.json', self::redact($flow->response_for_debug));
+			}
+
+			$this->report['exported']++;
+			$records[] = $identifier;
+		}
+
+		return $records;
+	}
+
+	/**
+	 * Write the selected API calls under calls/<identifier>/.
+	 *
+	 * @param	int[]				$ids		Rowids of the selected calls
+	 * @param	string				$stagingdir	Directory being staged
+	 * @return	array<int,string>				Identifier of each exported call
+	 * @phan-suppress PhanPluginMoreSpecificActualReturnType
+	 *  MoreSpecificElementTypePlugin reads the array as non-empty because it is filled in a loop.
+	 *  It is empty when nothing matched, and callers have to keep handling that.
+	 */
+	private function stageCalls($ids, $stagingdir)
+	{
+		$records = array();
+		$reachable = $this->reachableIds(new Call($this->db), $ids);
+
+		foreach ($reachable as $id) {
+			$call = new Call($this->db);
+			if ($call->fetch($id) <= 0) {
+				$this->report['skipped']++;
+				continue;
+			}
+
+			$identifier = $this->identifierOf($call, 'call_id');
+			$dir = $stagingdir.'/calls/'.$identifier;
+			dol_mkdir($dir);
+
+			// Request and response stay in the row here: they are short enough to read in place,
+			// and keeping them together is what makes a call log readable.
+			$this->writeFile($dir.'/call.json', $this->encodeJson($this->rowOf($call, array())));
+
+			$this->report['exported']++;
+			$records[] = $identifier;
+		}
+
+		return $records;
+	}
+
+	/**
+	 * Keep, of the posted selection, the rows the current entity may read.
+	 *
+	 * The filter has to be a query of its own: fetch() answers on the rowid alone, and the entity
+	 * column never even reaches the object, because CommonObject::getFieldList() leaves it out of
+	 * the SELECT it builds (checked on Dolibarr 18 and 24). So an export driven by ids posted in a
+	 * form is filtered here, on getEntity(), exactly the way the two list pages filter their own
+	 * query. Anything dropped is counted as skipped, and the manifest says so.
+	 *
+	 * @param	Document|Call	$object		An instance of the class being exported, for its table
+	 * @param	int[]			$ids		Rowids as they were posted
+	 * @return	int[]						Rowids that exist and are within reach, in ascending order
+	 */
+	private function reachableIds($object, $ids)
+	{
+		$wanted = array();
+		foreach ($ids as $id) {
+			if ((int) $id > 0) {
+				$wanted[(int) $id] = (int) $id;
+			}
+		}
+		if (empty($wanted)) {
+			$this->report['skipped'] += count($ids);
+			return array();
+		}
+
+		$sql = "SELECT rowid FROM ".$this->db->prefix().$object->table_element;
+		$sql .= " WHERE rowid IN (".$this->db->sanitize(implode(',', $wanted)).")";
+		$sql .= " AND entity IN (".getEntity($object->element).")";
+
+		$resql = $this->db->query($sql);
+		if (!$resql) {
+			dol_syslog(__METHOD__.' '.$this->db->lasterror(), LOG_ERR);
+			$this->report['skipped'] += count($wanted);
+			return array();
+		}
+
+		$reachable = array();
+		while ($obj = $this->db->fetch_object($resql)) {
+			$reachable[] = (int) $obj->rowid;
+		}
+		$this->db->free($resql);
+
+		$this->report['skipped'] += (count($ids) - count($reachable));
+
+		return $reachable;
+	}
+
+	/**
+	 * Name of the directory holding one record: its functional identifier when it has one, its
+	 * rowid otherwise. A flow that never reached the platform has no flow_id.
+	 *
+	 * @param	Document|Call	$object		Record being exported
+	 * @param	string			$property	Property holding the functional identifier
+	 * @return	string						A file name, safe to use as a directory name
+	 */
+	private function identifierOf($object, $property)
+	{
+		$identifier = (empty($object->$property) ? (string) $object->id : (string) $object->$property);
+
+		return dol_sanitizeFileName($identifier);
+	}
+
+	/**
+	 * The columns of a record, read from the field definition of its class so the export follows
+	 * the class rather than a list copied by hand, redacted, and with the bodies left out.
+	 *
+	 * @param	Document|Call		$object		Record read back from the database
+	 * @param	string[]			$except		Properties written to files of their own
+	 * @return	array<string,mixed>				Row ready to be encoded
+	 * @phan-suppress PhanPluginMoreSpecificActualReturnType
+	 *  MoreSpecificElementTypePlugin asks the documented type to repeat the union of the literal
+	 *  value types of this very array, which would have to be rewritten at every added field.
+	 */
+	private function rowOf($object, $except)
+	{
+		$row = array('rowid' => (int) $object->id);
+
+		foreach (array_keys($object->fields) as $field) {
+			// 'entity' is skipped, not forgotten: CommonObject::getFieldList() leaves it out of the
+			// SELECT of fetch(), so the property is always null here and writing it would only say
+			// something false. The entity of the export is named once, in the manifest.
+			if ($field == 'rowid' || $field == 'entity' || in_array($field, $except, true)) {
+				continue;
+			}
+			$value = (isset($object->$field) ? $object->$field : null);
+
+			// Dates come back from fetch() as unix timestamps. An archive that is read by a person
+			// says them in full, and the class already knows which columns are dates.
+			if ($object->isDate($object->fields[$field])) {
+				$row[$field] = (empty($value) ? null : dol_print_date($value, 'standard', 'gmt').' GMT');
+				continue;
+			}
+			if (is_int($value) || is_float($value) || is_bool($value) || is_null($value)) {
+				$row[$field] = $value;
+				continue;
+			}
+			$row[$field] = self::redact((string) $value);
+		}
+
+		return $row;
+	}
+
+	/**
+	 * Redact the credentials of a value on its way out.
+	 *
+	 * The call log is already written redacted (AbstractPDPProvider::logCall()), so this is
+	 * defence in depth: rows written before that redaction existed still hold what the platform
+	 * answered, tokens included, and this export is precisely what would take them out of the
+	 * instance.
+	 *
+	 * @param	string	$value	Value about to be written into the archive
+	 * @return	string			Same value, credentials replaced
+	 */
+	public static function redact($value)
+	{
+		$redacted = AbstractPDPProvider::redactSensitiveData($value);
+
+		return (is_string($redacted) ? $redacted : (string) json_encode($redacted));
+	}
+
+	/**
+	 * @param	array<string,mixed>	$data	Data to encode
+	 * @return	string						Pretty printed JSON, readable in a text editor
+	 */
+	private function encodeJson($data)
+	{
+		return (string) json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+	}
+
+	/**
+	 * @param	string	$path		File to write
+	 * @param	string	$content	Its content
+	 * @return	void
+	 */
+	private function writeFile($path, $content)
+	{
+		if (file_put_contents($path, $content) !== false) {
+			$this->report['files']++;
+			dolChmod($path);
+		}
+	}
+}

--- a/einvoicing/document_list.php
+++ b/einvoicing/document_list.php
@@ -329,6 +329,29 @@ if (empty($reshook)) {
 
 	// You can add more action here
 	// if ($action == 'xxx' && $permissiontoxxx) ...
+
+	// Mass action of the module: pack the selection into one archive a maintainer can read without
+	// walking the user through four screens (issue #799). The archive is built by a class of its
+	// own, because page code cannot be exercised by PHPUnit and the redaction it performs has to be
+	// covered by a test; the page only reads the selection and hands the file over.
+	if (empty($error) && ($massaction == 'supportexport' || ($action == 'supportexport' && $confirm == 'yes')) && $permissiontoread) {
+		dol_include_once('einvoicing/class/utils/SupportExport.class.php');
+
+		$supportexport = new SupportExport($db);
+		$supportarchive = $supportexport->build(SupportExport::TYPE_FLOW, $toselect, $diroutputmassaction);
+
+		if ($supportarchive == '') {
+			setEventMessages($supportexport->error, null, 'errors');
+			$massaction = '';
+			$action = 'list';
+		} else {
+			// Nothing has been printed yet at this point of the page, so the archive can be sent
+			// as the answer to this very request.
+			SupportExport::deliver($supportarchive);
+			$db->close();
+			exit;
+		}
+	}
 }
 
 
@@ -674,10 +697,13 @@ $arrayofmassactions = array(
 	//'builddoc'=>img_picto('', 'pdf', 'class="pictofixedwidth"').$langs->trans("PDFMerge"),
 	//'presend'=>img_picto('', 'email', 'class="pictofixedwidth"').$langs->trans("SendByMail"),
 );
+if (!empty($permissiontoread)) {
+	$arrayofmassactions['presupportexport'] = img_picto('', 'download', 'class="pictofixedwidth"').$langs->trans("EInvoicingSupportExport");
+}
 if (!empty($permissiontodelete)) {
 	$arrayofmassactions['predelete'] = img_picto('', 'delete', 'class="pictofixedwidth"').$langs->trans("Delete");
 }
-if (GETPOSTINT('nomassaction') || in_array($massaction, array('presend', 'predelete'))) {
+if (GETPOSTINT('nomassaction') || in_array($massaction, array('presend', 'predelete', 'presupportexport'))) {
 	$arrayofmassactions = array();
 }
 $massactionbutton = $form->selectMassAction('', $arrayofmassactions);
@@ -725,6 +751,14 @@ $modelmail = "document";
 $objecttmp = new Document($db);
 $trackid = 'xxxx'.$object->id;
 include DOL_DOCUMENT_ROOT.'/core/tpl/massactions_pre.tpl.php';
+
+// Confirmation of the support export, in the shape the core uses for its own mass actions: no ajax
+// and no form tag of its own, so that the buttons submit the list form and the selection survives.
+// The ajax variant jumps to a GET url instead, which would drop toselect[].
+if ($massaction == 'presupportexport') {
+	$formquestion = array('text' => $langs->trans("EInvoicingSupportExportPrivacy"));
+	print $form->formconfirm($_SERVER["PHP_SELF"], $langs->trans("EInvoicingSupportExport"), $langs->trans("EInvoicingSupportExportQuestion", count($toselect)), "supportexport", $formquestion, '', 0, 250, 500, 1);
+}
 
 if ($search_all) {
 	$setupstring = '';

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -679,8 +679,8 @@ ProxyRedirectDomainsNotSetDetail=The proxy page (einvoicing/public/proxy_oauthca
 ProxyRedirectDomainsGoToOtherSetup=Set the constant in Home - Setup - Other
 
 # Support export (mass action of the flow list and of the API call log)
-EInvoicingSupportExport=Export for support
-EInvoicingSupportExportQuestion=Build one archive out of the %s selected record(s), to be sent to support?
+EInvoicingSupportExport=Export in a zip archive
+EInvoicingSupportExportQuestion=Build one archive out of the %s selected record(s)?
 EInvoicingSupportExportPrivacy=The archive holds the selected records as they are stored, the e-invoice XML included, so it carries the names, addresses, e-mail addresses and phone numbers they contain. Credentials, tokens and passwords are removed. Read it before sending it to anyone.
 EInvoicingSupportExportNoZip=No support archive can be built: this PHP installation has no ZipArchive extension.
 EInvoicingSupportExportTooMany=Too many records selected for a support export: %s selected, %s at most. Narrow the selection, or raise the constant EINVOICING_SUPPORT_EXPORT_MAX.

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -677,3 +677,10 @@ EInvoicingInfoManagedByMasterSetup=The einvoicing setup is managed by the master
 ProxyRedirectDomainsNotSet=Security: this instance is an OAuth proxy and accepts any redirect destination
 ProxyRedirectDomainsNotSetDetail=The proxy page (einvoicing/public/proxy_oauthcallback.php) answers without authentication and sends the OAuth access token and refresh token to the address the caller asks for. As long as the constant EINVOICING_SUPERPDPVIAPARTNER_ONLY_DOMAIN is empty, every address is accepted, so anyone can have the tokens of an Access Point account delivered to a server of their own. Set that constant to the comma separated list of the domains of your customer instances, for example mycustomerdomain.com,anotherdomain.com. A future version will refuse every redirect while the list is empty.
 ProxyRedirectDomainsGoToOtherSetup=Set the constant in Home - Setup - Other
+
+# Support export (mass action of the flow list and of the API call log)
+EInvoicingSupportExport=Export for support
+EInvoicingSupportExportQuestion=Build one archive out of the %s selected record(s), to be sent to support?
+EInvoicingSupportExportPrivacy=The archive holds the selected records as they are stored, the e-invoice XML included, so it carries the names, addresses, e-mail addresses and phone numbers they contain. Credentials, tokens and passwords are removed. Read it before sending it to anyone.
+EInvoicingSupportExportNoZip=No support archive can be built: this PHP installation has no ZipArchive extension.
+EInvoicingSupportExportTooMany=Too many records selected for a support export: %s selected, %s at most. Narrow the selection, or raise the constant EINVOICING_SUPPORT_EXPORT_MAX.

--- a/einvoicing/test/phpunit/AllTests.php
+++ b/einvoicing/test/phpunit/AllTests.php
@@ -151,6 +151,8 @@ class AllTests
 		$suite->addTestSuite('SkipB2CPrecheckTest');
 		require_once dirname(__FILE__).'/StatusComboMarkupTest.php';
 		$suite->addTestSuite('StatusComboMarkupTest');
+		require_once dirname(__FILE__).'/SupportExportTest.php';
+		$suite->addTestSuite('SupportExportTest');
 		require_once dirname(__FILE__).'/SupplierInvoiceHelperTest.php';
 		$suite->addTestSuite('SupplierInvoiceHelperTest');
 		require_once dirname(__FILE__).'/TransmittedLockTest.php';

--- a/einvoicing/test/phpunit/SupportExportTest.php
+++ b/einvoicing/test/phpunit/SupportExportTest.php
@@ -1,0 +1,343 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/SupportExportTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for the "Export for support" mass action of the flow list and of the
+ *                  API call log. What has to hold whatever else changes: an archive built to be sent
+ *                  to a maintainer carries no credential, and its manifest alone says which core,
+ *                  which module build, which platform and which entity it was taken from - debug
+ *                  mode included, without which an empty response cannot be told from a response
+ *                  that was never stored.
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+// See SupplierInvoiceHelperTest.php for why DOLIBARR_HTDOCS is honoured before the relative path.
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+dol_include_once('einvoicing/class/utils/SupportExport.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+if (empty($user->id)) {
+	print "Load permissions for admin user nb 1\n";
+	$user->fetch(1);
+	// User::loadRights() only exists from Dolibarr 19 on, older versions name it getrights()
+	if (method_exists($user, 'loadRights')) {
+		$user->loadRights();
+	} else {
+		$user->getrights();
+	}
+}
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class SupportExportTest extends CommonClassTest
+{
+	/** @var string Directory the archives of the run are written into */
+	private $destdir;
+
+	/**
+	 * Give each test a directory of its own, outside the mass generation area of a real user.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void
+	{
+		global $conf;
+
+		parent::setUp();
+
+		$this->destdir = $conf->einvoicing->dir_output . '/temp/phpunit-supportexport-' . getmypid();
+		dol_mkdir($this->destdir);
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void
+	{
+		if (!empty($this->destdir) && dol_is_dir($this->destdir)) {
+			dol_delete_dir_recursive($this->destdir);
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Insert a row in the API call log, the way AbstractPDPProvider::logCall() does but WITHOUT its
+	 * redaction, which is the whole point: this is what a row written before that redaction existed
+	 * looks like, and such rows are still in the log of every instance updated since.
+	 *
+	 * @param	string	$requestBody	Value of the request_body column
+	 * @param	string	$response		Value of the response column
+	 * @return	int						Rowid of the inserted call
+	 */
+	private function insertCall($requestBody, $response)
+	{
+		global $conf, $db;
+
+		$now = $db->idate(dol_now());
+
+		$sql = "INSERT INTO " . MAIN_DB_PREFIX . "einvoicing_call";
+		$sql .= " (entity, call_id, provider, call_type, method, endpoint, request_body, response,";
+		$sql .= " status, skippedflow, successflow, totalflow, batchlimit, date_creation, fk_user_creat)";
+		$sql .= " VALUES (" . ((int) $conf->entity) . ", 'PHPUNIT-" . uniqid() . "', 'PHPUNIT', 'OAuth', 'POST',";
+		$sql .= " '/oauth/token', '" . $db->escape($requestBody) . "', '" . $db->escape($response) . "',";
+		$sql .= " 0, 0, 0, 0, 0, '" . $now . "', 1)";
+
+		$this->assertNotFalse($db->query($sql), (string) $db->lasterror());
+
+		return (int) $db->last_insert_id(MAIN_DB_PREFIX . 'einvoicing_call');
+	}
+
+	/**
+	 * Insert a flow row.
+	 *
+	 * @param	string	$documentBody	Value of the document_body column, '' for a flow that carries none
+	 * @return	int						Rowid of the inserted flow
+	 */
+	private function insertFlow($documentBody)
+	{
+		global $conf, $db;
+
+		$now = $db->idate(dol_now());
+
+		$sql = "INSERT INTO " . MAIN_DB_PREFIX . "einvoicing_document";
+		$sql .= " (entity, provider, flow_id, flow_type, flow_direction, document_body, submittedat, date_creation, fk_user_creat, status)";
+		$sql .= " VALUES (" . ((int) $conf->entity) . ", 'PHPUNIT', 'PHPUNIT-" . uniqid() . "', 'CustomerInvoice', 'Out',";
+		$sql .= " '" . $db->escape($documentBody) . "', '" . $now . "', '" . $now . "', 1, 0)";
+
+		$this->assertNotFalse($db->query($sql), (string) $db->lasterror());
+
+		return (int) $db->last_insert_id(MAIN_DB_PREFIX . 'einvoicing_document');
+	}
+
+	/**
+	 * Read an archive back as a map "entry name => content", so a test can assert on the shape of
+	 * the archive and on every byte it carries at once.
+	 *
+	 * @param	string					$zipfile	Archive built by SupportExport::build()
+	 * @return	array<string,string>				Content of each entry
+	 */
+	private function readArchive($zipfile)
+	{
+		$this->assertNotSame('', $zipfile, 'No archive was built');
+		$this->assertFileExists($zipfile);
+
+		$zip = new ZipArchive();
+		$this->assertTrue($zip->open($zipfile) === true, 'The archive could not be reopened');
+
+		$entries = array();
+		for ($i = 0; $i < $zip->numFiles; $i++) {
+			$name = $zip->getNameIndex($i);
+			$entries[$name] = (string) $zip->getFromIndex($i);
+		}
+		$zip->close();
+
+		return $entries;
+	}
+
+	/**
+	 * A token and a client secret left in an old row of the call log must not come out of the
+	 * archive, in any of its files.
+	 *
+	 * @return void
+	 */
+	public function testCredentialsOfAnOldCallLogRowDoNotLeaveTheInstance()
+	{
+		global $db;
+
+		$token = 'phpunit-access-token-a1b2c3d4e5';
+		$secret = 'phpunit-client-secret-f6g7h8';
+
+		$id = $this->insertCall(
+			'grant_type=client_credentials&client_id=someclient&client_secret=' . $secret,
+			'{"access_token":"' . $token . '","refresh_token":"' . $token . '-r","token_type":"Bearer","expires_in":3600}'
+		);
+
+		$export = new SupportExport($db);
+		$entries = $this->readArchive($export->build(SupportExport::TYPE_CALL, array($id), $this->destdir));
+
+		$whole = implode("\n", $entries);
+		$this->assertStringNotContainsString($token, $whole, 'The access token came out of the archive');
+		$this->assertStringNotContainsString($secret, $whole, 'The client secret came out of the archive');
+		$this->assertStringContainsString('[REDACTED]', $whole, 'Nothing was redacted at all, so the assertions above prove nothing');
+
+		// The rest of the call must still be there, otherwise the export is useless.
+		$this->assertStringContainsString('/oauth/token', $whole);
+		$this->assertStringContainsString('expires_in', $whole);
+	}
+
+	/**
+	 * The manifest alone must answer the questions a maintainer asks first.
+	 *
+	 * @return void
+	 */
+	public function testManifestNamesTheContextOfTheExport()
+	{
+		global $conf, $db;
+
+		$conf->global->EINVOICING_DEBUG_MODE = '1';
+
+		$id = $this->insertCall('{}', '{}');
+
+		$export = new SupportExport($db);
+		$entries = $this->readArchive($export->build(SupportExport::TYPE_CALL, array($id), $this->destdir));
+
+		$this->assertArrayHasKey('manifest.json', $entries);
+		$manifest = json_decode($entries['manifest.json'], true);
+		$this->assertIsArray($manifest, 'manifest.json is not readable JSON');
+
+		$this->assertSame(DOL_VERSION, $manifest['dolibarr_version']);
+		$this->assertSame(einvoicingModuleStamp(), $manifest['einvoicing_version']);
+		$this->assertSame(PHP_VERSION, $manifest['php_version']);
+		$this->assertSame((int) $conf->entity, $manifest['entity']);
+		$this->assertSame(getDolGlobalString('EINVOICING_PDP'), $manifest['provider']);
+		$this->assertSame(SupportExport::TYPE_CALL, $manifest['export_type']);
+		$this->assertTrue($manifest['debug_mode'], 'The manifest must say the debug columns could be written');
+		$this->assertSame(1, $manifest['exported_count']);
+
+		$conf->global->EINVOICING_DEBUG_MODE = '0';
+		$entries = $this->readArchive($export->build(SupportExport::TYPE_CALL, array($id), $this->destdir));
+		$manifest = json_decode($entries['manifest.json'], true);
+		$this->assertFalse($manifest['debug_mode'], 'An empty response must be tellable from a response never stored');
+	}
+
+	/**
+	 * A setup constant that holds a credential is reported as set, never quoted.
+	 *
+	 * @return void
+	 */
+	public function testSecretSetupConstantsAreReportedByTheirStateOnly()
+	{
+		global $conf, $db;
+
+		$conf->global->EINVOICING_SUPERPDP_CLIENT_SECRET = 'phpunit-setup-secret-z9y8x7';
+		$conf->global->EINVOICING_SUPERPDP_PROD_TOKEN = 'phpunit-setup-token-w6v5u4';
+		$conf->global->EINVOICING_FLOWS_SYNC_CALL_LIMIT = '25';
+
+		$id = $this->insertCall('{}', '{}');
+
+		$export = new SupportExport($db);
+		$entries = $this->readArchive($export->build(SupportExport::TYPE_CALL, array($id), $this->destdir));
+		$manifest = json_decode($entries['manifest.json'], true);
+
+		$this->assertSame(SupportExport::CONST_SET, $manifest['constants']['EINVOICING_SUPERPDP_CLIENT_SECRET']);
+		$this->assertSame(SupportExport::CONST_SET, $manifest['constants']['EINVOICING_SUPERPDP_PROD_TOKEN']);
+		$this->assertStringNotContainsString('phpunit-setup-secret-z9y8x7', $entries['manifest.json']);
+		$this->assertStringNotContainsString('phpunit-setup-token-w6v5u4', $entries['manifest.json']);
+
+		// A constant that is not a credential keeps its value, or the manifest tells nothing useful.
+		$this->assertSame('25', $manifest['constants']['EINVOICING_FLOWS_SYNC_CALL_LIMIT']);
+	}
+
+	/**
+	 * A flow carries its XML as a file of its own, and a flow that has none is still exported.
+	 *
+	 * @return void
+	 */
+	public function testFlowsAreExportedWithAndWithoutTheirDocument()
+	{
+		global $db;
+
+		$xml = '<?xml version="1.0" encoding="UTF-8"?><rsm:CrossIndustryInvoice><phpunit>1</phpunit></rsm:CrossIndustryInvoice>';
+
+		$withbody = $this->insertFlow($xml);
+		$withoutbody = $this->insertFlow('');
+
+		$export = new SupportExport($db);
+		$entries = $this->readArchive($export->build(SupportExport::TYPE_FLOW, array($withbody, $withoutbody), $this->destdir));
+
+		$this->assertSame(2, $export->report['exported']);
+		$this->assertSame(0, $export->report['skipped']);
+
+		$documents = preg_grep('#^flows/.*/document\.xml$#', array_keys($entries));
+		$rows = preg_grep('#^flows/.*/flow\.json$#', array_keys($entries));
+		$this->assertCount(2, $rows, 'Every selected flow must have its row in the archive');
+		$this->assertCount(1, $documents, 'Only the flow that carries an XML may have a document.xml');
+		$this->assertSame($xml, $entries[reset($documents)]);
+
+		// The row keeps the columns a maintainer reads, and leaves the body out of the JSON.
+		$flow = json_decode($entries[reset($rows)], true);
+		$this->assertIsArray($flow);
+		$this->assertArrayNotHasKey('document_body', $flow);
+		$this->assertSame('Out', $flow['flow_direction']);
+		$this->assertSame('CustomerInvoice', $flow['flow_type']);
+	}
+
+	/**
+	 * A selection wider than the bound is refused with a message, rather than met with a timeout
+	 * or a memory limit.
+	 *
+	 * @return void
+	 */
+	public function testASelectionOverTheBoundIsRefused()
+	{
+		global $conf, $db;
+
+		$conf->global->EINVOICING_SUPPORT_EXPORT_MAX = 2;
+		$this->assertSame(2, SupportExport::maxRecords());
+
+		$export = new SupportExport($db);
+		$this->assertSame('', $export->build(SupportExport::TYPE_FLOW, array(1, 2, 3), $this->destdir));
+		$this->assertNotSame('', $export->error, 'The refusal must carry a message for the user');
+
+		$this->assertCount(0, (array) dol_dir_list($this->destdir, 'files'), 'A refused export must leave nothing behind');
+
+		unset($conf->global->EINVOICING_SUPPORT_EXPORT_MAX);
+	}
+
+	/**
+	 * An id that does not exist, or that belongs to another entity, is counted as skipped instead
+	 * of aborting the whole export.
+	 *
+	 * @return void
+	 */
+	public function testAnUnreachableRecordIsSkippedWithoutLosingTheOthers()
+	{
+		global $db;
+
+		$id = $this->insertFlow('');
+
+		$export = new SupportExport($db);
+		$entries = $this->readArchive($export->build(SupportExport::TYPE_FLOW, array($id, 999999999), $this->destdir));
+
+		$this->assertSame(1, $export->report['exported']);
+		$this->assertSame(1, $export->report['skipped']);
+
+		$manifest = json_decode($entries['manifest.json'], true);
+		$this->assertSame(2, $manifest['requested_count']);
+		$this->assertSame(1, $manifest['skipped_count']);
+	}
+}


### PR DESCRIPTION
## The problem

Instructing a refusal of the platform means, today, walking the user through four screens — the flow
(stored XML, syntax, profile), the API call it came from (endpoint, request body, response body), the
setup constants, the versions — and having them turn an option on, because the two most useful
columns are only written when `EINVOICING_DEBUG_MODE` is set:

- `llx_einvoicing_call.response`
- `llx_einvoicing_document.response_for_debug`

On #799 that back and forth has cost several days and the deciding information is still missing. The
idea of a mass action for it is @mdeweerd's, in that same issue.

## What this adds

One entry, **Export for support**, in the mass action combo of `document_list.php` and
`call_list.php`. Both pages already carry the whole mass action plumbing (`$massaction`, `$toselect`,
`$diroutputmassaction`, `actions_massactions.inc.php`, `$arrayofmassactions`), so nothing is wired
here — only the entry, its confirmation, and the call.

Tick the rows, pick the entry, confirm, and the browser is handed one archive:

```
manifest.json                     the context: core, module build (einvoicingModuleStamp()), PHP,
                                  provider, protocol, entity, date, counts, whether debug mode was
                                  on, and every EINVOICING_* constant
flows/<flow_id>/flow.json         the row, bodies left out
flows/<flow_id>/document.xml      document_body, or xml_data when there is no document_body
flows/<flow_id>/metadata.json     response_for_debug, when it was written
calls/<call_id>/call.json         the row, request_body and response included
```

`debug_mode` is in the manifest on purpose: without it a reader cannot tell *a call that answered
nothing* from *a call whose answer was never stored*.

## What never leaves the instance

- Everything written goes through `AbstractPDPProvider::redactSensitiveData()` — the very method the
  call log is written with, made `public static` for this second caller. The log is already written
  redacted, so this is defence in depth: rows written *before* that redaction existed still hold
  what the platform answered, tokens included, and an export is exactly what would take them out.
- A constant whose name carries `SECRET`, `TOKEN`, `REFRESH`, `PASSWORD`, `PASSWD`, `CLIENT_ID`,
  `API_KEY`, `CREDENTIAL` or `PRIVATE` is reported as `[SET, NOT EXPORTED]` / `[NOT SET]`, never
  quoted. That covers the setup credentials and the OAuth tokens the module stores as
  `<PREFIX>_PROD_TOKEN` / `_REFRESH` on cores below 23.

The invoice XML **is** in the archive — that is the point, it is the document to diagnose — so it
carries the names, addresses, e-mail addresses and phone numbers of the parties. The confirmation
screen says so in one sentence before anything is built.

## Two decisions worth reviewing

**The archive is handed over straight away, not left in the "generated documents" box.** That box
downloads through `document.php` with the modulepart `massfilesarea_einvoicing`, and
`dol_check_secure_access_document()` grants that modulepart on `hasRight(<module>, 'lire')` up to
Dolibarr 21 — it moved to `'read'` in 22. The module declares `read`, like every module builder
module, so the link is refused on the lower half of the supported range. Measured on the bench, with
a plain user carrying only `einvoicing → read` (an admin passes everywhere and hides this):

| core | 18 | 19 | 20 | 21 | 22 | 23 | 24 |
|---|---|---|---|---|---|---|---|
| `massfilesarea_einvoicing` download | refused | refused | refused | refused | served | served | served |

Streaming answers the same on all seven. The file is built under `$diroutputmassaction` as any mass
action would, and removed once sent, which also keeps archives full of invoice XML from piling up in
the temporary area.

**The confirmation is the non-ajax `formconfirm()`,** like the core's own `predelete`: the ajax
variant jumps to a GET url and would drop `toselect[]`.

Two guards: `ZipArchive` is checked with `class_exists()` and answers a plain message rather than
letting `dol_compress_dir()` report no handler; and a selection wider than
`EINVOICING_SUPPORT_EXPORT_MAX` (50 by default — an e-invoice XML weighs 100 to 200 kB) is refused
with a message naming the bound, rather than met with a timeout or a memory limit.

The build lives in `class/utils/SupportExport.class.php`, not in the pages: page code cannot be
exercised by PHPUnit, and the redaction is exactly what has to be covered by a test.

## What was measured

Bench: Dolibarr **18.0.10** and **24.0.1**, PHP 8.4, module deployed by symlink, real HTTPS sessions.

**Ran.**

- `SupportExportTest.php`, 6 tests / 62 assertions, green on 18 and 24. It plants an
  `access_token` + a `client_secret` in a call log row written *without* redaction — the shape of a
  row predating it — exports, reopens the archive and asserts neither string comes out while
  `[REDACTED]` does; it checks the manifest, the secret constants, a flow with and without a
  document, the bound, and a row that cannot be reached.
- The whole PHPUnit suite of the module, **34 files**, green on 18 and 24.
- The mass action itself over HTTP, on both lists, for an **admin** and for a **plain user carrying
  only `einvoicing → read`**: 80 checks each, all green, on 18 and 24 — the entry is in the combo,
  the confirmation appears and says what leaves, the answer is `application/zip` with a
  `Content-Disposition` naming `einvoicing-support-<entity>-<date>.zip`, the archive reopens, its
  manifest counts exactly the selection, there is one row file per selected record, and no
  `access_token` / `client_secret` / `refresh_token` in clear anywhere in it.
- Cases covered: 1 flow with its XML, 1 flow with no document at all (no `document.xml`, no failure),
  3 flows mixed, 1 API call with its response, 2 API calls — each with `EINVOICING_DEBUG_MODE` **off**
  and **on** (the manifest follows).
- 61 rows selected → no archive, and the message naming the bound and the constant.
- A user without `einvoicing → read`: the two lists are refused, the entry is absent, and posting
  `action=supportexport` straight at the page answers **403**.
- `dolics` (phpcs 3.x + the ruleset of the repository) clean on the seven files, and `phan 5.5.2`
  with the configuration and baseline of the repository clean as well.

`MoreSpecificElementTypePlugin` wants the documented return type of five methods to repeat the
union of the literal value types phan infers for one run, or to call an array filled in a loop
non-empty. Those five carry a `@phan-suppress` with the reason; the one real finding it raised,
an unprotected variable in the `IN (...)` of `reachableIds()`, is fixed with `$db->sanitize()`
(the ids are cast to int before, so this is belt and braces).

**Read, not run.** The `massfilesarea` table above is measured, but the reading of
`dol_check_secure_access_document()` that explains it (`$lire` up to 21, `$read` from 22) is a
reading of the core sources of the seven versions. Cores 19 to 23 were only used for that
measurement; the mass action itself was exercised on 18 and 24.

## Not fixed by this

#799 is the use case this comes from — a refusal `B2BInt invoices only support payment received
event`. This export is what lets such a refusal be instructed; it does not correct it. The issue
stays open.

No ChangeLog entry, per `.agents/AGENTS.md`. Language keys in `en_US` only.
