### PR TITLE
FIX #806 [einvoicing] Write MDT-97 in the CDAR and stop relabelling the recipient address

### DIFF
--- a/einvoicing/class/utils/CdarHandler.class.php
+++ b/einvoicing/class/utils/CdarHandler.class.php
@@ -85,6 +85,12 @@ class CdarHandler
 	const SCHEME_SIREN_0225 = '0225';
 	const SCHEME_SIREN_0002 = '0002';
 
+	// MDT-97: what kind of object the lifecycle message is about (rule G7.14 of XP Z12-012).
+	// A status sent by this module always refers to an invoice of the e-invoicing circuit; the
+	// other values of the rule cover a flow, regulatory data, an e-reporting transmission, the
+	// directory, and a status about a status.
+	const REFERENCE_TYPE_EINVOICE = 'urn.cpro.gouv.fr:1p0:CDV:einvoicingF2';
+
 	// Status Codes
 	const STATUS_ACCEPTED = '1';
 	const STATUS_REJECTED = '8';
@@ -152,6 +158,11 @@ class CdarHandler
 	 *				'issuerid' (fallen back on an identifier of the vendor)
 	 */
 	public $recipientURIIDOrigin = '';
+
+	/**
+	 * @var string EAS scheme (MDT-73-1) declared for the address above, as chosen by generateCdarFile()
+	 */
+	public $recipientURISchemeID = self::SCHEME_SIREN_0225;
 
 	/**
 	 * readFromString
@@ -357,6 +368,7 @@ class CdarHandler
 		//      alone: the invoice-level routing override it also knows about is looked up among the customer
 		//      invoices (element_type = 'facture'), which a supplier invoice must not read.
 		$RecipientURIID = $InvoiceIssuerGlobalID;
+		$RecipientURISchemeID = CdarHandler::SCHEME_SIREN_0225;
 		$this->recipientURIIDOrigin = 'issuerid';
 		if ($statusCode != 212 && $object->thirdparty instanceof Societe) {
 			$vendorRouting = $einvoicing->fetchDefaultRouting($object->thirdparty->id);
@@ -370,6 +382,13 @@ class CdarHandler
 				$vendorURIID = $einvoicing->removeSpaces($vendorIdentity['uriid']);
 				if ($vendorURIID !== '') {
 					$this->recipientURIIDOrigin = 'einvoice';
+					// MDT-73-1 is the EAS scheme of the address actually used, not a constant: the vendor
+					// published this one on its invoice (BT-34) together with its scheme, and re-labelling
+					// it as a national directory address (0225) would describe it wrongly. Every other rung
+					// does take an address of the national directory, so 0225 stays right for them.
+					if ($vendorIdentity['urischeme'] !== '') {
+						$RecipientURISchemeID = $vendorIdentity['urischeme'];
+					}
 					dol_syslog(__METHOD__ . ' no routing ID recorded for vendor SIREN ' . $InvoiceIssuerGlobalID . ', replying to the electronic address of the invoice it sent us: ' . $vendorURIID, LOG_NOTICE);
 				}
 			}
@@ -410,6 +429,7 @@ class CdarHandler
 		// invoice that can be neither approved nor refused - and therefore not deleted - leaves the user
 		// with nothing to act on.
 		$this->recipientURIID = $RecipientURIID;
+		$this->recipientURISchemeID = $RecipientURISchemeID;
 
 		// MDG-43 blocks. Rule BR-FR-CDV-14: a "Encaissee" status (212) must carry at least one block with
 		// MDT-207 = MEN, and every MEN block must hold both an amount (MDT-215) and a VAT rate (MDT-224).
@@ -469,7 +489,7 @@ class CdarHandler
 				'SchemeID'     => CdarHandler::SCHEME_SIREN_0002,
 				'RoleCode'     => CdarHandler::ROLE_SE,
 				'URIID'        => $RecipientURIID,	// The routing of the vendor, its SIREN when none is recorded
-				'URISchemeID'  => CdarHandler::SCHEME_SIREN_0225
+				'URISchemeID'  => $RecipientURISchemeID
 			];
 		}
 
@@ -499,6 +519,8 @@ class CdarHandler
 					'IssuerAssignedID' => $IssuerAssignedID,
 					'StatusCode' => $StatusCodeCdar,
 					'TypeCode' => CdarHandler::DOC_INVOICE, // TODO: map DOC_INVOICE with $object type
+					// MDT-97, mandatory in the CTC-FR profile: it says what the lifecycle message is about
+					'ReferenceTypeCode' => CdarHandler::REFERENCE_TYPE_EINVOICE,
 					// Every XP Z12-012 reference example dates the referenced invoice with a plain date
 					'FormattedIssueDateTime' => date('Ymd', $object->date),
 					'ProcessConditionCode' => $statusCode,
@@ -596,12 +618,14 @@ class CdarHandler
 	 * A single parse serves both values, since a CDAR always needs the two together.
 	 *
 	 * @param  FactureFournisseur $object  Supplier invoice the status is sent on
-	 * @return array{globalid:string,uriid:string}  Empty strings when there is no stored e-invoice,
-	 *                                              when it is unparsable, or when it carries no such field
+	 * @return array{globalid:string,uriid:string,urischeme:string}  Empty strings when there is no stored
+	 *                                              e-invoice, when it is unparsable, or when it carries no
+	 *                                              such field. 'urischeme' is the EAS scheme the document
+	 *                                              declares on that address (MDT-73-1 of the CDAR).
 	 */
 	private function getVendorIdentityFromReceivedInvoice($object)
 	{
-		$identity = array('globalid' => '', 'uriid' => '');
+		$identity = array('globalid' => '', 'uriid' => '', 'urischeme' => '');
 
 		if (empty($object->id) || $object->element !== 'invoice_supplier') {
 			return $identity;
@@ -648,6 +672,11 @@ class CdarHandler
 		$found = $xml->xpath('//ram:SellerTradeParty/ram:URIUniversalCommunication/ram:URIID');
 		if (!empty($found)) {
 			$identity['uriid'] = trim((string) $found[0]);
+			// The scheme comes with the address: MDT-73-1 has to declare the address for what the vendor
+			// published it as, and a vendor reachable under its SIREN (0002) is not a national directory
+			// address (0225). Kept only when the document actually carries one.
+			$scheme = (string) ($found[0]->attributes()->schemeID ?? '');
+			$identity['urischeme'] = trim($scheme);
 		}
 
 		return $identity;
@@ -1114,6 +1143,12 @@ class CdarHandler
 		$ref->appendChild($dom->createElement('ram:IssuerAssignedID', htmlspecialchars((string) $doc['IssuerAssignedID'])));
 		$ref->appendChild($dom->createElement('ram:StatusCode', htmlspecialchars((string) $doc['StatusCode'])));
 		$ref->appendChild($dom->createElement('ram:TypeCode', htmlspecialchars((string) $doc['TypeCode'])));
+
+		// MDT-97. Its place in the CDAR XSD sequence (ReferencedDocumentType) is after ReceiptDateTime /
+		// AttachmentBinaryObject and before FormattedIssueDateTime - the order the platforms use too.
+		if (!empty($doc['ReferenceTypeCode'])) {
+			$ref->appendChild($dom->createElement('ram:ReferenceTypeCode', htmlspecialchars((string) $doc['ReferenceTypeCode'])));
+		}
 
 		$formattedDateTime = $dom->createElement('ram:FormattedIssueDateTime');
 		$dateTimeStr = $dom->createElement('qdt:DateTimeString', htmlspecialchars((string) $doc['FormattedIssueDateTime']));

--- a/einvoicing/test/phpunit/CdarConformanceTest.php
+++ b/einvoicing/test/phpunit/CdarConformanceTest.php
@@ -1,0 +1,177 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/CdarConformanceTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for the two fields of a lifecycle CDAR that XP Z12-012 constrains and
+ *                  that no validator checks: MDT-97 (ReferenceTypeCode), which says what the message is
+ *                  about, and MDT-73-1 (the EAS scheme of the recipient address).
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db, $mysoc;
+
+// See RecipientDirectoryTest.php for why DOLIBARR_HTDOCS is honoured before the relative path.
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+dol_include_once('einvoicing/class/utils/CdarHandler.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+if (empty($user->id)) {
+	print "Load permissions for admin user nb 1\n";
+	$user->fetch(1);
+	// User::loadRights() only exists from Dolibarr 19 on, older versions name it getrights()
+	if (method_exists($user, 'loadRights')) {
+		$user->loadRights();
+	} else {
+		$user->getrights();
+	}
+}
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+
+
+/**
+ * Tests on the CDAR built by CdarHandler::generate().
+ *
+ * Nothing is written and no platform is called: the generator is handed a data array and the XML it
+ * returns is read back.
+ */
+class CdarConformanceTest extends CommonClassTest
+{
+	/**
+	 * A minimal status CDAR, in the shape generateCdarFile() builds for a status sent as the buyer.
+	 *
+	 * @param	string	$uriScheme	EAS scheme (MDT-73-1) of the recipient address
+	 * @return	array<string,mixed>	Data for CdarHandler::generate()
+	 */
+	private function statusData($uriScheme)
+	{
+		return array(
+			'GuidelineID' => 'urn.cpro.gouv.fr:1p0:CDV:invoice',
+			'ExchangedDocument' => array(
+				'ID' => 'REF_205_20260901120000#380_20260901',
+				'Name' => 'REF_205_20260901120000#380_20260901',
+				'IssueDateTime' => '20260901120000',
+				'SenderTradeParty' => array('RoleCode' => CdarHandler::ROLE_WK),
+				'IssuerTradeParty' => array(
+					'GlobalID' => '000000001',
+					'SchemeID' => CdarHandler::SCHEME_SIREN_0002,
+					'RoleCode' => CdarHandler::ROLE_BY,
+				),
+				'RecipientTradeParty' => array(
+					'GlobalID' => '424761419',
+					'SchemeID' => CdarHandler::SCHEME_SIREN_0002,
+					'RoleCode' => CdarHandler::ROLE_SE,
+					'URIID' => '424761419',
+					'URISchemeID' => $uriScheme,
+				),
+			),
+			'AcknowledgementDocument' => array(
+				'MultipleReferencesIndicator' => false,
+				'TypeCode' => '23',
+				'IssueDateTime' => '20260901120000',
+				'ReferenceReferencedDocument' => array(
+					'IssuerAssignedID' => 'FR00000001',
+					'StatusCode' => CdarHandler::STATUS_IN_PROCESS,
+					'TypeCode' => CdarHandler::DOC_INVOICE,
+					'ReferenceTypeCode' => CdarHandler::REFERENCE_TYPE_EINVOICE,
+					'FormattedIssueDateTime' => '20260901',
+					'ProcessConditionCode' => '205',
+					'ProcessCondition' => 'Approuvee',
+					'SpecifiedDocumentStatus' => array(),
+					'IssuerTradeParty' => array(
+						'GlobalID' => '424761419',
+						'SchemeID' => CdarHandler::SCHEME_SIREN_0002,
+						'RoleCode' => CdarHandler::ROLE_SE,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * MDT-97 is written, with the URN rule G7.14 gives for a lifecycle message about an invoice.
+	 *
+	 * @return void
+	 */
+	public function testReferenceTypeCodeIsTheEinvoiceUrn()
+	{
+		global $db;
+
+		$handler = new CdarHandler($db);
+		$xml = (string) $handler->generate($this->statusData(CdarHandler::SCHEME_SIREN_0225));
+
+		$this->assertStringContainsString(
+			'<ram:ReferenceTypeCode>urn.cpro.gouv.fr:1p0:CDV:einvoicingF2</ram:ReferenceTypeCode>',
+			$xml,
+			'MDT-97 must carry the URN of rule G7.14 for a lifecycle message about an invoice'
+		);
+	}
+
+	/**
+	 * MDT-97 sits where the CDAR XSD puts it: after TypeCode, before FormattedIssueDateTime.
+	 *
+	 * An element in the wrong place makes the whole document invalid against the XSD, so the order is
+	 * asserted rather than only the presence.
+	 *
+	 * @return void
+	 */
+	public function testReferenceTypeCodeIsInItsXsdPlace()
+	{
+		global $db;
+
+		$handler = new CdarHandler($db);
+		$xml = (string) $handler->generate($this->statusData(CdarHandler::SCHEME_SIREN_0225));
+
+		$posType = strpos($xml, '<ram:TypeCode>' . CdarHandler::DOC_INVOICE . '</ram:TypeCode>');
+		$posRef = strpos($xml, '<ram:ReferenceTypeCode>');
+		$posDate = strpos($xml, '<ram:FormattedIssueDateTime>');
+
+		$this->assertNotFalse($posType, 'the referenced document must carry its TypeCode');
+		$this->assertNotFalse($posRef, 'the referenced document must carry MDT-97');
+		$this->assertNotFalse($posDate, 'the referenced document must carry its issue date');
+		$this->assertLessThan($posRef, $posType, 'MDT-97 comes after the TypeCode of the referenced document');
+		$this->assertLessThan($posDate, $posRef, 'MDT-97 comes before FormattedIssueDateTime');
+	}
+
+	/**
+	 * MDT-73-1 is whatever scheme the caller settled on, not a constant.
+	 *
+	 * @return void
+	 */
+	public function testRecipientAddressKeepsTheSchemeItWasGiven()
+	{
+		global $db;
+
+		$handler = new CdarHandler($db);
+
+		$xml0225 = (string) $handler->generate($this->statusData(CdarHandler::SCHEME_SIREN_0225));
+		$this->assertStringContainsString('<ram:URIID schemeID="0225">424761419</ram:URIID>', $xml0225);
+
+		$xml0002 = (string) $handler->generate($this->statusData(CdarHandler::SCHEME_SIREN_0002));
+		$this->assertStringContainsString('<ram:URIID schemeID="0002">424761419</ram:URIID>', $xml0002);
+	}
+}


### PR DESCRIPTION
Fixes the two deviations reported in #806. Both are conformance fixes: no validator catches either, so nothing complains today.

## 1. MDT-97 (`ReferenceTypeCode`) was never written

XP Z12-012 Annexe A, sheet *CDV FE - CDAR*, makes `/rsm:AcknowledgementDocument/ram:ReferenceReferencedDocument/ram:ReferenceTypeCode` **mandatory in the CTC-FR profile (1..1)**, and rule **G7.14** gives its value: it is the field that states what the lifecycle message is about, with distinct URNs for an invoice of the e-invoicing circuit, a flow, regulatory data, an e-reporting transmission, the directory, or a status about a status.

Every status this module sends is about an invoice, so the CDAR now carries `urn.cpro.gouv.fr:1p0:CDV:einvoicingF2`, placed where the CDAR XSD (`ReferencedDocumentType`) puts it — after `TypeCode` / `ReceiptDateTime`, before `FormattedIssueDateTime` — which is also where the platforms put it in the CDARs they issue.

## 2. MDT-73-1 (the EAS scheme of the recipient address) was hardcoded

`CdarHandler` declared the recipient address as scheme `0225` whatever that address was. The annex defines MDT-73-1 as the **EAS scheme of the address actually used**, `0225` being the example given for an address of the national directory.

Four rungs choose that address: a routing recorded in Dolibarr, else the electronic address (BT-34) published by the vendor on the invoice we received, else the platform directory, else the vendor SIREN. Only one of them is not a national-directory address: the BT-34, which carries its own scheme and is `0002` for a vendor reachable under its SIREN. That rung now keeps the scheme of the document; the other three still declare `0225`, so nothing changes for an invoice whose vendor has a routing recorded or is found in the directory.

`getVendorIdentityFromReceivedInvoice()` already read that BT-34 — it dropped the `schemeID` attribute.

## What this does not do

It does not fix #799. The vendor of that issue publishes no usable reception address at all (no Peppol participant for its SIREN or SIRET, no routing line in the national directory as exposed by one platform, and a line without `directoryLineStatus` as exposed by another), and no scheme makes an address reachable that no directory publishes.

## Tests

- **New unit test** `test/phpunit/CdarConformanceTest.php` (3 tests): MDT-97 carries the G7.14 URN, MDT-97 sits between `TypeCode` and `FormattedIssueDateTime` (order asserted, since a misplaced element invalidates the document against the XSD), and MDT-73-1 keeps the scheme it was given.
- **PHPUnit** green on Dolibarr 18, 19, 20, 21, 22, 23 and 24 (34/34 files each).
- **Generated CDAR validated against the official schematron** `BR-FR-CDV-Schematron-CDAR.xslt` (FNFE France_RFE, EUPL): **0 failed-assert**, 23 fired rules. Positive control: a real CDAR issued by a certified platform gives 0 failed-assert / 24 fired rules through the same validator.
- **On the bench, on a real received invoice** whose stored document is the CII of a vendor publishing its address as `0002` (imported from a real Factur-X): the address ladder settles on the BT-34, and the CDAR now carries `URIID schemeID="0002"` plus the MDT-97 URN.
- **Non-regression, on a flow of the sandbox** with a routing recorded: the ladder still settles on the routing and the CDAR still declares `0225`; only MDT-97 is added.

## Sources

XP Z12-012 Annexe A (sheets *CDV FE - CDAR* and *Règles de gestion 3.2*) and the CDAR schematron and XSD, published under EUPL in <https://github.com/fnfempe/France_RFE>.
