### PR TITLE
FIX einvoicing: build the VAT number the way the core does

### DIFF
--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -3614,24 +3614,31 @@ class EInvoicing
 	/**
 	 * Calculate TVA intracommunity number for a thirdparty if missing, from the professional ID
 	 *
+	 * The core does exactly this, in Societe::calculateVATNumberFromProperties(), since Dolibarr 24.
+	 * This method is kept as the entry point of the module - it is what buildinvoicelines.inc.php calls
+	 * to fill BT-31 and BT-48 - but it no longer computes anything itself: it hands the thirdparty over
+	 * to the core when the core knows how, and to the faithful backport of compat/societe.lib.php on the
+	 * versions that do not have it yet. The presence of the method is what decides, not a version test:
+	 * the same module runs on 18 to 24, and a backport of the method into a maintenance release would
+	 * then be used as soon as it is there.
+	 *
+	 * The copy this replaced was wrong twice, and both defects reached the XML: the key was concatenated
+	 * raw, where the core pads it to two digits, so the roughly one SIREN in ten whose key is below 10
+	 * got a 12 character number instead of 13; and the SIRET to SIREN fallback cast to int, which eats
+	 * the leading zero of a SIREN that starts with one.
+	 *
 	 * @param mixed $thirdparty		Third party
 	 * @return string
 	 */
 	public function thirdpartyCalcVATIntra($thirdparty)
 	{
-		if ($thirdparty->country_code == 'FR' && empty($thirdparty->tva_intra) && !empty($thirdparty->tva_assuj)) {
-			$siren = trim($thirdparty->idprof1);
-			if (empty($siren)) {
-				$siren = (int) substr(str_replace(' ', '', $thirdparty->idprof2), 0, 9);
-			}
-			if (!empty($siren)) {
-				// [FR + code clé  + numéro SIREN ]
-				//Clé TVA = [12 + 3 × (SIREN modulo 97)] modulo 97
-				$cle = (12 + 3 * $siren % 97) % 97;
-				$tva_intra = 'FR' . $cle . $siren;
-			}
+		if (is_object($thirdparty) && method_exists($thirdparty, 'calculateVATNumberFromProperties')) {
+			return $thirdparty->calculateVATNumberFromProperties($thirdparty);
 		}
-		return $tva_intra ?? '';
+
+		require_once __DIR__ . '/../compat/societe.lib.php';
+
+		return calculateVATNumberFromProperties($thirdparty);
 	}
 
 	/**

--- a/einvoicing/compat/societe.lib.php
+++ b/einvoicing/compat/societe.lib.php
@@ -1,0 +1,81 @@
+<?php
+/* Copyright (C) 2004-2026	Laurent Destailleur		<eldy@users.sourceforge.net>
+ * Copyright (C) 2026		Pierre Grasswill		<da.grumpf@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *  \file		einvoicing/compat/societe.lib.php
+ *  \ingroup	einvoicing
+ *  \brief		Thirdparty helper of societe/class/societe.class.php this module uses and that Dolibarr
+ *  			does not ship before 24
+ */
+
+// @phan-file-suppress PhanRedefineFunction
+
+if (!function_exists('calculateVATNumberFromProperties')) {
+	/**
+	 *  Calculate VAT intracommunity number for a thirdparty if missing, from the professional ID.
+	 *
+	 *  Copy of Societe::calculateVATNumberFromProperties(), added to
+	 *  htdocs/societe/class/societe.class.php in Dolibarr 24, kept identical so a VAT number built on
+	 *  18 to 23 is the number the core would build. Measured: the method is absent from 18.0.10,
+	 *  19.0.4, 20.0.4, 21.0.4, 22.0.5 and 23.0.4, and present in 24.0.1.
+	 *
+	 *  The core exposes it as a *method* of Societe, and a method cannot be added to a core class from
+	 *  outside without patching the core, which a module must never do. So the backport takes the only
+	 *  shape a shim can take here: a free function carrying the name and the signature of the core
+	 *  symbol, guarded like every other shim of this directory. The module never reaches it when the
+	 *  real method is there - EInvoicing::thirdpartyCalcVATIntra() tests the method first, and calls
+	 *  this only as a fallback.
+	 *
+	 *  Note that the core method takes the thirdparty as an argument rather than working on $this,
+	 *  which is what makes it transposable to a function without changing what it does.
+	 *
+	 *  @param	mixed	$thirdparty		A thirdparty object
+	 *  @return	string					A VAT number, '' if none can be built
+	 *  @since	Dolibarr V24
+	 */
+	function calculateVATNumberFromProperties($thirdparty)
+	{
+		if ($thirdparty->country_code == 'FR' && empty($thirdparty->tva_intra) && !empty($thirdparty->tva_assuj)) {
+			// The core requires DOL_DOCUMENT_ROOT/core/lib/profid.lib.php here. That file only exists
+			// since Dolibarr 20, so on 18 and 19 the backported checks of compat/profid.lib.php, which
+			// sits next to this file, are the ones to load.
+			if (!function_exists('isValidSiren')) {
+				require_once __DIR__ . '/profid.lib.php';
+			}
+
+			$siren = preg_replace('/\s+/', '', (string) $thirdparty->idprof1);
+			$siret = preg_replace('/\s+/', '', (string) $thirdparty->idprof2);
+			if (!isValidSiren($siren)) {
+				if (!isValidSiret($siret)) {
+					return '';
+				}
+
+				$siren = substr($siret, 0, 9);
+			}
+			if (!empty($siren)) {
+				// [FR + key code + SIREN number ]
+				// Key VAT = [12 + 3 * (SIREN modulo 97)] modulo 97
+				$cle = (12 + 3 * (((int) $siren) % 97)) % 97;
+				$tva_intra = 'FR' . str_pad((string) $cle, 2, '0', STR_PAD_LEFT) . $siren;
+			}
+		}
+
+		return $tva_intra ?? '';
+	}
+}

--- a/einvoicing/test/phpunit/CompatShimReloadTest.php
+++ b/einvoicing/test/phpunit/CompatShimReloadTest.php
@@ -81,6 +81,11 @@ class CompatShimReloadTest extends CommonClassTest
 				'function isValidLuhn($str) { return true; } function isValidSiren($siren) { return true; } function isValidSiret($siret) { return true; } function isValidTinForPT($str) { return true; } function isValidTinForDZ($str) { return true; } function isValidTinForBE($str) { return true; } function isValidTinForES($str) { return 1; }',
 				'function_exists("isValidLuhn") && function_exists("isValidTinForES")',
 			),
+			'societe' => array(
+				'compat/societe.lib.php',
+				'function calculateVATNumberFromProperties($thirdparty) { return ""; }',
+				'function_exists("calculateVATNumberFromProperties")',
+			),
 			'files' => array(
 				'compat/files.lib.php',
 				'function dolChmod($filepath, $newmask = "") { }',

--- a/einvoicing/test/phpunit/VatNumberFromProfessionalIdTest.php
+++ b/einvoicing/test/phpunit/VatNumberFromProfessionalIdTest.php
@@ -1,0 +1,208 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/VatNumberFromProfessionalIdTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for the VAT number the module builds for a French thirdparty that has
+ *                  none, BT-31 for the seller and BT-48 for the buyer.
+ *
+ *                  A French VAT number is FR, a two digit key, and the nine digits of the SIREN: it is
+ *                  thirteen characters, always. The module used to carry its own copy of the core
+ *                  computation and the copy was wrong twice:
+ *
+ *                  - the key was concatenated raw. It is [12 + 3 * (SIREN modulo 97)] modulo 97, so it
+ *                    falls between 00 and 09 for about one SIREN in ten - 3 being invertible modulo 97,
+ *                    every key from 0 to 96 is reached by exactly one residue - and those numbers went
+ *                    out on twelve characters;
+ *                  - the SIRET to SIREN fallback cast to int, which eats the leading zero of a SIREN
+ *                    that starts with one, and the number went out on twelve characters again, with the
+ *                    wrong digits.
+ *
+ *                  Both defects reached the XML, where a malformed BT-31 or BT-48 is a document the
+ *                  platform refuses. The computation is now the core one - Societe::calculateVAT-
+ *                  NumberFromProperties(), there since Dolibarr 24 - or the faithful backport of
+ *                  compat/societe.lib.php on 18 to 23, which do not have it. Both paths are checked
+ *                  here: the entry point of the module, and the backport on its own, so that the
+ *                  fallback is covered whatever core the test runs against.
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+// See VatPointDateCodeTest for why DOLIBARR_HTDOCS is honoured before the relative path.
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
+dol_include_once('einvoicing/class/einvoicing.class.php');
+// Reached by its own path, not through dol_include_once(): the shim has to be loaded even when
+// dol_buildpath() cannot resolve the module, which is how issue #565 turned a missing polyfill into a
+// fatal. The module root is two levels above this directory.
+require_once dirname(__DIR__, 2) . '/compat/societe.lib.php';
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class VatNumberFromProfessionalIdTest extends CommonClassTest
+{
+	/**
+	 * A thirdparty, reduced to the five properties the computation reads on it.
+	 *
+	 * @param	string		$idprof1		SIREN held by the record, '' when it has none
+	 * @param	string		$idprof2		SIRET held by the record, '' when it has none
+	 * @param	string		$countryCode	Country of the thirdparty
+	 * @param	string		$vatNumber		VAT number already on the record, '' when it has none
+	 * @param	int|string	$vatEnabled		->tva_assuj, 0 for a thirdparty not subject to VAT
+	 * @return	Societe
+	 */
+	private function thirdparty($idprof1, $idprof2 = '', $countryCode = 'FR', $vatNumber = '', $vatEnabled = 1)
+	{
+		global $db;
+
+		$thirdparty = new Societe($db);
+		$thirdparty->name = 'Thirdparty';
+		$thirdparty->country_code = $countryCode;
+		$thirdparty->tva_intra = $vatNumber;
+		$thirdparty->tva_assuj = $vatEnabled;
+		$thirdparty->idprof1 = $idprof1;
+		$thirdparty->idprof2 = $idprof2;
+
+		return $thirdparty;
+	}
+
+	/**
+	 * What the module puts in BT-31 / BT-48, through its own entry point. On a core that has
+	 * Societe::calculateVATNumberFromProperties() this hands over to the core; on the others it goes
+	 * through the backport.
+	 *
+	 * @param	Societe	$thirdparty		The thirdparty to build a number for
+	 * @return	string					The VAT number, '' when none can be built
+	 */
+	private function vatNumberOf($thirdparty)
+	{
+		global $db;
+
+		$einvoicing = new EInvoicing($db);
+
+		return $einvoicing->thirdpartyCalcVATIntra($thirdparty);
+	}
+
+	/**
+	 * The same thing asked of the backport alone, so the branch taken on 18 to 23 is exercised even when
+	 * the test runs on a core that answers for itself.
+	 *
+	 * @param	Societe	$thirdparty		The thirdparty to build a number for
+	 * @return	string					The VAT number, '' when none can be built
+	 */
+	private function backportedVatNumberOf($thirdparty)
+	{
+		return calculateVATNumberFromProperties($thirdparty);
+	}
+
+	/**
+	 * Assert both paths agree on the number, and return it.
+	 *
+	 * @param	string	$expected		The VAT number both must build
+	 * @param	Societe	$thirdparty		The thirdparty to build it for
+	 * @return	void
+	 */
+	private function assertVatNumberIs($expected, $thirdparty)
+	{
+		$this->assertSame($expected, $this->vatNumberOf($thirdparty), 'The module does not build the expected VAT number.');
+		$this->assertSame($expected, $this->backportedVatNumberOf($thirdparty), 'The backport does not build the same VAT number as the core.');
+	}
+
+	/**
+	 * A key below 10 is written on two digits, like every other key: the number is thirteen characters
+	 * whatever the SIREN. 800000028 has a key of 3, and used to come out as "FR3800000028".
+	 *
+	 * @return void
+	 */
+	public function testTheKeyIsAlwaysTwoDigits()
+	{
+		$this->assertVatNumberIs('FR03800000028', $this->thirdparty('800000028'));
+		$this->assertSame(13, strlen($this->vatNumberOf($this->thirdparty('800000028'))));
+
+		// A key of 10 or more was already right, and stays right.
+		$this->assertVatNumberIs('FR75911270304', $this->thirdparty('911270304'));
+
+		// The separators an operator types in the field are not part of the number.
+		$this->assertVatNumberIs('FR03800000028', $this->thirdparty('800 000 028'));
+	}
+
+	/**
+	 * A record that holds no SIREN but a SIRET is identified by the first nine digits of the SIRET. Those
+	 * nine digits are a string, not a number: a SIREN that starts with a zero keeps it, or the number
+	 * names another company than the one being invoiced.
+	 *
+	 * @return void
+	 */
+	public function testTheSirenTakenFromASiretKeepsItsLeadingZero()
+	{
+		$number = $this->vatNumberOf($this->thirdparty('', '01234567500008'));
+
+		$this->assertSame('FR12012345675', $number);
+		$this->assertSame(13, strlen($number));
+		$this->assertVatNumberIs('FR12012345675', $this->thirdparty('', '01234567500008'));
+
+		// And a SIRET with the separators of the paper form is read the same way.
+		$this->assertVatNumberIs('FR75911270304', $this->thirdparty('', '911 270 304 00015'));
+	}
+
+	/**
+	 * Nothing is built when nothing can be. A thirdparty outside France, one that already carries its
+	 * number, one that is not subject to VAT, and one whose professional ids are not a SIREN nor a SIRET
+	 * all give an empty string: an invented number is worse than an absent one, since BT-31 and BT-48 are
+	 * what the platform routes and controls the document on.
+	 *
+	 * @return void
+	 */
+	public function testNoNumberIsInventedWhenTheRecordDoesNotCarryOne()
+	{
+		// Not a French thirdparty: the FR algorithm says nothing about it.
+		$this->assertVatNumberIs('', $this->thirdparty('800000028', '', 'BE'));
+
+		// The record already states its number, which is the one to use.
+		$this->assertVatNumberIs('', $this->thirdparty('800000028', '', 'FR', 'FR75911270304'));
+
+		// Not subject to VAT.
+		$this->assertVatNumberIs('', $this->thirdparty('800000028', '', 'FR', '', 0));
+
+		// No professional id at all.
+		$this->assertVatNumberIs('', $this->thirdparty('', ''));
+
+		// An idprof1 that is not a SIREN, with no SIRET to fall back on. This used to build
+		// "FR9012345" out of it.
+		$this->assertVatNumberIs('', $this->thirdparty('12345', ''));
+
+		// Neither of the two is valid.
+		$this->assertVatNumberIs('', $this->thirdparty('12345', '12345678912345'));
+	}
+}


### PR DESCRIPTION
`EInvoicing::thirdpartyCalcVATIntra()` was a module-side copy of a method the core already
has, `Societe::calculateVATNumberFromProperties()` — and the copy carried two defects the core
version does not.

Read on the seven supported cores (18.0.10, 19.0.4, 20.0.4, 21.0.4, 22.0.5, 23, 24): the core
method exists in **24 only**, in `societe/class/societe.class.php`.

| | core | module before |
|---|---|---|
| VAT key | `str_pad($cle, 2, '0', STR_PAD_LEFT)` | raw concatenation |
| SIREN taken from a SIRET | `substr($siret, 0, 9)`, kept a string | `(int) substr(...)` |

What that cost on the seller (BT-31) and buyer (BT-48) VAT identifier:

- the key is `00`..`09` for about one SIREN in ten — 3 is invertible modulo 97, so each key
  0..96 falls for exactly one remainder — which produced `FR5123456789`, 12 characters
  instead of 13;
- a SIREN starting with `0`, derived from `idprof2` when `idprof1` is empty, lost its leading
  zero: `01234567500008` gave `FR1212345675` instead of `FR12012345675`;
- an identifier written with separators kept them: `800 000 028` gave `FR84800 000 028`.

The method now delegates to the core when the core has it — a `method_exists()` test, not a
version test — and falls back on a faithful backport in `compat/`, next to the polyfills already
there. The backport reuses `isValidSiren()`/`isValidSiret()` from `compat/profid.lib.php`, which
matters because `core/lib/profid.lib.php` itself does not exist before Dolibarr 20.

Callers are unchanged.

Tested on a bench running the seven cores side by side: PHPUnit 34/34 on each of 18, 19, 20, 21,
22, 23 and 24. The new test covers a SIREN whose key is below 10, a SIRET with a leading zero,
and every case that must yield no number at all (country other than FR, VAT number already
filled, not liable to VAT, invalid identifiers).


---

This PR stands alone on `main`. It is one of eleven opened together, each on its own subject; every
pair of them, and the whole set in either order, merge onto `main` with no conflict, and the fully
merged tree passes 44/44 on the seven cores. They can be reviewed and merged in any order, or
individually.
