### PR TITLE
FIX einvoicing: strip the spaces of an identifier the same way everywhere

### DIFF
--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -1008,7 +1008,7 @@ class EInvoicing
 						$einvoiceid = getDolGlobalString($uriConf);
 
 						//EINVOICING_LIVE
-						if (!preg_match('/^' . preg_replace('/\s+/', '', $mysoc->idprof1) . '/', $this->removeSpaces($einvoiceid))) {
+						if (!preg_match('/^' . removeAllSpaces($mysoc->idprof1) . '/', removeAllSpaces($einvoiceid))) {
 							//if (!empty($provider)) {
 								$baseWarnings[] = $langs->trans("FxCheckErrorRoutingIDFR", $einvoiceid);	// Your company profid must match the routing ID
 							//}
@@ -1025,7 +1025,7 @@ class EInvoicing
 		if (empty($mysoc->tva_intra) && (!empty($mysoc->tva_assuj) && $mysoc->tva_assuj != 'franchise')) {
 			$baseWarnings[] = $langs->trans("FxCheckErrorVATnumber");
 		}
-		if (!empty($mysoc->tva_intra) && !preg_match('/^[A-Z]{2}[A-Z0-9]{2,12}$/', $this->removeSpaces($mysoc->tva_intra))) { // Check VAT number format: 2-letter country code + 2 to 12 alphanumeric characters
+		if (!empty($mysoc->tva_intra) && !preg_match('/^[A-Z]{2}[A-Z0-9]{2,12}$/', removeAllSpaces($mysoc->tva_intra))) { // Check VAT number format: 2-letter country code + 2 to 12 alphanumeric characters
 			$baseErrors[] = $langs->trans("FxCheckErrorVATnumberFormat");
 		}
 		if (empty($mysoc->address)) {
@@ -1089,7 +1089,7 @@ class EInvoicing
 			}
 		} elseif (!empty($thirdparty->country_code) && $thirdparty->country_code === 'FR') {
 			// Validate SIREN/SIRET format based on length (French companies only)
-			$idprof1 = preg_replace('/\s+/', '', (string) $thirdparty->idprof1);
+			$idprof1 = removeAllSpaces((string) $thirdparty->idprof1);
 			if (strlen($idprof1) === 14) {
 				if (!isValidSiret($idprof1)) {
 					$baseWarnings[] = $langs->trans("FxCheckErrorCustomerSIRETFormat");
@@ -1131,12 +1131,12 @@ class EInvoicing
 			$baseWarnings[] = $langs->trans("FxCheckErrorCustomerVAT");
 		} elseif ($thirdparty->tva_assuj && !empty($thirdparty->tva_intra) && !empty($thirdparty->country_code) && $thirdparty->country_code === 'FR') {
 			// Validate French intra-community VAT number format: FR + 2 alphanumeric characters + 9 digits (SIREN)
-			$vatNormalized = strtoupper(preg_replace('/\s+/', '', $thirdparty->tva_intra));
+			$vatNormalized = strtoupper(removeAllSpaces($thirdparty->tva_intra));
 			if (!preg_match('/^FR[0-9A-Z]{2}[0-9]{9}$/', $vatNormalized)) {
 				$baseWarnings[] = $langs->trans("FxCheckErrorCustomerVATFormat");
 			} elseif (!empty($thirdparty->idprof1)) {
 				// Cross-check VAT against SIREN: French VAT key is deterministic (formula: (12 + 3 * (SIREN % 97)) % 97)
-				$siren9 = substr(preg_replace('/\s+/', '', $thirdparty->idprof1), 0, 9);
+				$siren9 = substr(removeAllSpaces($thirdparty->idprof1), 0, 9);
 				if (ctype_digit($siren9) && strlen($siren9) === 9) {
 					$expectedKey = (12 + 3 * ((int) $siren9 % 97)) % 97;
 					$expectedVAT = 'FR' . str_pad((string) $expectedKey, 2, '0', STR_PAD_LEFT) . $siren9;
@@ -1257,7 +1257,7 @@ class EInvoicing
 			!empty($thirdparty->country_code) && $thirdparty->country_code === 'FR'
 			&& !empty($thirdparty->name) && !empty($thirdparty->idprof1)
 		) {
-			$siren = substr(preg_replace('/\s+/', '', $thirdparty->idprof1), 0, 9);
+			$siren = substr(removeAllSpaces($thirdparty->idprof1), 0, 9);
 			$apiUrl = 'https://recherche-entreprises.api.gouv.fr/search?q=' . urlencode($siren) . '&per_page=5';
 
 			$response = getURLContent($apiUrl, 'GET', '', 1, ['Accept: application/json']);
@@ -3692,8 +3692,11 @@ class EInvoicing
 		if ($check) {
 			if ($mysoc->country_code == 'FR') {
 				if (!empty($einvoiceid)) {
-					$einvoiceid = $this->removeSpaces($einvoiceid);
-					if (!preg_match('/^' . preg_replace('/\s+/', '', $mysoc->idprof1) . '/', $einvoiceid)) {
+					$einvoiceid = removeAllSpaces($einvoiceid);
+					// Both sides of the comparison must be stripped the same way: idprof() built the routing id
+					// with removeAllSpaces(), so a non-breaking space pasted into idprof1 would otherwise survive
+					// here only, the match would fail and, in live mode, the seller URI would be emptied below.
+					if (!preg_match('/^' . removeAllSpaces($mysoc->idprof1) . '/', $einvoiceid)) {
 						if (getDolGlobalString('EINVOICING_LIVE')) {	// In live mode, we do not allow profid1 not matching routing id
 							dol_syslog("Error: The seller communication URI seems not correct (should be or start with your SIRET number). Value: " . $einvoiceid, LOG_WARNING);
 							$einvoiceid = '';
@@ -3703,7 +3706,7 @@ class EInvoicing
 			}
 		}
 
-		return $this->removeSpaces($einvoiceid);
+		return removeAllSpaces($einvoiceid);
 	}
 
 	/**
@@ -3717,7 +3720,7 @@ class EInvoicing
 	 */
 	public function getPeppolAccessPointBySiren($siren)
 	{
-		$siren = $this->removeSpaces((string) $siren);
+		$siren = removeAllSpaces((string) $siren);
 		if (empty($siren)) {
 			return null;
 		}
@@ -3777,7 +3780,7 @@ class EInvoicing
 		if ($invoice !== null && !empty($invoice->id)) {
 			$statusInfo = $this->fetchLastknownInvoiceStatus($invoice->id, $invoice->ref);
 			if (!empty($statusInfo['override_routing_id'])) {
-				return $this->removeSpaces($statusInfo['override_routing_id']);
+				return removeAllSpaces($statusInfo['override_routing_id']);
 			}
 		}
 
@@ -3791,7 +3794,7 @@ class EInvoicing
 			$uri = $thirdparty->idprof1;
 		}
 
-		return $this->removeSpaces($uri);
+		return removeAllSpaces($uri);
 	}
 
 	/**
@@ -3800,11 +3803,15 @@ class EInvoicing
 	 *
 	 * @param   string  $str  	String to cleanup
 	 * @return  string  		cleaned up string
+	 * @deprecated			Use the removeAllSpaces() function of einvoicing/lib/einvoicing.lib.php instead. This
+	 *						method only removed the ASCII spaces, so an identifier carrying a non-breaking space
+	 *						came out of it differently than out of idprof(). Kept as a delegation because it is
+	 *						public: another module or a hook may be calling it.
+	 * @see removeAllSpaces()
 	 */
 	public function removeSpaces($str)
 	{
-		// TODO: move this function to class utils
-		return preg_replace('/\\s+/', '', $str);
+		return removeAllSpaces($str);
 	}
 
 	/**

--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -24,6 +24,8 @@
  * \brief   Common methods for all AP protocols.
  */
 
+dol_include_once('einvoicing/lib/einvoicing.lib.php');	// removeAllSpaces(), used to clean the identifiers read from a received document
+
 /**
  * @mixin AbstractProtocol
  */
@@ -560,7 +562,7 @@ trait CommonProtocol
 		// Step 2: Try to find using VAT number if not found by global IDs
 		if ($thirdpartyId < 0) {
 			if (!empty($sellerInfo['sellerTaxRegistations']['VA'])) {
-				$sql = "SELECT rowid FROM " . MAIN_DB_PREFIX . "societe WHERE REPLACE(tva_intra, ' ', '') = '" . $db->escape($einvoicing->removeSpaces($sellerInfo['sellerTaxRegistations']['VA'])) . "' AND entity IN (". getEntity('societe').")";
+				$sql = "SELECT rowid FROM " . MAIN_DB_PREFIX . "societe WHERE REPLACE(tva_intra, ' ', '') = '" . $db->escape(removeAllSpaces($sellerInfo['sellerTaxRegistations']['VA'])) . "' AND entity IN (". getEntity('societe').")";
 				$resql = $db->query($sql);
 				if ($resql) {
 					if ($db->num_rows($resql) > 1) {
@@ -717,13 +719,13 @@ trait CommonProtocol
 							if (!empty($globalId)) {
 								$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode);
 								if (!empty($idprofField)) {
-									$thirdparty->$idprofField = $einvoicing->removeSpaces($globalId);
+									$thirdparty->$idprofField = removeAllSpaces($globalId);
 								}
 							}
 						}
 					}
 					if (!empty($sellerInfo['sellerTaxRegistations']['VA'])) {
-						$thirdparty->tva_intra = $einvoicing->removeSpaces($sellerInfo['sellerTaxRegistations']['VA']);
+						$thirdparty->tva_intra = removeAllSpaces($sellerInfo['sellerTaxRegistations']['VA']);
 						$thirdparty->tva_assuj = 1;
 					}
 				} elseif ($priority === 'dolibarr') { // Fill only empty fields from pdp data
@@ -765,13 +767,13 @@ trait CommonProtocol
 							if (!empty($globalId)) {
 								$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode);
 								if (!empty($idprofField) && empty($thirdparty->$idprofField)) {
-									$thirdparty->$idprofField = $einvoicing->removeSpaces($globalId);
+									$thirdparty->$idprofField = removeAllSpaces($globalId);
 								}
 							}
 						}
 					}
 					if (!empty($sellerInfo['sellerTaxRegistations']['VA']) && empty($thirdparty->tva_intra)) {
-						$thirdparty->tva_intra = $einvoicing->removeSpaces($sellerInfo['sellerTaxRegistations']['VA']);
+						$thirdparty->tva_intra = removeAllSpaces($sellerInfo['sellerTaxRegistations']['VA']);
 						$thirdparty->tva_assuj = 1;
 					}
 				}
@@ -855,14 +857,14 @@ trait CommonProtocol
 					if (!empty($globalId)) {
 						$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode);
 						if (!empty($idprofField)) {
-							$thirdparty->$idprofField = $einvoicing->removeSpaces($globalId);
+							$thirdparty->$idprofField = removeAllSpaces($globalId);
 						}
 					}
 				}
 			}
 
 			if (!empty($sellerInfo['sellerTaxRegistations']['VA'])) {
-				$thirdparty->tva_intra = $einvoicing->removeSpaces($sellerInfo['sellerTaxRegistations']['VA']);
+				$thirdparty->tva_intra = removeAllSpaces($sellerInfo['sellerTaxRegistations']['VA']);
 				$thirdparty->tva_assuj = 1;
 			}
 

--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -27,6 +27,7 @@
  */
 
 require_once __DIR__ . '/../protocols/ProtocolManager.class.php';
+dol_include_once('einvoicing/lib/einvoicing.lib.php');	// removeAllSpaces(), used to normalize an electronic address
 
 
 /**
@@ -387,7 +388,7 @@ abstract class AbstractPDPProvider
 	 */
 	protected static function normalizeAddressingIdentifier($identifier)
 	{
-		$identifier = preg_replace('/\s+/', '', (string) $identifier);
+		$identifier = removeAllSpaces((string) $identifier);
 
 		$reg = array();
 		if (preg_match('/^[0-9]{4}:(.+)$/', $identifier, $reg)) {

--- a/einvoicing/class/utils/CdarHandler.class.php
+++ b/einvoicing/class/utils/CdarHandler.class.php
@@ -360,14 +360,14 @@ class CdarHandler
 		$this->recipientURIIDOrigin = 'issuerid';
 		if ($statusCode != 212 && $object->thirdparty instanceof Societe) {
 			$vendorRouting = $einvoicing->fetchDefaultRouting($object->thirdparty->id);
-			$vendorURIID = ($vendorRouting > 0) ? $einvoicing->removeSpaces((string) $vendorRouting) : '';	// 0 when none is recorded, -1 on error
+			$vendorURIID = ($vendorRouting > 0) ? removeAllSpaces((string) $vendorRouting) : '';	// 0 when none is recorded, -1 on error
 
 			if ($vendorURIID !== '') {
 				$this->recipientURIIDOrigin = 'routing';
 			}
 
 			if ($vendorURIID === '') {
-				$vendorURIID = $einvoicing->removeSpaces($vendorIdentity['uriid']);
+				$vendorURIID = removeAllSpaces($vendorIdentity['uriid']);
 				if ($vendorURIID !== '') {
 					$this->recipientURIIDOrigin = 'einvoice';
 					dol_syslog(__METHOD__ . ' no routing ID recorded for vendor SIREN ' . $InvoiceIssuerGlobalID . ', replying to the electronic address of the invoice it sent us: ' . $vendorURIID, LOG_NOTICE);
@@ -382,7 +382,7 @@ class CdarHandler
 				if (is_object($provider)) {
 					$directory = $provider->checkRecipientDirectory($InvoiceIssuerGlobalID);
 					if (!empty($directory['identifier'])) {
-						$vendorURIID = $einvoicing->removeSpaces($directory['identifier']);
+						$vendorURIID = removeAllSpaces($directory['identifier']);
 						$this->recipientURIIDOrigin = 'directory';
 						dol_syslog(__METHOD__ . ' nothing known about how to reach vendor SIREN ' . $InvoiceIssuerGlobalID . ', using the address the directory declares for it: ' . $vendorURIID, LOG_NOTICE);
 					} else {

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -1007,8 +1007,8 @@ $invoiceData = [
 	'totalPrepaidAmount'        => $prepaidAmount,
 
 	'iban_id'                   => $account->id,
-	'iban'                      => $einvoicing->removeSpaces($account->iban),
-	'bic'                       => $einvoicing->removeSpaces($account->bic),
+	'iban'                      => removeAllSpaces($account->iban),
+	'bic'                       => removeAllSpaces($account->bic),
 	'accountName'               => $account_proprio,
 	'accountRef'                => $account->ref,
 	'accountLabel'              => $account->label,
@@ -1121,12 +1121,12 @@ if ($mySchemeIdProf == "0002" && strlen($myidprof) != 9) {
 	throw new Exception('BADPROFID: The professional ID ' . $myidprof . ' has type SIREN but length is not 9 characters. Fix this in your company or einvoice module setup page.');
 }
 if ($mysoc->country_code == 'FR' && !empty($mysoc->idprof1) && !empty($mysoc->idprof2)) {
-	if (strpos(preg_replace('/\s+/', '', $mysoc->idprof2), preg_replace('/\s+/', '', $mysoc->idprof1)) !== 0) {
+	if (strpos(removeAllSpaces($mysoc->idprof2), removeAllSpaces($mysoc->idprof1)) !== 0) {
 		throw new Exception('BADVALUEFORSIRENORSIRET: The seller has both a SIREN and SIRET but SIRET does not start with value of SIREN.');
 	}
 }
 if ($buyerParty->country_code == 'FR' && !empty($buyerParty->idprof1) && !empty($buyerParty->idprof2)) {
-	if (strpos(preg_replace('/\s+/', '', $buyerParty->idprof2), preg_replace('/\s+/', '', $buyerParty->idprof1)) !== 0) {
+	if (strpos(removeAllSpaces($buyerParty->idprof2), removeAllSpaces($buyerParty->idprof1)) !== 0) {
 		throw new Exception('BADVALUEFORSIRENORSIRET: The buyer has both a SIREN "' . $buyerParty->idprof1 . '" and SIRET "' . $buyerParty->idprof2 . '" but SIRET does not start with value of SIREN.');
 	}
 }

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -217,11 +217,24 @@ function thirdpartyidprof($object)
 }
 
 /**
- * removeAllSpaces
+ * Remove every space of an identifier, whatever kind of space it is.
  *
- * @param  ?string $str string to be cleaned
- * @param  ?string $original_encoding original encoding
- * @return string
+ * French people write a long number in groups to read it back - SIREN "844 431 239", SIRET
+ * "844 431 239 00020", VAT number "FR 43 844431239" - and a value copied from a web page or from a
+ * PDF very often carries a non-breaking space (U+00A0), a thin space or a zero-width character
+ * rather than the ordinary one. None of them belongs to the identifier, and a '/\s+/' pattern
+ * written without the /u modifier sees none of them.
+ *
+ * This is the one and only place where the module strips those spaces, so the identifier it emits
+ * (idprof(), the routing id sent to the platform) and the identifier it checks back
+ * (EInvoicing::getSellerCommunicationURI() and the configuration pre-checks) are always cleaned the
+ * same way. It lives here, in the module library, rather than in a class: idprof() and the provider
+ * classes call it as a free function, and it needs no object to do its job. See the deprecated
+ * EInvoicing::removeSpaces(), which now delegates here.
+ *
+ * @param  ?string $str					String to be cleaned. null is accepted and gives ''.
+ * @param  ?string $original_encoding	Encoding of $str, null to detect it. The result is given back in that same encoding.
+ * @return string						Cleaned up string
  */
 function removeAllSpaces($str, $original_encoding = null)
 {
@@ -229,28 +242,52 @@ function removeAllSpaces($str, $original_encoding = null)
 	if ($str === null) {
 		$str = '';
 	}
+	$str = (string) $str;
+	if ($str === '') {
+		return '';
+	}
+
+	// mbstring is only recommended by Dolibarr, never required: without it we still strip what the
+	// Unicode pattern below can strip, instead of fataling on mb_detect_encoding().
+	$hasmbstring = (function_exists('mb_detect_encoding') && function_exists('mb_convert_encoding'));
+
 	// find encoding
-	if ($original_encoding === null) {
+	if ($original_encoding === null && $hasmbstring) {
 		$original_encoding = mb_detect_encoding($str, mb_detect_order(), true) ?: 'UTF-8';
 	}
 
-	$is_utf8 = (strtoupper($original_encoding) === 'UTF-8');
-	if (!$is_utf8) {
-		$str = mb_convert_encoding($str, 'UTF-8', $original_encoding);
+	// Convert to UTF-8 only when the encoding is known and we are able to convert: everything below works
+	// on UTF-8. The encoding to restore is held in its own variable rather than in a boolean, so that it
+	// is plainly a string on both conversions below - mb_convert_encoding() takes no null.
+	$sourceencoding = ($hasmbstring && $original_encoding !== null && strtoupper($original_encoding) !== 'UTF-8') ? $original_encoding : '';
+	if ($sourceencoding !== '') {
+		$str = mb_convert_encoding($str, 'UTF-8', $sourceencoding);
 	}
 
 	// this transform '&nbsp;', '&ensp;', '&emsp;', '&thinsp;' etc. in real spaces Unicode
-	$str = html_entity_decode($str, ENT_QUOTES | ENT_HTML5, 'UTF-8');
-
-	// suppress via Regex
-	$str = preg_replace('/[\p{Z}\s\x{200B}-\x{200D}\x{FEFF}]+/u', '', $str);
-
-	// restore encoding
-	if (!$is_utf8) {
-		$str = mb_convert_encoding($str, $original_encoding, 'UTF-8');
+	$decoded = html_entity_decode($str, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+	// Without ENT_SUBSTITUTE, html_entity_decode() answers '' on a string that is not valid UTF-8.
+	// Keep the bytes we were given rather than losing the identifier altogether.
+	if ($decoded !== '') {
+		$str = $decoded;
 	}
 
-	return $str;
+	// suppress via Regex
+	$cleaned = preg_replace('/[\p{Z}\s\x{200B}-\x{200D}\x{FEFF}]+/u', '', $str);
+	if ($cleaned === null) {
+		// The /u modifier makes preg_replace() answer null on a string that is not valid UTF-8. Fall
+		// back to the ASCII-only strip, so a badly encoded identifier is at worst cleaned the way the
+		// deprecated EInvoicing::removeSpaces() used to clean it, and never returned as null.
+		$cleaned = preg_replace('/\s+/', '', $str);
+	}
+	$str = ($cleaned === null ? $str : $cleaned);
+
+	// restore encoding
+	if ($sourceencoding !== '') {
+		$str = mb_convert_encoding($str, $sourceencoding, 'UTF-8');
+	}
+
+	return (string) $str;
 }
 
 

--- a/einvoicing/test/phpunit/IdentifierSpaceStrippingTest.php
+++ b/einvoicing/test/phpunit/IdentifierSpaceStrippingTest.php
@@ -1,0 +1,348 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/IdentifierSpaceStrippingTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test proving the module strips the spaces of an identifier the same way everywhere.
+ *                  The module used to carry two strippers: removeAllSpaces(), which knows every kind of
+ *                  space, and EInvoicing::removeSpaces(), a '/\s+/' without the /u modifier that sees
+ *                  none of the non-breaking, thin or zero-width ones. idprof() built the routing id with
+ *                  the first one while getSellerCommunicationURI() checked it back with the second, so a
+ *                  non-breaking space pasted into idprof1 - what a SIRET copied from a web page or a PDF
+ *                  carries - made the two sides disagree and, in EINVOICING_LIVE, emptied the seller URI.
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+// See VatPointDateCodeTest for why DOLIBARR_HTDOCS is honoured before the relative path.
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
+dol_include_once('einvoicing/lib/einvoicing.lib.php');
+dol_include_once('einvoicing/class/einvoicing.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class IdentifierSpaceStrippingTest extends CommonClassTest
+{
+	/** @var string	The SIREN of the fixtures, without any separator */
+	const SIREN = '844431239';
+	/** @var string	The SIRET of the same company, without any separator. It starts with the SIREN, as the check expects. */
+	const SIRET = '84443123900020';
+
+	/** @var array<string,string> Module options this test pins, saved as they were found */
+	private $savedoptions = array();
+	/** @var Societe|null Global $mysoc as it was found */
+	private $savedmysoc = null;
+
+	/**
+	 * Pin the options getSellerCommunicationURI() reads, and give the test its own $mysoc so the
+	 * company of the instance the suite runs against does not decide the result.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void
+	{
+		global $conf, $mysoc;
+
+		parent::setUp();
+
+		foreach (array('EINVOICING_PDP', 'EINVOICING_SUPERPDP_ROUTING_ID', 'EINVOICING_LIVE') as $option) {
+			$this->savedoptions[$option] = getDolGlobalString($option);
+		}
+		$this->savedmysoc = $mysoc;
+
+		$conf->global->EINVOICING_PDP = 'SuperPDP';
+	}
+
+	/**
+	 * Put back the options and the company, whatever the test did with them.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void
+	{
+		global $conf, $mysoc;
+
+		$mysoc = $this->savedmysoc;
+		foreach ($this->savedoptions as $option => $value) {
+			if ($value === '') {
+				unset($conf->global->$option);
+			} else {
+				$conf->global->$option = $value;
+			}
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The company of the test, written the way a user writes it: the professional id carries the
+	 * separator given, which is what a value copied from a web page or from a PDF looks like.
+	 *
+	 * @param	string	$separator	The character written between the groups of the SIREN
+	 * @return	Societe
+	 */
+	private function seller($separator)
+	{
+		global $db;
+
+		$seller = new Societe($db);
+		$seller->name = 'Seller';
+		$seller->country_code = 'FR';
+		$seller->idprof1 = '844' . $separator . '431' . $separator . '239';
+
+		return $seller;
+	}
+
+	/**
+	 * Every writing of a space a French identifier may carry. The key names the character, the value
+	 * is the SIRET written with it, and each of them must be stripped down to the bare number.
+	 *
+	 * @return array<string,string>
+	 */
+	private function siretsWrittenWithEveryKindOfSpace()
+	{
+		return array(
+			'ordinary space'      => '844 431 239 00020',
+			'tabulation'          => "844\t431\t239\t00020",
+			'line feed'           => "844\n431 239 00020",
+			'non-breaking space'  => "844\xC2\xA0431\xC2\xA0239\xC2\xA000020",	// U+00A0, what a copy-paste brings
+			'narrow nbsp'         => "844\xE2\x80\xAF431\xE2\x80\xAF239\xE2\x80\xAF00020",	// U+202F
+			'thin space'          => "844\xE2\x80\x89431\xE2\x80\x89239\xE2\x80\x8900020",	// U+2009
+			'zero width space'    => "844\xE2\x80\x8B431\xE2\x80\x8B239\xE2\x80\x8B00020",	// U+200B
+			'byte order mark'     => "\xEF\xBB\xBF84443123900020",					// U+FEFF, in head of a pasted value
+			'html entity'         => '844&nbsp;431&nbsp;239&nbsp;00020',
+		);
+	}
+
+	/**
+	 * The single stripper must see every kind of space, not only the ASCII ones.
+	 *
+	 * @return void
+	 */
+	public function testEveryKindOfSpaceIsStrippedFromAnIdentifier()
+	{
+		foreach ($this->siretsWrittenWithEveryKindOfSpace() as $kind => $siret) {
+			$this->assertSame(self::SIRET, removeAllSpaces($siret), 'a SIRET written with a ' . $kind . ' must be cleaned');
+		}
+	}
+
+	/**
+	 * The public method of the class is deprecated but still reachable by another module or by a hook.
+	 * It must now answer exactly what the function answers: one implementation, one result.
+	 *
+	 * @return void
+	 */
+	public function testTheDeprecatedMethodStripsExactlyLikeTheFunction()
+	{
+		global $db;
+
+		$einvoicing = new EInvoicing($db);
+
+		foreach ($this->siretsWrittenWithEveryKindOfSpace() as $kind => $siret) {
+			$this->assertSame(removeAllSpaces($siret), $einvoicing->removeSpaces($siret), 'both strippers must agree on a SIRET written with a ' . $kind);
+			$this->assertSame(self::SIRET, $einvoicing->removeSpaces($siret), 'the deprecated method must clean a SIRET written with a ' . $kind);
+		}
+	}
+
+	/**
+	 * The single stripper replaces one that never failed on anything, so it must not be more fragile
+	 * than it was: a null identifier and an empty one give '', a badly encoded one keeps its bytes
+	 * cleaned of the ASCII spaces (what the deprecated method used to return), and the answer is
+	 * always a string, never null.
+	 *
+	 * @return void
+	 */
+	public function testTheEdgeCasesAreNoMoreFragileThanTheAsciiStrip()
+	{
+		global $db;
+
+		$einvoicing = new EInvoicing($db);
+
+		$this->assertSame('', removeAllSpaces(null), 'a null identifier is an empty one');
+		$this->assertSame('', removeAllSpaces(''), 'an empty identifier stays empty');
+		$this->assertSame('', $einvoicing->removeSpaces(null));
+		$this->assertSame('', $einvoicing->removeSpaces(''));
+
+		// A Latin-1 payload: "\xE9" alone is not valid UTF-8, so neither the entity decoding nor the
+		// Unicode pattern can work on it. The identifier must come back stripped of its ASCII spaces
+		// rather than emptied or turned into null.
+		$latin1 = "SIRET\xE9 844 431 239";
+		$this->assertSame("SIRET\xE9844431239", removeAllSpaces($latin1), 'a badly encoded identifier keeps its bytes');
+		$this->assertSame(removeAllSpaces($latin1), $einvoicing->removeSpaces($latin1));
+
+		foreach (array(null, '', $latin1, '844 431 239') as $value) {
+			$this->assertIsString(removeAllSpaces($value), 'the stripper always answers a string');
+		}
+	}
+
+	/**
+	 * The stripper works on UTF-8 internally, so when the caller names another encoding it converts,
+	 * strips, and must give the value back in the encoding it was handed. Two things are asserted:
+	 * the round trip really enables the strip - a Latin-1 identifier separated by the single byte
+	 * 0xA0 comes back as the bare number - and a byte that only exists in the source encoding is
+	 * restored as it was, not left in its UTF-8 form.
+	 *
+	 * @return void
+	 */
+	public function testTheOriginalEncodingIsRestoredWhenOneIsNamed()
+	{
+		if (!function_exists('mb_convert_encoding')) {
+			$this->markTestSkipped('mbstring is not installed, the stripper does not convert anything');
+		}
+
+		// "844 431 239" written in ISO-8859-1, where the non-breaking space is the single byte 0xA0.
+		// Read as UTF-8 those bytes mean nothing, so only the conversion lets the pattern see them.
+		$this->assertSame(self::SIREN, removeAllSpaces("844\xA0431\xA0239", 'ISO-8859-1'), 'a Latin-1 non-breaking space must be stripped too');
+
+		// "SIRETé 844 431 239" in ISO-8859-1: the accented byte is not part of a space and must come
+		// back as the single byte 0xE9 it was, not as the two bytes of its UTF-8 form.
+		$restored = removeAllSpaces("SIRET\xE9 844 431 239", 'ISO-8859-1');
+		$this->assertSame("SIRET\xE9844431239", $restored, 'the value must be given back in the encoding it was handed');
+		$this->assertNotSame("SIRET\xC3\xA9844431239", $restored, 'the value must not stay converted to UTF-8');
+
+		// Naming UTF-8 explicitly must change nothing compared to letting the stripper detect it.
+		$utf8 = "844\xC2\xA0431\xC2\xA0239";
+		$this->assertSame(self::SIREN, removeAllSpaces($utf8, 'UTF-8'));
+		$this->assertSame(removeAllSpaces($utf8), removeAllSpaces($utf8, 'UTF-8'));
+	}
+
+	/**
+	 * The bug: in live mode, a non-breaking space in the professional id emptied the seller
+	 * communication URI. idprof() had stripped it to build the routing id while the check kept it,
+	 * so the two sides of the same comparison never matched and the URI was dropped.
+	 *
+	 * @return void
+	 */
+	public function testTheSellerUriSurvivesANonBreakingSpaceInTheProfessionalIdInLiveMode()
+	{
+		global $conf, $db, $mysoc;
+
+		$mysoc = $this->seller("\xC2\xA0");
+		$conf->global->EINVOICING_SUPERPDP_ROUTING_ID = self::SIRET;
+		$conf->global->EINVOICING_LIVE = 1;
+
+		$einvoicing = new EInvoicing($db);
+
+		$this->assertSame(self::SIRET, $einvoicing->getSellerCommunicationURI(), 'a non-breaking space in idprof1 must not empty the seller URI');
+	}
+
+	/**
+	 * The same scenario with the ordinary space, which used to work and must keep working: this is the
+	 * control telling a regression of the fix apart from a fixture that never exercised the bug.
+	 *
+	 * @return void
+	 */
+	public function testTheSellerUriSurvivesAnOrdinarySpaceInTheProfessionalIdInLiveMode()
+	{
+		global $conf, $db, $mysoc;
+
+		$mysoc = $this->seller(' ');
+		$conf->global->EINVOICING_SUPERPDP_ROUTING_ID = self::SIRET;
+		$conf->global->EINVOICING_LIVE = 1;
+
+		$einvoicing = new EInvoicing($db);
+
+		$this->assertSame(self::SIRET, $einvoicing->getSellerCommunicationURI());
+	}
+
+	/**
+	 * The check itself must keep biting: a routing id that really does not belong to the company is
+	 * still refused in live mode. Stripping the spaces the same way on both sides removes the false
+	 * mismatch, not the real one.
+	 *
+	 * @return void
+	 */
+	public function testTheSellerUriIsStillEmptiedInLiveModeWhenTheRoutingIdDoesNotBelongToTheCompany()
+	{
+		global $conf, $db, $mysoc;
+
+		$mysoc = $this->seller("\xC2\xA0");
+		$conf->global->EINVOICING_SUPERPDP_ROUTING_ID = '99999999900011';	// another company
+		$conf->global->EINVOICING_LIVE = 1;
+
+		$einvoicing = new EInvoicing($db);
+
+		$this->assertSame('', $einvoicing->getSellerCommunicationURI(), 'a routing id of another company must still be refused in live mode');
+	}
+
+	/**
+	 * When no routing id is recorded for the access point, the URI falls back on the professional id
+	 * through idprof(). Both the value produced and the value checked go through the same stripper, so
+	 * the fallback answers the bare SIREN whatever kind of space the user typed in it.
+	 *
+	 * @return void
+	 */
+	public function testTheFallbackOnTheProfessionalIdIsCleanedTheSameWay()
+	{
+		global $conf, $db, $mysoc;
+
+		unset($conf->global->EINVOICING_SUPERPDP_ROUTING_ID);
+		$conf->global->EINVOICING_LIVE = 1;
+
+		foreach (array('ordinary space' => ' ', 'non-breaking space' => "\xC2\xA0", 'thin space' => "\xE2\x80\x89") as $kind => $separator) {
+			$mysoc = $this->seller($separator);
+			$einvoicing = new EInvoicing($db);
+
+			$this->assertSame(self::SIREN, $einvoicing->getSellerCommunicationURI(), 'the fallback on idprof1 written with a ' . $kind . ' must give the bare SIREN');
+		}
+	}
+
+	/**
+	 * idprof() and the check of getSellerCommunicationURI() are the two ends of the same chain: what
+	 * one produces, the other must recognise. Assert it directly, on every kind of space, so a future
+	 * stripper added on one end only is caught here.
+	 *
+	 * @return void
+	 */
+	public function testIdprofAndTheSellerUriAgreeOnEveryKindOfSpace()
+	{
+		global $conf, $db, $mysoc;
+
+		$conf->global->EINVOICING_LIVE = 1;
+
+		foreach (array(' ', "\xC2\xA0", "\xE2\x80\xAF", "\xE2\x80\x89", "\xE2\x80\x8B") as $separator) {
+			$mysoc = $this->seller($separator);
+			$this->assertSame(self::SIREN, idprof($mysoc), 'idprof() must give the bare SIREN');
+
+			$conf->global->EINVOICING_SUPERPDP_ROUTING_ID = idprof($mysoc);
+			$einvoicing = new EInvoicing($db);
+
+			$this->assertSame(self::SIREN, $einvoicing->getSellerCommunicationURI(), 'the URI check must recognise the routing id idprof() built');
+		}
+	}
+}


### PR DESCRIPTION
The module had two functions doing the same job — stripping the spaces French users put inside a
SIREN, a SIRET or a VAT number — and the weaker one was used where it mattered.

- `EInvoicing::removeSpaces()` : `preg_replace('/\s+/', '', $str)`, and it carried its own
  `// TODO: move this function to class utils`.
- `removeAllSpaces()` in `lib/einvoicing.lib.php` : `preg_replace('/[\p{Z}\s\x{200B}-\x{200D}\x{FEFF}]+/u', ...)`.

`\s` without the `/u` modifier does not match the non-breaking space U+00A0, nor a narrow or thin
space, nor a BOM. The strong one does.

That split had a consequence. `idprof()`, which **produces** the routing identifier, used the
strong function; `EInvoicing::getSellerCommunicationURI()`, which **validates** that same
identifier, used the weak one on both sides of its comparison. A non-breaking space in `idprof1` —
which is what you get pasting a SIRET from a web page or a PDF — made the two cleanups disagree,
the `preg_match()` fail, and **in `EINVOICING_LIVE` mode the seller URI was emptied**.

There is no core equivalent to call instead, checked on the seven supported cores:
`dol_string_nospecial()` only replaces the literal ASCII space through `str_replace`,
`dol_string_nounprintableascii()` stops at `[\x00-\x1F\x7F]`, `dol_sanitizeKeyCode()` only exists
from v21 and drops far more than spaces. No `\p{Z}`, no `\x{00A0}`, no `\x{FEFF}` anywhere in the
core function library on any of the seven.

So the module keeps one implementation, the strong one, and every caller goes through it —
including the `preg_replace('/\s+/', '', …)` written inline on identifiers at several places.
`EInvoicing::removeSpaces()` is public, so it is kept and now delegates, marked `@deprecated`.

The strong function was also hardened along the way: it called `mb_detect_encoding()` unguarded
(fatal without mbstring, which Dolibarr only recommends), and on non-UTF-8 input it returned an
empty string or `null` — silently losing the identifier. Both paths now fall back to the ASCII
strip, which is exactly what the deprecated function returned.

Tested: PHPUnit 34/34 on each of the seven cores. The new test covers every kind of space, the
edge cases, and the live-mode case above — plus the negative control that a routing identifier
genuinely belonging to another company is **still** rejected.


---

This PR stands alone on `main`. It is one of eleven opened together, each on its own subject; every
pair of them, and the whole set in either order, merge onto `main` with no conflict, and the fully
merged tree passes 44/44 on the seven cores. They can be reviewed and merged in any order, or
individually.
