### PR TITLE
QUAL: [einvoicing] Shorten the comment blocks of the module to the rule of AGENTS.md

### DIFF
--- a/einvoicing/admin/setup_options.php
+++ b/einvoicing/admin/setup_options.php
@@ -267,11 +267,6 @@ if (!getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP')) {
 	$item->defaultFieldValue = '0';
 	$item->cssClass = 'minwidth500';
 
-	// The VAT exigibility scheme decides when the VAT of an invoice falls due, hence the VAT point date
-	// code (BT-8) the document declares, the "VAT on debits" legal mention it carries, and whether a
-	// cash-in has to be reported with the status 212. Dolibarr already holds that scheme in the setup of
-	// the Tax/VAT module (TAX_MODE_SELL_PRODUCT / TAX_MODE_SELL_SERVICE), so it is not duplicated here:
-	// remind its current value, with a link to the page that owns it.
 	// The VAT regime the generated documents declare in BT-8. Left to the VAT mode above by default;
 	// an explicit value is for a seller whose regime that mode cannot express (issue #419).
 	$item = $formSetup->newItem('EINVOICING_VAT_POINT_DATE_CODE')->setAsSelect(array(

--- a/einvoicing/ajax/checkdirectory.php
+++ b/einvoicing/ajax/checkdirectory.php
@@ -181,14 +181,10 @@ function einvoicing_directory_html($r, $siren)
 			}
 			return img_picto('', 'warning', 'class="paddingright"').$txt;
 		case 'undetermined':
-			// Neutral on purpose: a line exists but its status was not communicated, so the check fails
-			// open without asserting anything. Green here is what let an undeliverable invoice be sent.
-			// The provenance matters most here, and used to be the one thing this branch dropped: the
-			// same wording is reached both when the standardized directory answered without a line
-			// status and when it did not answer at all and the platform's own endpoint was read
-			// instead. The first is the recipient's platform being terse, the second is a call
-			// failing on this instance - two different problems, and only the message tells them
-			// apart (issue #698).
+			// Neutral on purpose: the line exists but its status was not communicated, so fail open
+			// without asserting anything. Green here would let an undeliverable invoice be sent.
+			// Report the provenance: a terse directory answer and a failed call reach the same
+			// wording, and only the message tells the two apart (issue #698).
 			$txt = $langs->trans("EInvoicingDirectoryUndetermined", $siren);
 			$details = array();
 			if (!empty($r['identifier'])) {

--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -199,19 +199,9 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 							// Optionally transmit to the Access Point right after generation (opt-in + idempotent) and if not yet generated.
 							// Without this, validation only generates the Factur-X; the invoice is never sent to the
 							// PA (transmission was a manual "send_to_pdp" click only).
-							// Restricted to the generation that follows a validation, which is what the option says
-							// it does. This hook is called for every rebuild of the invoice PDF, and several of them
-							// happen long after the validation and with nobody asking for a transmission: recording a
-							// payment rebuilds the document from inside Paiement::create(), and so do the "Generate"
-							// button of the invoice card and any mass/cron PDF rebuild. On an invoice validated before
-							// the module was set up - or deliberately left to be sent by hand - the first of those
-							// rebuilds used to deposit it at the PA on its own, months after its date, and to unlock
-							// the cash-in status (212) that the very same payment then reported.
-							// Then two more guards, because one is not enough: 'transmitted' reads the syncstatus,
-							// which generateInvoice() just reset to GENERATED a few lines above, so it stops seeing a
-							// transmission from the second regeneration on. isTransmittedLockActive() reads the
-							// flow_id, which the first submission assigned and nothing clears, so it holds for good
-							// (and honors EINVOICING_ALLOW_RESEND_TRANSMITTED like the manual send does).
+							// Restricted to the generation following a validation: the other PDF rebuilds (payment,
+							// Generate button, mass/cron) must not deposit the invoice at the PA. The flow_id lock is
+							// the reliable guard, as generateInvoice() just reset the syncstatus to GENERATED above.
 							if (getDolGlobalString('EINVOICING_AUTO_SEND_ON_GENERATION') && EInvoicing::isInvoiceValidatedInThisRequest($invoiceObject->id)
 								&& empty($currentStatusDetails['transmitted'])
 								&& !$einvoicing->isTransmittedLockActive($invoiceObject->id, $invoiceObject->ref) && $precheckresult >= 0) {
@@ -475,12 +465,10 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 					print '<div class="info">' . $langs->trans('EInvoiceCreditNoteOfRefusedInvoice', $sourceRef) . '</div>';
 				}
 
-				// Accepting a received invoice validates it in Dolibarr, so on a draft those statuses take
-				// the right the core asks for a validation (fourn/facture/card.php, $usercanvalidate) on
-				// top of the one to edit. Left to the core to render: dolGetButtonAction() drops a
-				// dropdown entry whose perm is empty before Dolibarr 22, and shows it disabled with
-				// "NotEnoughPermissions" after - what it never does is leave a live button that the
-				// action would refuse. A -1 would not do: it is truthy, so the old cores show it enabled.
+				// Accepting a received invoice validates it, so on a draft those statuses also need the right
+				// the core asks for a validation (fourn/facture/card.php, $usercanvalidate). Left to
+				// dolGetButtonAction() to render: an empty perm drops the dropdown entry before Dolibarr 22 and
+				// shows it disabled after. Not -1: it is truthy, so the old cores would show it enabled.
 				$canvalidate = ((!getDolGlobalString('MAIN_USE_ADVANCED_PERMS') && $user->hasRight('fournisseur', 'facture', 'creer'))
 					|| (getDolGlobalString('MAIN_USE_ADVANCED_PERMS') && $user->hasRight('fournisseur', 'supplier_invoice_advance', 'validate')));
 				$isdraft = ((int) $object->status === FactureFournisseur::STATUS_DRAFT);
@@ -641,13 +629,10 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 				}
 			}
 
-			// An invoice already transmitted to the Access Point (a flow_id is assigned, by any provider) is
-			// immutable: re-sending it makes the PA refuse a duplicate, and regenerating it would only reset
-			// the local status and re-open that trap. Block both by default; correct a transmitted invoice
-			// with a credit note / corrective invoice. The operator can opt in (e.g. to test PA retry) via
-			// EINVOICING_ALLOW_RESEND_TRANSMITTED. Based on the persistent flow_id, not the resettable status.
-			// EINVOICING_ALLOW_REGEN_TRANSMITTED keeps regenerate (generate_einvoice) available on a
-			// transmitted-locked invoice for dev/inspection; re-sending (send_to_pdp) stays locked.
+			// An invoice already transmitted (a flow_id is assigned) is immutable: re-sending it makes the PA
+			// refuse a duplicate, and regenerating it would only reset the local status. Block both; correct a
+			// transmitted invoice with a credit note. The lock is based on the persistent flow_id, not on the
+			// resettable status. EINVOICING_ALLOW_RESEND_TRANSMITTED / _ALLOW_REGEN_TRANSMITTED opt out.
 			$lockedActions = getDolGlobalString('EINVOICING_ALLOW_REGEN_TRANSMITTED')
 				? array('send_to_pdp')
 				: array('send_to_pdp', 'generate_einvoice');
@@ -793,12 +778,10 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 					}
 				}
 
-				// Answering "approved" while the invoice stays a draft tells the vendor and the accounts two
-				// different things about the same document. Validating a received invoice in Dolibarr is
-				// the act of accepting it - that is why the BILL_SUPPLIER_VALIDATE trigger answers 205 by
-				// itself - so the answer given from the card validates it too. Validation comes first: a
-				// status accepted by the platform cannot be taken back, while a validation that fails
-				// (numbering, closed period, ...) must leave the exchange untouched.
+				// Validating a received invoice in Dolibarr is the act of accepting it - that is why the
+				// BILL_SUPPLIER_VALIDATE trigger answers 205 by itself - so an approval given from the card
+				// validates it too. Validation comes first: a status accepted by the platform cannot be taken
+				// back, while a validation that fails (numbering, closed period, ...) must leave it untouched.
 				$sendtheanswer = true;
 				if (in_array($pdpstatuscode, EInvoicing::STATUSES_ACCEPTING_A_DOCUMENT, true) && (int) $object->status === FactureFournisseur::STATUS_DRAFT) {
 					if (!$permissiontovalidate) {
@@ -1592,11 +1575,9 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	/**
 	 * Build the condition restricting the join on einvoicing_extlinks (aliased 'ext') to a single row.
 	 *
-	 * An element can carry several links: one per provider, and a provider can be registered both
-	 * directly and through a partner. Without this condition every extra link adds a line to the list
-	 * of the core and, because list.php builds its record count on the same FROM clause, the element
-	 * is counted as many times as it has links. The row kept here is the one
-	 * EInvoicing::fetchLastknownInvoiceStatus() would keep, so a list and a card never disagree.
+	 * An element can carry several links (one per provider, registered directly and through a partner), and
+	 * every extra link would duplicate the element in the core list and in its record count. The row kept
+	 * here is the one EInvoicing::fetchLastknownInvoiceStatus() keeps, so a list and a card never disagree.
 	 *
 	 * @param 	'facture'|'invoice_supplier'|'societe'|'product'	$elementtype	Value of einvoicing_extlinks.element_type, which also tells which list of the core is being built
 	 * @return 	string															Condition to append to the ON clause of the join
@@ -1647,12 +1628,9 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 			if (in_array('thirdpartylist', $contexts, true)) {
 				$this->resprints .= ' LEFT JOIN ' . $db->prefix() . "einvoicing_extlinks as ext ON ext.element_id = s.rowid AND ext.element_type = 'societe'" . self::getExtLinkJoinCondition('societe');
 				$this->resprints .= ' LEFT JOIN ' . $db->prefix() . "einvoicing_routing rt ON rt.fk_soc = s.rowid";
-				// A thirdparty can hold several routing identifiers, and a routing row for its default product
-				// on top of them, so joining on fk_soc alone repeats the thirdparty in the list as many times.
-				// The active default routing of type 'thirdparty' is the single row the list must show: it is
-				// the one the card of the thirdparty displays at the top of its list, and the one
-				// EInvoicing::fetchDefaultRouting() answers. The column stays empty for a thirdparty holding
-				// no routing identifier, so no row leaves the list.
+				// A thirdparty can hold several routing rows, so joining on fk_soc alone repeats it in the list.
+				// Keep the active default routing of type 'thirdparty', the row the card and
+				// EInvoicing::fetchDefaultRouting() show. Stays empty, never filtering, when there is none.
 				$this->resprints .= " AND rt.routing_type = 'thirdparty' AND rt.active = 1 AND rt.is_default = 1";
 			}
 
@@ -1693,13 +1671,10 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 			}
 		}
 
-		// The routing identifier is a column of einvoicing_routing, and printFieldListFrom() joins that
-		// table into the thirdparty list only. Read on 'ext', the alias of einvoicing_extlinks, which
-		// holds no such column, the filter turned the page of the core into an SQL error.
-		//
-		// The filter is written on a subquery of its own rather than on the joined row: a thirdparty can
-		// hold several routing identifiers while the list shows only one of them, so a condition on the
-		// joined row would answer 'no result' for every identifier that is not the one displayed.
+		// The routing identifier is a column of einvoicing_routing, joined by printFieldListFrom() into the
+		// thirdparty list only, never on the 'ext' alias (einvoicing_extlinks). Filter on a subquery of its
+		// own, not on the joined row: a thirdparty can hold several routing identifiers while the list shows
+		// only one, so a condition on the joined row would answer 'no result' for all the others.
 		if (in_array('thirdpartylist', $contexts, true) && GETPOST('search_routing_id', 'alpha') !== '') {
 			$this->resprints .= ' AND EXISTS (SELECT 1 FROM ' . $db->prefix() . 'einvoicing_routing as subrt';
 			$this->resprints .= ' WHERE subrt.fk_soc = s.rowid';	// Alias of the thirdparty in the thirdparty list of the core
@@ -1966,12 +1941,10 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 
 		$contexts = explode(':', $parameters['context']);
 
-		// Every block below counts the cells it prints into the caller's column counter, which sizes the
-		// footer of the list. A hook is not guaranteed to receive that counter already built, so make sure
-		// of it once, before the first increment rather than after it. Only create the key when it is
-		// missing: the caller passes its own counter by reference (list.php builds 'totalarray' =>
-		// &$totalarray), so replacing an existing one would write through that reference and reset the
-		// count it has already accumulated.
+		// The blocks below count their cells into the caller's column counter, which sizes the list footer,
+		// and a hook is not guaranteed to receive it already built. Only create the key when it is missing:
+		// the caller passes it by reference (list.php builds 'totalarray' => &$totalarray), so replacing an
+		// existing one would write through that reference and reset the count already accumulated.
 		if (!array_key_exists('totalarray', $parameters)) {
 			$parameters['totalarray'] = array('nbfield' => 0);
 		} elseif (!array_key_exists('nbfield', $parameters['totalarray'])) {

--- a/einvoicing/class/call.class.php
+++ b/einvoicing/class/call.class.php
@@ -1231,17 +1231,9 @@ class Call extends CommonObject
 	{
 		$prefix = 'Call-';
 
-		// Read the highest number through the connection this record will be written on, not through
-		// the global $db. logCall() builds its Call on the independent $dbhistory precisely so the trace
-		// survives a rollback of the caller, and a number read on another connection can be neither
-		// current nor locked: a page working inside a transaction on $db - recording a payment,
-		// importing a received invoice - holds a consistent-read snapshot taken before the previous
-		// call was committed by $dbhistory, so the same number comes back twice and the second insert
-		// dies on uk_einvoicing_call_callid. The API call it was tracing then leaves no trace at all.
-		//
-		// FOR UPDATE holds the range from this read to that insert: being a locking read it returns the
-		// last committed number instead of a snapshot, and another request numbering at the same moment
-		// waits for the insert rather than taking the number again.
+		// Read on the connection this record will be written on ($dbhistory), not on the global $db: a
+		// snapshot read from another transaction returns a stale number and the insert dies on
+		// uk_einvoicing_call_callid. FOR UPDATE makes it a locking read and holds the range until insert.
 		$sql = "SELECT MAX(CAST(SUBSTRING(call_id, ".(strlen($prefix) + 1).") AS SIGNED)) AS maxref";
 		$sql .= " FROM ".$this->db->prefix().$this->table_element;
 		$sql .= " WHERE call_id LIKE '".$this->db->escape($prefix)."%'";

--- a/einvoicing/class/document.class.php
+++ b/einvoicing/class/document.class.php
@@ -535,18 +535,10 @@ class Document extends CommonObject
 	/**
 	 * Import a received document again, from the access point, as if it had never been imported.
 	 *
-	 * The vendor of a supplier invoice cannot be changed once it exists, so an incoming document
-	 * booked on the wrong third party - because the identifiers it carries matched nothing, or
-	 * matched the wrong record - has no way back short of this: fix the third party data, then run
-	 * the import again and let it resolve the vendor from the document a second time.
-	 *
-	 * The local draft goes first (a validated invoice is refused: it is an accounting record, and
-	 * the recovery this offers is for an import that has not been acted on yet). The flow is then
-	 * fetched from the platform again, which creates the invoice and a record of its own, and that
-	 * record is moved onto this one: a flow the user has imported again keeps the line it already
-	 * had in the list, now pointing at the invoice that has just been created - and that invoice is
-	 * given back the temporary number of the draft it replaces. A failed import changes nothing and
-	 * leaves this record in place, detached, rather than losing the document.
+	 * The vendor of a supplier invoice cannot be changed once it exists, so a document booked on the
+	 * wrong third party has no way back short of this: fix the third party data, then import again.
+	 * The local draft is deleted first; a validated invoice is refused, it is an accounting record.
+	 * A failed import leaves this record in place, detached, rather than losing the document.
 	 *
 	 * @param	User				$user		User asking for the import
 	 * @return	array{res:int,message:string}	res > 0 is the id of the supplier invoice created
@@ -758,11 +750,8 @@ class Document extends CommonObject
 	/**
 	 * Attach to a supplier invoice the lifecycle history of the one it replaces.
 	 *
-	 * A status a vendor has sent - received, made available, rejected - is about the invoice the vendor
-	 * issued, not about the row Dolibarr booked it on: an import made again creates another row for the
-	 * same document, and the statuses already received belong to it just the same. Left where they are
-	 * they would be attached to an invoice that no longer exists, so the new draft would come up with no
-	 * status at all while the flows that carried them sit in the list, linked to nothing.
+	 * A status sent by the vendor is about the document, not about the row Dolibarr booked it on, so an
+	 * import made again must carry it over. Left in place it would point at a deleted invoice.
 	 *
 	 * @param	int			$previousinvoiceid	Supplier invoice the import has just replaced
 	 * @param	int			$newinvoiceid		Supplier invoice the import has just created
@@ -806,14 +795,10 @@ class Document extends CommonObject
 	/**
 	 * Give a draft supplier invoice the temporary reference of the draft it replaces.
 	 *
-	 * A draft is numbered by the core from the id of the row it has just created ("(PROV1234)"), so an
-	 * invoice imported again is a new row and gets a new number, for a document that has not changed.
-	 * The number of the draft that has just been deleted is free, and no code of the core reads an id
-	 * back out of it - it only tests the "PROV" prefix and skips such references when it looks for the
-	 * last number used - so it is given back here, files included.
-	 *
-	 * Only a temporary reference is ever moved this way, and only onto a draft: a validated invoice
-	 * carries a number of the numbering module, which belongs to it alone.
+	 * The core never reads an id back out of a "(PROV1234)" reference, it only tests the prefix, so the
+	 * number of the deleted draft can be given back to the new row, files included.
+	 * Only a temporary reference is moved this way, and only onto a draft: a validated invoice carries
+	 * a number of the numbering module, which belongs to it alone.
 	 *
 	 * @param	FactureFournisseur	$invoice	Draft the import has just created, renamed in place on success
 	 * @param	string				$wantedref	Reference of the draft it replaces

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -61,11 +61,10 @@ class EInvoicing
 	/**
 	 * Ids of the customer invoices whose validation happened during the current request.
 	 *
-	 * The hook that generates the e-invoice, afterPDFCreation(), is called for every rebuild of the
-	 * invoice PDF and cannot tell what asked for it. The BILL_VALIDATE trigger can: it runs inside
-	 * Facture::validate(), before the caller regenerates the document, and it runs for no other
-	 * reason. Marking the invoice there is what lets the hook recognise the generation that follows a
-	 * validation - the only one EINVOICING_AUTO_SEND_ON_GENERATION is meant to transmit.
+	 * afterPDFCreation() runs for every rebuild of the invoice PDF and cannot tell what asked for it;
+	 * the BILL_VALIDATE trigger runs inside Facture::validate() and for no other reason. Marking the
+	 * invoice there is what lets the hook recognise the generation that follows a validation, the only
+	 * one EINVOICING_AUTO_SEND_ON_GENERATION is meant to transmit.
 	 *
 	 * @var int[]
 	 */
@@ -901,20 +900,9 @@ class EInvoicing
 	/**
 	 * Statuses a user may still send by hand on an invoice received through the platform.
 	 *
-	 * The sendable list is narrowed by what the platform already accepted for that invoice. A status
-	 * it accepted is not proposed again. "Refused" (210) ends the exchange - an invoice sent back to
-	 * its vendor is not going to be paid, so nothing else is owed on it. "Approved" (205) ends nothing:
-	 * the normal order of things is to approve an invoice and then pay it, and "Payment transmitted"
-	 * (211) is precisely what is sent afterwards. An approved invoice can no longer be refused either.
-	 *
-	 * The order matters both ways: "Payment transmitted" is only offered once that approval has been
-	 * accepted by the platform, and never on a draft. Announcing the payment of an invoice nobody has
-	 * answered yet - or of one Dolibarr does not owe anything on - runs the lifecycle backwards.
-	 *
-	 * One last thing narrows the list beyond that history: a credit note correcting an invoice we
-	 * refused cannot be accepted, since the invoice it credits owes nothing (issue #594, see
-	 * SupplierInvoiceHelper::refusedSourceOfCreditNote()). Refusing it stays offered - that is what the
-	 * document is for here - as do the statuses that settle nothing, like "Disputed" or "Suspended".
+	 * A status already accepted is not proposed again, "Refused" (210) ends the exchange, and "Payment
+	 * transmitted" (211) needs an accepted "Approved" (205) on a non-draft invoice. A credit note
+	 * correcting an invoice we refused cannot be accepted either (issue #594).
 	 *
 	 * @param	int		$elementId		Id of the invoice
 	 * @param	string	$elementType	Element type ('invoice_supplier')
@@ -942,10 +930,7 @@ class EInvoicing
 
 		// The lifecycle runs in one direction: a received invoice is first answered - approved (205) or
 		// refused (210) - and only then paid, so "Payment transmitted" (211) is offered once that answer
-		// has been given and accepted by the platform, not before. Offering it right away announced the
-		// payment of an invoice we had said nothing about, and let it be sent while the answer was still
-		// pending or had been rejected by the platform - which is when the button is the most tempting,
-		// and the most wrong.
+		// has been accepted by the platform, not while it is still pending or was rejected.
 		if (!$approved) {
 			unset($statuses[self::STATUS_PAYMENT_SENT]);
 		}
@@ -1242,12 +1227,10 @@ class EInvoicing
 	/**
 	 * Tell whether a value returned by the French National Business Registry API is masked.
 	 *
-	 * Units that exercised their right to opposition (art. A123-96 of the French commercial code)
-	 * carry the "partial diffusion" status: they are still returned by the API, but each protected
-	 * field is replaced by the literal string "[NON-DIFFUSIBLE]". Cross-checking such a placeholder
-	 * against the third party record can only ever mismatch, so the field must be skipped instead of
-	 * being reported. Fields that stay public for those units (SIREN, commune, administrative status)
-	 * keep being checked.
+	 * A unit under "partial diffusion" (art. A123-96 of the French commercial code) is still returned by
+	 * the API, but each protected field holds the literal string "[NON-DIFFUSIBLE]": cross-checking that
+	 * against the third party record can only ever mismatch, so the field is skipped instead of being
+	 * reported. The fields that stay public (SIREN, commune, administrative status) keep being checked.
 	 *
 	 * @param  string|null $value   Value read from the API response
 	 * @return bool                 True when the field is masked and must not be cross-checked
@@ -1393,14 +1376,9 @@ class EInvoicing
 	/**
 	 * Check that the setup of the instance can produce a conformant carrier for the selected format.
 	 *
-	 * Only Factur-X is concerned: a Factur-X file is a PDF/A-3 file carrying the XML (ISO 19005-3), and
-	 * the module can only embed the XML into the PDF the core produced - it cannot repair its pages. At
-	 * the default PDF_USE_A = 0 that PDF is drawn with the Standard 14 fonts, which are not embedded,
-	 * while 6.2.11.4.1 requires every font used for rendering to be: the result is rejected by any PDF/A
-	 * validator (veraPDF), whatever the container of the module does right, and the invoice is not a
-	 * conformant Factur-X. The setting belongs to the core and is only read here, never written: the
-	 * user is told to raise it, in "Home - Setup - PDF", or to use CII - which is the recommended format
-	 * and needs no PDF at all.
+	 * Only Factur-X is concerned: at the core default PDF_USE_A = 0 the Standard 14 fonts are not
+	 * embedded, while ISO 19005-3 6.2.11.4.1 requires every rendering font to be, so veraPDF rejects the
+	 * file. The setting belongs to the core, so the user is told to raise it, or to use CII.
 	 *
 	 * @return array{res:int, message:string} Returns array with 'res' (1 when nothing to report, 0 on warning) and info 'message'
 	 */
@@ -2382,15 +2360,10 @@ class EInvoicing
 	/**
 	 * Combo of the products of a vendor, to pick the default product of an import.
 	 *
-	 * A product bought from a vendor has to be flagged "to buy"; whether it is on sale is none of our
-	 * business, and a product created by a previous import never is. select_produits_fournisseurs()
-	 * filters on that purchase status, but reads it from the global $status, which the calling page is
-	 * free to have set to anything: force it here, and give it back, so the combo cannot silently come
-	 * back empty.
-	 *
-	 * The field also follows the two setup options the core uses for its own product combos:
-	 * PRODUIT_USE_SEARCH_TO_SELECT (search form instead of a combo, with its minimum number of
-	 * characters) and PRODUIT_LIMIT_SIZE (number of products shown in a select).
+	 * select_produits_fournisseurs() filters on the "to buy" status but reads it from the global $status,
+	 * which the calling page is free to have set to anything: it is forced here, and given back, so the
+	 * combo cannot silently come back empty. PRODUIT_USE_SEARCH_TO_SELECT and PRODUIT_LIMIT_SIZE are
+	 * honoured as the core does for its own product combos.
 	 *
 	 * @param	Form	$form		Form handler
 	 * @param	int		$socid		Vendor id
@@ -2644,11 +2617,10 @@ class EInvoicing
 	/**
 	 * Whether an invoice is locked because it was already transmitted to the Access Point.
 	 *
-	 * Based on the REAL PA state (a flow_id was assigned on the first successful submission and is never
-	 * cleared), not on the Dolibarr syncstatus which is reset to GENERATED when the e-invoice is
-	 * regenerated. A transmitted invoice is immutable (you correct it with a credit note / corrective
-	 * invoice), so by default we block re-sending, regenerating and re-editing it. The operator can opt
-	 * out (e.g. to test PA retry behaviour) by setting EINVOICING_ALLOW_RESEND_TRANSMITTED.
+	 * Based on the real PA state (a flow_id, assigned on the first successful submission and never
+	 * cleared), not on the Dolibarr syncstatus which is reset to GENERATED on every regeneration. A
+	 * transmitted invoice is immutable, so re-sending, regenerating and re-editing are blocked unless
+	 * EINVOICING_ALLOW_RESEND_TRANSMITTED is set.
 	 *
 	 * @param 	int 	$invoiceId 	Invoice id
 	 * @param 	?string $invoiceRef Invoice ref (fallback if id is 0)
@@ -2667,21 +2639,10 @@ class EInvoicing
 	 * Gate generation/transmission on the recipient being reachable in the Approved Platforms directory.
 	 *
 	 * Only enforced when EINVOICING_REQUIRE_ROUTABLE_RECIPIENT is on (off by default, opt-in). A recipient
-	 * that is absent from the directory, present without an active routing line, or present without the
-	 * very address this invoice is addressed to, would be rejected by the platform with a routing error
-	 * (fr:213): blocking generation/sending avoids reaching that error state. That option has a second,
-	 * stricter, value (2) that also blocks a non-conclusive directory answer.
-	 *
-	 * What is checked is the electronic address the document will carry (BT-49), read through the same
-	 * getBuyerCommunicationURI() the generation uses, so the gate and the document can never disagree.
-	 * When that address is empty - only reachable with EINVOICING_BLOCK_INVOICE_NO_ROUTING_ID and no
-	 * routing recorded, a configuration the required-information checks already stop - the check falls
-	 * back on any line declared for the SIREN.
+	 * the directory does not route to the BT-49 of the document (getBuyerCommunicationURI()) is a fr:213.
 	 *
 	 * Fails open (ok=1) whenever the check cannot be trusted, so it never blocks unexpectedly: option off,
-	 * provider without a directory lookup (status unsupported), directory call error, a directory answer that
-	 * does not report the line status (status undetermined, unless the option is set to its strict value), or
-	 * a recipient with no SIREN (handled by the standard required-information checks).
+	 * lookup unsupported, call error, or an undetermined answer unless the option is at its strict value 2.
 	 *
 	 * @param 	Facture 	$object 	Invoice
 	 * @return 	array{ok:int,status:string,message:string}	ok=0 only when the recipient is confirmed not routable.
@@ -3640,18 +3601,10 @@ class EInvoicing
 	/**
 	 * Calculate TVA intracommunity number for a thirdparty if missing, from the professional ID
 	 *
-	 * The core does exactly this, in Societe::calculateVATNumberFromProperties(), since Dolibarr 24.
-	 * This method is kept as the entry point of the module - it is what buildinvoicelines.inc.php calls
-	 * to fill BT-31 and BT-48 - but it no longer computes anything itself: it hands the thirdparty over
-	 * to the core when the core knows how, and to the faithful backport of compat/societe.lib.php on the
-	 * versions that do not have it yet. The presence of the method is what decides, not a version test:
-	 * the same module runs on 18 to 24, and a backport of the method into a maintenance release would
-	 * then be used as soon as it is there.
-	 *
-	 * The copy this replaced was wrong twice, and both defects reached the XML: the key was concatenated
-	 * raw, where the core pads it to two digits, so the roughly one SIREN in ten whose key is below 10
-	 * got a 12 character number instead of 13; and the SIRET to SIREN fallback cast to int, which eats
-	 * the leading zero of a SIREN that starts with one.
+	 * Delegates to the core Societe::calculateVATNumberFromProperties() when it exists (Dolibarr 24 on,
+	 * or any release it gets backported into - the presence of the method decides, not a version test),
+	 * and to compat/societe.lib.php otherwise. Kept as the entry point of the module: it is what
+	 * buildinvoicelines.inc.php calls to fill BT-31 and BT-48.
 	 *
 	 * @param mixed $thirdparty		Third party
 	 * @return string
@@ -3684,12 +3637,9 @@ class EInvoicing
 			return;
 		}
 
-		// Files at the root of the directory only, which is the whole of what the module writes there:
-		// the working copies of an incoming document (in_*.xml, in_*_readable.pdf), the CDAR being sent
-		// (cdar_*.xml), the einvoice.* diagnostics and the sample invoices of the setup page are all
-		// flat. A subdirectory found here was put by something else and is not ours to remove, so the
-		// listing stays non recursive - and dol_dir_list() also skips the dot files the core protects,
-		// which a raw scandir() loop happily deleted.
+		// Files at the root only: everything the module writes there is flat, so a subdirectory found here
+		// is not ours to remove. dol_dir_list() also skips the dot files the core protects, which a raw
+		// scandir() loop happily deleted.
 		$files = dol_dir_list($tempDir, 'files', 0);
 		foreach ($files as $file) {
 			// Exact delete: the name comes from the listing and must not be read back as a glob mask.
@@ -3857,14 +3807,9 @@ class EInvoicing
 	/**
 	 * Split a Dolibarr postal address into the three lines EN 16931 has for it.
 	 *
-	 * Dolibarr keeps a postal address as one free text field where the user separates the lines with
-	 * newlines, while the norm gives an address three separate terms - BT-35/36/162 for the seller,
-	 * BT-50/51/163 for the buyer, BT-75/76/165 for the deliver-to party. Handing the whole field to
-	 * the first of them puts raw newlines inside a single element, which the receiving side renders
-	 * as one run-on line (issue #683).
-	 *
-	 * Nothing is dropped: the norm stops at three lines, so a fourth and beyond join the third,
-	 * separated by a comma, rather than disappearing from the document.
+	 * Dolibarr keeps the address as one free text field where the norm gives three terms (BT-35/36/162,
+	 * BT-50/51/163, BT-75/76/165): handing the whole field to the first one renders as one run-on line
+	 * (issue #683). A fourth line and beyond join the third, separated by a comma.
 	 *
 	 * @param	string	$address	Address as Dolibarr stores it, lines separated by newlines
 	 * @return	string[]			Exactly three lines, empty strings when the address has fewer
@@ -3938,12 +3883,9 @@ class EInvoicing
 		$conf->global->TAX_MODE_SELL_PRODUCT = 'invoice';
 		$conf->global->TAX_MODE_SELL_SERVICE = 'payment';
 
-		// Same reason for the language: CommonProtocol::generateSampleInvoice() builds the specimen
-		// with the ambient $langs, so the free text it carries (BT-20 payment terms, BT-22 notes,
-		// line descriptions) follows whatever language the instance runs in. The reference fixtures
-		// would then match only on an instance set to the language of whoever generated them.
-		// Pin en_US here, so the specimen is the same everywhere; the interactive sample generation
-		// keeps following the user language, it does not go through this method.
+		// Same reason for the language: generateSampleInvoice() builds the specimen with the ambient
+		// $langs, so its free text would follow the instance language and the reference fixtures would
+		// only match there. Pinned to en_US; the interactive sample generation does not come through here.
 		$savLangs = $langs;
 		$langs = new Translate('', $conf);
 		$langs->setDefaultLang('en_US');

--- a/einvoicing/class/protocols/AbstractProtocol.class.php
+++ b/einvoicing/class/protocols/AbstractProtocol.class.php
@@ -192,9 +192,8 @@ abstract class AbstractProtocol
 	 * "warning_only" (default) reports violations as non-blocking warnings, and "blocking" aborts
 	 * the generation (the exception is caught by generateInvoice() which returns -1 with the messages).
 	 *
-	 * The check also covers what no rule of the standard can see: that the document claims the amount
-	 * the invoice claims. A document can be perfectly conformant and still state another total than the
-	 * invoice it stands for, and the platform accepts it without a word.
+	 * It also checks that the document claims the amount the invoice claims, which no rule of the
+	 * standard covers.
 	 *
 	 * @param	string			$xmlcontent		Generated CII XML content
 	 * @param	?CommonInvoice	$invoice		Invoice the document was built from, to compare the amounts
@@ -232,16 +231,10 @@ abstract class AbstractProtocol
 	/**
 	 * Check that the generated document claims the amount the invoice claims.
 	 *
-	 * No rule of the standard can catch this: the rules relate the amounts of the document to each
-	 * other, and a document whose totals are wrong by a cent is as consistent as a correct one. The
-	 * platform therefore accepts it, and the discrepancy only surfaces later, on payment
-	 * reconciliation or on the buyer's side.
-	 *
-	 * The known cause left is a currency accuracy for totals (MAIN_MAX_DECIMALS_TOT) other than 2: the
-	 * invoice then carries a third decimal, and EN 16931 caps every amount at two, the rounding amount
-	 * (BT-114) included (BR-DEC-09 to BR-DEC-23). No computation can make the two equal, so the
-	 * operator is told instead of being left with a document that quietly claims something else
-	 * (issue #506).
+	 * No EN 16931 rule catches this: they relate the amounts of the document to each other, so a
+	 * document consistent with itself but wrong against the invoice is accepted by the platform.
+	 * Known cause: MAIN_MAX_DECIMALS_TOT other than 2, where the standard caps every amount at two
+	 * decimals, BT-114 included (BR-DEC-09 to BR-DEC-23). Issue #506.
 	 *
 	 * @param	string			$xmlcontent		Generated CII XML content
 	 * @param	?CommonInvoice	$invoice		Invoice the document was built from
@@ -290,14 +283,10 @@ abstract class AbstractProtocol
 	}
 
 	/**
-	 * Clean up the per-call working temp files of an inbound invoice, while preserving the
-	 * "last invoice that could not be processed" diagnostic shown (and downloadable) in the
-	 * document list view.
+	 * Clean up the per-call working temp files of an inbound invoice.
 	 *
-	 * Each inbound sync writes the received document to its own unique working file, so two
-	 * concurrent syncs can no longer overwrite each other and parse the wrong invoice (#226).
-	 * On failure, the working file is promoted to the fixed diagnostic slot (overwriting the
-	 * previous one) so it stays downloadable; on success, the working files are simply removed.
+	 * Each sync uses its own working file so concurrent syncs cannot parse each other's invoice (#226).
+	 * On failure it is promoted to the fixed diagnostic slot, kept downloadable from the document list.
 	 *
 	 * @param	string	$tempDir			Module temp directory
 	 * @param	string	$workFile			Unique working file for the received document

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -75,12 +75,8 @@ class CIIProtocol extends AbstractProtocol
 	 * Maximum number of decimals allowed for the unit prices: Item net price (BT-146),
 	 * Item price discount (BT-147) and Item gross price (BT-148).
 	 *
-	 * EN 16931 sets no limit on these (BT-146 only carries BR-26 and BR-27), but the French
-	 * CTC layer does: rule BR-FR-DEC-03 of the FNFE-MPE CTC-FR Schematron rejects, with a
-	 * "fatal" flag, any value matching more than 6 decimals ('^[-]?\d{1,19}(\.\d{1,6})?$').
-	 * Note this is NOT the 2 decimals limit of the amounts (BR-DEC-* / BR-FR-DEC-01): a unit
-	 * price is not an amount, and no rule checks that the line net amount (BT-131) derives
-	 * arithmetically from the unit price.
+	 * EN 16931 sets no limit, but rule BR-FR-DEC-03 of the CTC-FR Schematron rejects, as fatal, more than 6
+	 * decimals. This is not the 2 decimals limit of the amounts (BR-DEC-* / BR-FR-DEC-01): a price is not an amount.
 	 *
 	 * @const int
 	 */
@@ -705,13 +701,10 @@ class CIIProtocol extends AbstractProtocol
 			$failed = !is_array($result) || !isset($result['res']) || $result['res'] < 0;
 			$this->cleanupIncomingTempFiles($tempDir, $tempFile, $tempFileReadableView, $failed);
 
-			// The invoice import transaction is opened by doCreateSupplierInvoiceFromSource() once the
-			// vendor has been synchronized. Close it here so every early return - and any exception -
-			// leaves a clean transaction state. A transaction left open would be rolled back by
-			// Dolibarr at the end of the request, taking the imported invoices AND the synchronization
-			// history down with it (issue #524).
-			// One commit/rollback per opened level: nested levels only decrement the counter of the
-			// database handler, the real COMMIT/ROLLBACK is issued on the last one.
+			// The invoice import transaction is opened by doCreateSupplierInvoiceFromSource(). Close it here so
+			// every early return - and any exception - leaves a clean transaction state, otherwise Dolibarr rolls
+			// it back at the end of the request and takes the synchronization history with it (issue #524).
+			// One commit/rollback per opened level: only the last one issues the real COMMIT/ROLLBACK.
 			while ($this->openedTransactions > 0) {
 				$this->openedTransactions--;
 				if ($failed) {
@@ -824,12 +817,8 @@ class CIIProtocol extends AbstractProtocol
 		// Done before the duplicate/ref-docs checks below so those checks can be scoped to this supplier
 		// (ref_supplier is only unique per supplier, not globally - see issue about cross-supplier collisions).
 		//
-		// The vendor is reference data, not part of the invoice: it gets its own transaction, committed
-		// before the import starts. A business error raised further down - a product that cannot be
-		// auto-created, a referenced document missing - must not roll back the thirdparty the operator is
-		// precisely being asked to complete: the "create the product" and "map the product" links returned
-		// with that error carry its socid, so a rolled back vendor makes them point to a thirdparty that
-		// never existed.
+		// The vendor is reference data: it gets its own transaction, committed before the import starts, so a
+		// business error further down does not roll back the thirdparty the operator is asked to complete.
 		$db->begin();
 		$this->openedTransactions++;
 
@@ -940,12 +929,9 @@ class CIIProtocol extends AbstractProtocol
 					return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($refDocInvoiceId, $refDoc, 'required by received document ' . ($parsedHeader['documentno'] ?? ''))];
 				}
 				if ($refDocInvoiceId == 0) {
-					// The invoice references a document this Dolibarr does not hold: the final invoice of a
-					// deposit, the invoice a credit note credits, the one a replacement replaces. Nothing has
-					// been created at this point, so the flow is postponed rather than failed: it is retried
-					// on the next synchronization, and the invoices queued behind it keep coming in. What the
-					// user has to do cannot be guessed from a technical message, so it is spelled out with a
-					// link to the screen where the missing invoice is created.
+					// The document references an invoice this Dolibarr does not hold. Nothing has been created at this
+					// point, so the flow is postponed and retried on the next synchronization rather than failed, and
+					// the message spells out what to create with a link to the screen that creates it.
 					$langs->load("bills");
 					$action = $langs->trans('CreateTheMissingSupplierInvoiceToImport', $refDoc);
 					$action .= ' <a class="butAction small smallpaddingimp nomarginleft" href="' . DOL_URL_ROOT . '/fourn/facture/card.php?action=create&socid=' . (int) $socId . '&ref_supplier=' . urlencode($refDoc) . '" target="_blank">';
@@ -1408,12 +1394,9 @@ class CIIProtocol extends AbstractProtocol
 			$line->total_tva = $parsedLine['calculatedAmount'] ?? 0;
 			$line->total_ttc = $parsedLine['lineTotalAmount'] + ($parsedLine['calculatedAmount'] ?? 0);
 
-			// The three properties just set are not what reaches the database: the line is written by
-			// createSupplierInvoiceLinesIntoDatabase(), which hands quantity, unit price and discount to
-			// FactureFournisseur::updateline() and lets the core recompute the totals. So BT-131 is read
-			// and then dropped, and whatever quantity times price gives is what the invoice ends up with.
-			// A deposit line is left alone: its amount does not come from the document but from the
-			// discount created out of the deposit invoice.
+			// The three properties just set are not what reaches the database: updateline() recomputes the totals
+			// from quantity, unit price and discount, so BT-131 is read and then dropped. A deposit line is left
+			// alone: its amount comes from the discount created out of the deposit invoice.
 			if (!$is_deposit_line) {
 				$amounts = $this->resolveLineAmounts($parsedLine, (float) $line->qty, (float) $line->subprice, (float) $line->remise_percent);
 				$line->qty = $amounts['qty'];
@@ -1614,27 +1597,10 @@ class CIIProtocol extends AbstractProtocol
 	/**
 	 * Unit price a received line must carry in Dolibarr: BT-146 brought back to a single unit.
 	 *
-	 * EN 16931 does not state the price of one item. It states BT-146, the item net price, as the price of
-	 * BT-149 units of that item - the item price base quantity. A price of "2.00 per 100" is
-	 * <ram:ChargeAmount>2.00</ram:ChargeAmount> with <ram:BasisQuantity>100</ram:BasisQuantity>, and the
-	 * net amount the document announces for the line, BT-131, is BT-129 / BT-149 x BT-146. UBL says the
-	 * same thing with cbc:PriceAmount and cbc:BaseQuantity. The pattern is ordinary wherever a rate is
-	 * billed rather than an item: a fuel surcharge per 100, a metered consumption per 100 000.
-	 *
-	 * A Dolibarr line has no such divisor. It holds one price for one unit and lets the core multiply it
-	 * by the quantity, so BT-149 has to be folded into the price at import. It was read by the parser and
-	 * then dropped, which multiplied the line - and the total of the whole invoice - by that base
-	 * quantity: a line priced 0.134195 per 100 000 came in at 9 983 012.03 instead of 99.83
-	 * (issues #777 and #778).
-	 *
-	 * BT-149 is optional and means one when absent; BR-64 requires it to be positive when present, and
-	 * BR-65 requires its unit code (BT-150) to be the invoiced quantity unit code (BT-130), so there is no
-	 * unit conversion to make here. Anything else - absent, zero, negative, unreadable - is taken as one,
-	 * which leaves the line exactly as the import built it before.
-	 *
-	 * The division is handed to the core unrounded on purpose: calcul_price_total() computes the total of
-	 * the line from the unit price it receives and only rounds the copy it stores as pu_ht, so a price
-	 * below the display precision still totals what the document announces.
+	 * BT-146 is the price of BT-149 units (the item price base quantity) while a Dolibarr line holds the price of
+	 * one unit, so BT-149 has to be folded into the price at import (issues #777 and #778). BT-149 is optional and
+	 * means one when absent. The division is left unrounded: calcul_price_total() rounds only the pu_ht copy it
+	 * stores, so a price below the display precision still totals what the document announces.
 	 *
 	 * @param	array<string,mixed>		$parsedLine		One line as parseInvoiceLines() returns it
 	 * @return	float									Price of a single unit, to hand to updateline()
@@ -1654,35 +1620,10 @@ class CIIProtocol extends AbstractProtocol
 	/**
 	 * Decide the quantity, unit price and discount a received line must carry in Dolibarr.
 	 *
-	 * The line is written by createSupplierInvoiceLinesIntoDatabase(), which hands those three to
-	 * FactureFournisseur::updateline() and lets the core recompute the totals of the line. The net amount
-	 * the document announces for the line, BT-131, is therefore never stored as such: whatever quantity
-	 * times unit price gives is what the invoice ends up with. Three cases have to be told apart.
-	 *
-	 * 1. A line that is not a regular item - EXTENDED CTC-FR, BT-X-8 other than DETAIL: a comment, a group
-	 *    header, a subtotal. BR-FREXT-CO-10 sums BT-106 over the DETAIL lines only, so such a line carries
-	 *    no amount of its own and importing it as a priced line would count its amount a second time. It
-	 *    becomes a text line. BR-FREXT-BR-22 is also why it may carry no quantity at all.
-	 * 2. A regular item whose quantity and unit price cannot express the amount it announces at all. Three
-	 *    shapes reach that state, and the repair is the same for the three: carry BT-131 as a single unit,
-	 *    the way it would be keyed in by hand, so the total of the invoice stays the total of the document.
-	 *    a. The invoiced quantity is zero or absent. Such a document is not necessarily wrong: BR-22 only
-	 *       tests the presence of ram:BilledQuantity, so a quantity of zero satisfies it, and nothing in
-	 *       EN 16931 requires BT-131 to equal BT-129 times BT-146. The document of issue #726 is exactly
-	 *       that - EXTENDED CTC-FR, a line carrying <BilledQuantity unitCode="C62">0.0000</BilledQuantity>,
-	 *       no BT-X-8, and a BT-131 of 12.00 that BR-FREXT-CO-10 does count into BT-106.
-	 *    b. The unit price is zero or absent while the line announces an amount. A free item that is then
-	 *       credited is written that way - issue #772, a vendor invoice whose "free" lines each announce a
-	 *       BT-131 of -0.30 over a BT-146 of 0.00. Quantity times price rebuilds 0.00, so every one of
-	 *       those credits used to be dropped and the invoice came out above the document.
-	 *    c. Quantity times price rebuilds the opposite sign of what the line announces. BT-146 is forbidden
-	 *       to be negative by BR-27, so a line that subtracts from the invoice carries its sign on BT-129
-	 *       alone; a document that puts it on BT-131 only would otherwise be imported as a charge, moving
-	 *       the invoice by twice the amount of the line.
-	 * 3. Everything else: check that what the core is about to compute is what the document announces, and
-	 *    say so when it is not. The tolerance is the one BR-FREXT-CO-10 applies to the totals. A line that
-	 *    does rebuild its amount can still hold a unit price too small for the core to store - see the
-	 *    branch below - and that is reported too.
+	 * updateline() recomputes the totals from those three, so BT-131 is never stored as such. A line that is not a
+	 * DETAIL item (BT-X-8) carries no amount and becomes a text line. A regular item whose quantity times price
+	 * cannot express BT-131 - zero quantity, zero price, opposite sign - carries BT-131 as a single unit instead
+	 * (issues #726 and #772). Anything else is checked against BT-131 and reported when it does not match.
 	 *
 	 * @param	array<string,mixed>		$parsedLine			One line as parseInvoiceLines() returns it
 	 * @param	float					$qty				Quantity read from the document (BT-129)
@@ -1726,14 +1667,10 @@ class CIIProtocol extends AbstractProtocol
 			$warning = 'Line ' . $lineid . ' of the received document announces a net amount (BT-131) of ' . $announced
 				. ', but its quantity and unit price rebuild ' . $rebuilt . '. The invoice carries the rebuilt amount.';
 		} elseif ($subprice != 0.0 && (float) price2num($subprice, 'MU') == 0.0) {
-			// calcul_price_total() totals the line from the unit price it is handed and rounds only the copy
-			// it stores as pu_ht, to MAIN_MAX_DECIMALS_UNIT. A price of one unit below that precision -
-			// which is what a price stated per 100 000 comes down to (issue #777) - therefore totals exactly
-			// what the document announces and still reaches the line as 0.00000. The line as imported is
-			// right; it is opening and saving it again that would recompute it to zero, so say so here
-			// rather than let it be found out later.
-			// A price that small is a float PHP writes as 1.34195E-6, which reads as a typo in a message:
-			// spell it out in full, without the trailing zeros of a fixed number of decimals.
+			// calcul_price_total() rounds only the pu_ht copy it stores, to MAIN_MAX_DECIMALS_UNIT: a price stated
+			// per 100 000 (issue #777) totals what the document announces and still reaches the line as 0.00000.
+			// The import is right, but reopening and saving the line would recompute it to zero, so say so now.
+			// Spell the price out in full: PHP writes such a float as 1.34195E-6, which reads as a typo.
 			$spelled = rtrim(rtrim(number_format($subprice, 12, '.', ''), '0'), '.');
 
 			$warning = 'Line ' . $lineid . ' of the received document prices a single unit at ' . $spelled
@@ -1749,18 +1686,9 @@ class CIIProtocol extends AbstractProtocol
 	/**
 	 * Tell whether a parsed line is a regular invoice item, the only kind that carries an amount.
 	 *
-	 * EN 16931 has one sort of line and every one of them is priced. The EXTENDED profile adds a subtype,
-	 * BT-X-8, carried by ram:AssociatedDocumentLineDocument/ram:LineStatusReasonCode, and the French rules
-	 * hang two behaviours on it:
-	 *
-	 * - BR-FREXT-BR-22 requires the invoiced quantity (BT-129) only when the subtype is DETAIL or absent,
-	 *   so a comment or a group header may legitimately carry no quantity at all;
-	 * - BR-FREXT-CO-10 sums BT-131 into BT-106 over those same lines only:
-	 *   [not(ram:AssociatedDocumentLineDocument/ram:LineStatusReasonCode)
-	 *    or ram:AssociatedDocumentLineDocument/ram:LineStatusReasonCode = 'DETAIL'].
-	 *
-	 * The predicate below is that XPath. An absent code means a regular item, which is also what every
-	 * EN 16931 document gives, so nothing changes for the profiles that have no subtype.
+	 * The EXTENDED profile adds the BT-X-8 subtype on ram:LineStatusReasonCode. BR-FREXT-BR-22 requires the
+	 * invoiced quantity (BT-129) only when it is DETAIL or absent, and BR-FREXT-CO-10 sums BT-131 into BT-106 over
+	 * those same lines only. The predicate below is that XPath; an absent code means a regular item.
 	 *
 	 * @param	array<string,mixed>		$parsedLine		One line as parseInvoiceLines() returns it
 	 * @return	bool									True for a regular item, false for a line that carries no amount
@@ -1776,19 +1704,10 @@ class CIIProtocol extends AbstractProtocol
 	/**
 	 * Billing period of a received line (BG-26 / BT-134 / BT-135), as the timestamps a Dolibarr line holds.
 	 *
-	 * parseInvoiceLines() hands the two dates as 'Y-m-d' strings, normDate() having already reduced whatever the
-	 * document carried to that shape, and a supplier invoice line stores a timestamp: updateline() passes
-	 * date_start / date_end to idate() on every supported core. dol_stringtotime() is the conversion the
-	 * import already makes for the invoice date itself, so the line periods are read the same way rather
-	 * than through a second convention (issue #576).
-	 *
-	 * One side alone is kept: BR-CO-20 accepts a period with a start date or an end date, "or both", and
-	 * facture_fourn_det holds one without the other.
-	 *
-	 * A period that ends before it starts is dropped, keeping the line. Such a document breaks BR-30 and
-	 * should not exist, but it comes from outside, and updateline() answers -1 on that pair
-	 * (ErrorStartDateGreaterEnd) - which would fail the whole import over a period, where dropping it
-	 * imports the invoice as it always did.
+	 * The dates arrive as 'Y-m-d' strings and a line stores a timestamp, read with dol_stringtotime() the way the
+	 * invoice date already is (issue #576). One side alone is kept, BR-CO-20 accepting a start or an end. A period
+	 * that ends before it starts is dropped, keeping the line: updateline() answers -1 on that pair
+	 * (ErrorStartDateGreaterEnd), which would fail the whole import over a period.
 	 *
 	 * @param	array<string,mixed>				$parsedLine		One line as parseInvoiceLines() returns it
 	 * @return	array{start: ?int, end: ?int}					Timestamps to store, null for a side with nothing
@@ -2094,16 +2013,9 @@ class CIIProtocol extends AbstractProtocol
 	/**
 	 * Tell whether a profile is one of the header-only Factur-X profiles.
 	 *
-	 * MINIMUM and BASIC WL ("WL" being "without lines") do not merely make some groups optional:
-	 * the elements are absent from their XSD altogether, so emitting one makes the whole document
-	 * fail schema validation. Checked against the schemas shipped by FNFE-MPE (France_RFE,
-	 * Factur-X/<profile>/1xsd/), the ones this module builds and that BASIC and above declare are:
-	 *   - ram:IncludedSupplyChainTradeLineItem 				(BG-25, the invoice lines)
-	 *   - ram:DefinedTradeContact 								(BG-6 / BG-9, the party contacts)
-	 *   - ram:Information 									(BT-82, payment means label)
-	 *   - ram:AccountName 									(BT-85, payment account holder)
-	 *   - ram:PayeeSpecifiedCreditorFinancialInstitution 	(BT-86, the BIC)
-	 * ram:IBANID and ram:ProprietaryID (BT-84) do exist there and stay.
+	 * MINIMUM and BASIC WL do not merely make some groups optional: the elements are absent from their XSD, so
+	 * emitting one makes the whole document fail schema validation. Concerned here, of what this module builds:
+	 * BG-25, BG-6 / BG-9, BT-82, BT-85 and BT-86. ram:IBANID and ram:ProprietaryID (BT-84) do exist there and stay.
 	 *
 	 * @param 	string 	$profile 	Profile name, uppercased
 	 * @return 	bool 				True if only the header-level subset may be emitted
@@ -2116,11 +2028,9 @@ class CIIProtocol extends AbstractProtocol
 	/**
 	 * Tell whether a profile carries the whole EN 16931 core.
 	 *
-	 * MINIMUM, BASIC WL and BASIC are subsets: a term of the core may simply not exist in their
-	 * XSD, and emitting it makes the document fail schema validation. EN16931 declares the core in
-	 * full, and EXTENDED / EXTENDED-CTC-FR are conformant extensions of it. Checked against the
-	 * Factur-X schemas (vendor/horstoeko/zugferd/src/schema/FACTUR-X_<profile>*.xsd): for instance
-	 * ram:SpecifiedProcuringProject (BT-11) appears from EN16931 on and nowhere below.
+	 * MINIMUM, BASIC WL and BASIC are subsets: a term of the core may simply not exist in their XSD, and emitting
+	 * it makes the document fail schema validation. EN16931 declares the core in full, and EXTENDED /
+	 * EXTENDED-CTC-FR are conformant extensions of it.
 	 *
 	 * @param 	string 	$profile 	Profile name, uppercased
 	 * @return 	bool 				True if the full EN 16931 core may be emitted
@@ -2133,20 +2043,10 @@ class CIIProtocol extends AbstractProtocol
 	/**
 	 * Tell whether a profile is MINIMUM, whose schema declares almost nothing.
 	 *
-	 * MINIMUM is not a reduced EN 16931: it is a different, far smaller document, and every type it
-	 * declares is cut down. Emitting anything else fails schema validation. What it allows, in full
-	 * (FACTUR-X_MINIMUM_*ReusableAggregateBusinessInformationEntity_100.xsd):
-	 *   ExchangedDocument                   ID, TypeCode, IssueDateTime          (no ram:IncludedNote)
-	 *   HeaderTradeAgreement                BuyerReference, Seller, Buyer, BuyerOrderReferencedDocument
-	 *   TradeParty                          Name, SpecifiedLegalOrganization, PostalTradeAddress,
-	 *                                       SpecifiedTaxRegistration            (no ID/GlobalID, no URI)
-	 *   LegalOrganization                   ID                                  (no TradingBusinessName)
-	 *   TradeAddress                        CountryID                           (nothing else)
-	 *   HeaderTradeDelivery                 nothing at all, the type is empty
-	 *   HeaderTradeSettlement               InvoiceCurrencyCode, SpecifiedTradeSettlementHeaderMonetarySummation
-	 *                                       (no payment means, no ApplicableTradeTax, no payment terms)
-	 *   MonetarySummation                   TaxBasisTotalAmount, TaxTotalAmount, GrandTotalAmount,
-	 *                                       DuePayableAmount                    (no line/charge/allowance/prepaid)
+	 * MINIMUM is not a reduced EN 16931: it is a far smaller document and every type it declares is cut down - no
+	 * note, no party identifier or URI, an empty HeaderTradeDelivery, no payment means, no ApplicableTradeTax, no
+	 * payment terms, and a monetary summation limited to BT-109, BT-110, BT-112 and BT-115. Emitting anything else
+	 * fails schema validation.
 	 *
 	 * @param 	string 	$profile 	Profile name, uppercased
 	 * @return 	bool 				True if only the MINIMUM subset may be emitted
@@ -2159,12 +2059,9 @@ class CIIProtocol extends AbstractProtocol
 	/**
 	 * Build CII XML from invoice data.
 	 *
-	 * Every value taken from the invoice or the company data is passed through htmlspecialchars()
-	 * before it is handed to DOMDocument::createElement(): that method parses its second argument,
-	 * so a value holding an ampersand ("A & B", a very ordinary company name) raises an
-	 * "unterminated entity reference" warning and produces an EMPTY element, silently losing the
-	 * business term - issue #695. Only literals of this file and values coming out of
-	 * number_format() or DateTime::format() may be written unescaped.
+	 * Every value taken from the invoice or the company data is passed through htmlspecialchars() before it is
+	 * handed to DOMDocument::createElement(): that method parses its second argument, so a value holding an
+	 * ampersand produces an EMPTY element and silently loses the business term - issue #695.
 	 *
 	 * @param array 		$invoiceData 	Header-level invoice data (generated by the buildinvoicelines.inc.php)
 	 * @param array 		$linesData 		Array of line-level data arrays (generated by the buildinvoicelines.inc.php)
@@ -2193,11 +2090,10 @@ class CIIProtocol extends AbstractProtocol
 		$doc->appendChild($root);
 
 		// Add comment
-		// getHashUniqueIdOfRegistration() lives in the blockedlog library, which only the paths going through
-		// the PDF builder happen to include (pdf.lib.php). Load it here as well, otherwise the very same invoice
-		// is stamped with the instance hash or not depending on the button that triggered the generation.
-		// The library ships with every supported version, the function itself only from Dolibarr 23, so the
-		// function_exists() below still decides: nothing is stamped under 23, exactly as before.
+		// getHashUniqueIdOfRegistration() lives in the blockedlog library, included only by the paths going
+		// through the PDF builder. Load it here too, otherwise the same invoice is stamped with the instance
+		// hash or not depending on the button used. The function itself exists only from Dolibarr 23, so the
+		// function_exists() below still decides.
 		if (!function_exists('getHashUniqueIdOfRegistration')) {
 			include_once DOL_DOCUMENT_ROOT.'/blockedlog/lib/blockedlog.lib.php';
 		}
@@ -2335,12 +2231,10 @@ class CIIProtocol extends AbstractProtocol
 		$agreement = $doc->createElement('ram:ApplicableHeaderTradeAgreement');
 		$sctt->appendChild($agreement);
 
-		// Buyer reference (BT-10): what the buyer needs to route the invoice inside its own
-		// organisation (business unit, service reference, internal mailbox...), and what Annexe A of
-		// XP Z12-012 documents as the "Service Executant" of a public buyer. Every profile declares
-		// it, MINIMUM included, and it opens the HeaderTradeAgreement sequence, so it is appended
-		// before the parties. It is not what BR-FR-CPRO-11 and BR-FR-CPRO-13 read, though: those two
-		// look the service code up on BT-46 under scheme 0224, emitted by buildParty() (issue #678).
+		// Buyer reference (BT-10): what the buyer needs to route the invoice inside its own organisation.
+		// Every profile declares it, MINIMUM included, and it opens the HeaderTradeAgreement sequence, so it
+		// is appended before the parties. BR-FR-CPRO-11 and BR-FR-CPRO-13 read BT-46 under scheme 0224
+		// instead, emitted by buildParty() (issue #678).
 		if (!empty($invoiceData['buyerReference'])) {
 			$comment = $doc->createComment('Buyer reference (BT-10)');
 			$agreement->appendChild($comment);
@@ -2432,11 +2326,9 @@ class CIIProtocol extends AbstractProtocol
 		// childless there - even a comment or a line feed inside it fails validation.
 		if (!$this->isMinimumProfile($profile)) {
 			// Add the ship to trade party (mandatory when using intracommunity delivery)
-			// ShipToTradeParty is itself a TradePartyType — populate it directly without
-			// wrapping it in another BuyerTradeParty (which would break XSD validation).
-			// When an external SHIPPING contact with a distinct address is attached to the invoice
-			// (keys filled by buildinvoicelines.inc.php), emit a dedicated deliver-to party (BG-15);
-			// otherwise fall back to the buyer party so the node stays present (upstream behaviour).
+			// ShipToTradeParty is itself a TradePartyType - do not wrap it in another BuyerTradeParty, that
+			// would break XSD validation. With an external SHIPPING contact carrying a distinct address, emit a
+			// dedicated deliver-to party (BG-15); otherwise fall back to the buyer party so the node stays.
 			$shiptotrade = null;
 			if (!empty($invoiceData['_shipFromContactShip'])) {
 				$shiptotrade = $this->buildShipToTradeParty(
@@ -2543,12 +2435,10 @@ class CIIProtocol extends AbstractProtocol
 				);
 			}
 
-			// Invoicing period of the document (BG-14 / BT-73 / BT-74), derived from the periods of the
-			// lines by einvoicingInvoicingPeriodFromLines(). Placed after the ApplicableTradeTax nodes
-			// and before SpecifiedTradeAllowanceCharge (the global discounts below), which is where
-			// HeaderTradeSettlementType declares it in every schema from BASIC WL upwards; MINIMUM does
-			// not declare it at all, and the enclosing condition already excludes that profile (issue
-			// #572).
+			// Invoicing period of the document (BG-14 / BT-73 / BT-74), derived from the line periods. Placed
+			// after the ApplicableTradeTax nodes and before SpecifiedTradeAllowanceCharge, where
+			// HeaderTradeSettlementType declares it from BASIC WL upwards; MINIMUM does not declare it at all
+			// and is already excluded by the enclosing condition (issue #572).
 			if ($invoiceData['invoicingPeriodStart'] !== null || $invoiceData['invoicingPeriodEnd'] !== null) {
 				$comment = $doc->createComment('Invoicing period');
 				$settlement->appendChild($comment);
@@ -2662,12 +2552,10 @@ class CIIProtocol extends AbstractProtocol
 
 		$xml = $doc->saveXML();
 
-		// XML 1.0 admits no C0 control character other than tab, line feed and carriage return -
-		// neither as a character nor as a numeric reference. A description pasted from a PDF or from
-		// a terminal brings them in (0x0B is the usual one), DOM writes them out as they are, and
-		// what leaves is not XML: the platform answers HTTP 400 and the invoice never reaches its
-		// recipient. They carry no meaning in an invoice text, so they go. A byte below 0x80 never
-		// appears inside a UTF-8 sequence, so this cannot cut a character in half.
+		// XML 1.0 admits no C0 control character other than tab, line feed and carriage return, neither as a
+		// character nor as a numeric reference. A description pasted from a PDF brings them in (0x0B is the
+		// usual one) and the platform then answers HTTP 400. A byte below 0x80 never appears inside a UTF-8
+		// sequence, so this cannot cut a character in half.
 		$xml = (string) preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F]/', '', $xml);
 
 		return $xml;
@@ -2748,12 +2636,9 @@ class CIIProtocol extends AbstractProtocol
 		$tax->appendChild($doc->createElement('ram:TypeCode', 'VAT'));
 
 		// The exemption reason is repeated on the line, not only in the VAT breakdown it also feeds.
-		// BR-FXEXT-E-08 reconciles the taxable amount of an exempt breakdown (BT-116) with the sum of
-		// the net amounts of the lines it covers, and it only counts a line whose own reason code and
-		// reason text equal those of the breakdown. Writing them on the breakdown alone made it count
-		// zero lines, so an exempt invoice was reported as unbalanced - "basisAmount : 100, SumBT131 :
-		// 0, NBlines : 0" - and refused by the platform validator. The reader of this class already
-		// expects both at line level, so this closes the loop rather than opening a new one.
+		// BR-FXEXT-E-08 reconciles BT-116 with the sum of the net amounts of the lines it covers, and only
+		// counts a line whose own reason code and text equal those of the breakdown: written on the breakdown
+		// alone it counted zero lines and the platform validator refused the invoice.
 		// Order follows the CII D22B sequence of TradeTaxType, which is not the order of the getters.
 		$lineExemptionReason = (string) ($line['ExemptionReason'] ?? '');
 		$lineExemptionReasonCode = (string) ($line['ExemptionReasonCode'] ?? '');
@@ -2850,13 +2735,10 @@ class CIIProtocol extends AbstractProtocol
 				$node->appendChild($doc->createElement('ram:ID', htmlspecialchars((string) $data[$prefix . 'ids'])));
 			}
 
-			// Routing code of the buyer (BT-46 under scheme 0224), where BR-FR-CPRO-11 and
-			// BR-FR-CPRO-13 read the Chorus Pro "code service exécutant". It is a second ram:GlobalID,
-			// which only the EXTENDED profiles accept (FX-SCH-A-000164 caps that element at one
-			// occurrence below them), and it belongs to the buyer alone: the deliver-to party is built
-			// from the same data in minimal mode, and its own identifier is BT-71, a location, not a
-			// routing code of the buyer. See issue #678; the caller only fills the key when the value
-			// is emittable.
+			// Routing code of the buyer (BT-46 under scheme 0224), where BR-FR-CPRO-11 and BR-FR-CPRO-13 read
+			// the Chorus Pro "code service exécutant". It is a second ram:GlobalID, which only the EXTENDED
+			// profiles accept (FX-SCH-A-000164 caps that element at one occurrence below them), and it belongs
+			// to the buyer alone: on the deliver-to party the identifier is BT-71, a location (issue #678).
 			if ($type === 'buyer' && !$minimal && $this->isExtendedProfile($profile) && !empty($data['buyerRoutingCode'])) {
 				$routing = $doc->createElement('ram:GlobalID', htmlspecialchars($data['buyerRoutingCode']));
 				$routing->setAttribute('schemeID', EInvoicing::SCHEME_FR_ROUTING_CODE);
@@ -2885,14 +2767,10 @@ class CIIProtocol extends AbstractProtocol
 		}
 
 		// Contact
-		// ram:DefinedTradeContact is the wrapper for all contact sub-fields. Only create it when at
-		// least one sub-field is present, otherwise $contact stays null and appendChild() fatals
-		// (e.g. specimen seller with a phone but no contact person name).
-		// Skipped in minimal mode: the deliver-to party is a stripped-down copy of the buyer, and the
-		// CII syntax binding forbids a contact there (CII-SR-312), as it does a legal organization.
-		// The fax number is deliberately not part of this list: EN16931 has no business term for it
-		// and the CII syntax binding forbids ram:FaxUniversalCommunication (CII-SR-236 / CII-SR-265),
-		// so a party known only by its fax gets no contact block at all.
+		// ram:DefinedTradeContact is created only when a sub-field is present, otherwise $contact stays null
+		// and appendChild() fatals. Skipped in minimal mode: the CII syntax binding forbids a contact on the
+		// deliver-to party (CII-SR-312). The fax is deliberately absent: EN16931 has no business term for it
+		// and CII-SR-236 / CII-SR-265 forbid ram:FaxUniversalCommunication.
 		if (!$minimal
 			&& $this->isEn16931Profile($profile)
 			&& (!empty($data[$prefix . 'contactpersonname'])
@@ -2961,12 +2839,10 @@ class CIIProtocol extends AbstractProtocol
 		}
 
 		// VAT
-		// The party declares the tax registrations built for it, which is how a seller that charges no
-		// VAT declares its SIREN as BT-32 (schemeID FC) where a seller that does declares its VAT number
-		// as BT-31 (schemeID VA). Writing only the latter left the party of a "Non assujetti a la TVA"
-		// company with no tax registration at all, and every exempt line then tripped BR-E-02 (issue
-		// #560). Parties built without that list - the buyer, which has no BT-32 in EN 16931 - keep
-		// being written from their VAT number alone.
+		// The party declares the tax registrations built for it: a seller that charges no VAT declares its
+		// SIREN as BT-32 (schemeID FC) where a seller that does declares its VAT number as BT-31 (schemeID
+		// VA). Writing only the latter left an exempt seller with no registration at all and every exempt
+		// line then tripped BR-E-02 (issue #560).
 		if (!$minimal) {
 			$registrations = array();
 			if (!empty($data[$prefix . 'TaxRegistations']) && is_array($data[$prefix . 'TaxRegistations'])) {
@@ -3062,11 +2938,9 @@ class CIIProtocol extends AbstractProtocol
 	/**
 	 * Build a ram:BillingSpecifiedPeriod node.
 	 *
-	 * The same type serves the two levels the norm has for a period: BT-73/BT-74 under
-	 * ApplicableHeaderTradeSettlement (BG-14, the period the invoice covers) and BT-134/BT-135 under
-	 * SpecifiedLineTradeSettlement (BG-26, the period a line covers). One side alone is a period the
-	 * norm accepts - BR-CO-19 asks for the start date or the end date - so each date is written only
-	 * if it is there.
+	 * The same type serves BT-73 / BT-74 (BG-14, the period the invoice covers) and BT-134 / BT-135 (BG-26, the
+	 * period a line covers). One side alone is a period the norm accepts - BR-CO-19 asks for the start date or the
+	 * end date - so each date is written only if it is there.
 	 *
 	 * @param \DOMDocument 			$doc 	Document to create nodes in
 	 * @param ?\DateTimeInterface	$start 	Start of the period, null to leave BT-73 / BT-134 out
@@ -3341,11 +3215,9 @@ class CIIProtocol extends AbstractProtocol
 		global $conf;
 
 		// Ensure upload directory exists
-		// The arguments are the ones the card of the core passes (fourn/facture/card.php), and they are
-		// passed in full on purpose: get_exdir(0, 0, ...) answers the same thing only since Dolibarr 20,
-		// where an empty level defaults to 2 for a supplier invoice. On 18 and 19 that default does not
-		// exist, the path falls back to the reference of the invoice, and the document is written into a
-		// directory the card never reads - so a received e-invoice was shown nowhere.
+		// The arguments are the ones the card of the core passes (fourn/facture/card.php) and are passed in
+		// full on purpose: get_exdir(0, 0, ...) defaults an empty level to 2 only since Dolibarr 20. On 18
+		// and 19 the path falls back to the reference of the invoice, into a directory the card never reads.
 		$folder_part = get_exdir($supplierInvoice->id, 2, 0, 0, $supplierInvoice, 'invoice_supplier');
 
 		if ($supplierInvoice->entity > 1) {
@@ -3457,14 +3329,10 @@ class CIIProtocol extends AbstractProtocol
 	/**
 	 * Turn the charges of one received line (BG-28) into the invoice lines that carry them.
 	 *
-	 * EN 16931 mirrors at line level what it has at document level: BG-27, an allowance, and BG-28, a
-	 * charge. A Dolibarr line holds a quantity, a unit price and a discount percentage - it can express
-	 * an allowance and has nowhere to put a charge - so the charge follows its line instead, the way it
-	 * would be keyed in by hand. The unit price stored then stays the one the document gives (BT-146),
-	 * and the two lines together are worth the BT-131 the document announces.
-	 *
-	 * The VAT rate is the one of the line: in CII a line level allowance or charge carries none of its
-	 * own, CII-SR-191 forbidding ram:CategoryTradeTax there.
+	 * A Dolibarr line can express an allowance (BG-27) but has nowhere to put a charge, so the charge follows its
+	 * line as a line of its own: the unit price stored stays BT-146 and the two lines together are worth the BT-131
+	 * the document announces. The VAT rate is the one of the line, CII-SR-191 forbidding ram:CategoryTradeTax on a
+	 * line level allowance or charge.
 	 *
 	 * @param	array<string,mixed>		$parsedLine		One line as parseInvoiceLines() returns it
 	 * @return	SupplierInvoiceLine[]					One line per charge, in the order of the document
@@ -3524,20 +3392,9 @@ class CIIProtocol extends AbstractProtocol
 	/**
 	 * Resolve multiple line allowances into a single percentage for Dolibarr.
 	 *
-	 * Dolibarr only supports percentage discounts on lines, so the fixed amount the document states
-	 * (BT-136) has to be turned into one. A percentage needs the amount it is taken off, which EN 16931
-	 * carries as BT-137 - an optional field, and one a fair share of issuers do not send.
-	 *
-	 * When it is missing the base is rebuilt from the line itself: BT-131 is the amount that remains
-	 * after the allowances, so adding them back (and taking the charges out, they leave by a line of
-	 * their own, issue #735) gives the amount before discount, the very number the caller then divides
-	 * by the quantity to get the unit price. Using BT-131 itself, as this did until issue #783, applied
-	 * the percentage to the amount after discount: the ratio came out too large and the line was
-	 * imported short - 94.74 instead of 95.00 for a 5.00 allowance on a 100.00 line.
-	 *
-	 * The amount itself is read as a magnitude, whatever sign the document puts on it: ram:ChargeIndicator
-	 * already says which way it goes. Both readings are met in the field, and taken with its sign a
-	 * negative BT-136 turned the discount negative and left the line short in the same way.
+	 * Dolibarr only supports percentage discounts on lines, so BT-136 has to be turned into one. Its base is BT-137
+	 * when the issuer sends it, otherwise it is rebuilt from BT-131 with the allowances added back and the charges
+	 * taken out (issues #735 and #783). BT-136 is read as a magnitude, ram:ChargeIndicator saying which way it goes.
 	 *
 	 * Multiple allowances are summed into one final percentage.
 	 *
@@ -3565,13 +3422,9 @@ class CIIProtocol extends AbstractProtocol
 			return false;
 		}
 
-		// Sum all actualAmounts — always populated whether the source was % or fixed.
-		// Read as a magnitude: ram:ChargeIndicator already says which way the amount goes, so BT-136 is
-		// the size of the allowance and not a signed correction. An issuer that writes it negative -
-		// <ActualAmount>-0.6</ActualAmount> under an indicator of false, reported on issue #783 - means
-		// the same 0.60 off the line, and its own BT-131 is computed that way. Taken with its sign the
-		// discount came out negative, which put the line back *up* by that much on both sides of the
-		// division and left it short of the announced amount.
+		// Sum all actualAmounts - always populated whether the source was % or fixed.
+		// Read as a magnitude: ram:ChargeIndicator already says which way the amount goes, so a BT-136 written
+		// negative under an indicator of false (issue #783) still means that much off the line.
 		$totalDiscountAmount = 0.0;
 		foreach ($allowances as $allowance) {
 			$totalDiscountAmount += abs((float) ($allowance['actualAmount'] ?? 0));
@@ -3603,29 +3456,12 @@ class CIIProtocol extends AbstractProtocol
 
 
 	/**
-	 * Record an imported invoice at the totals its document announces, whatever the VAT calculation
-	 * mode of the instance.
+	 * Record an imported invoice at the totals its document announces (issue #781).
 	 *
-	 * Dolibarr computes the VAT of an invoice in one of two conventions, chosen once for the whole
-	 * instance: "total of round" - round the VAT of every line, then add them up - which is what
-	 * update_price() applies when nothing is set, or "round of total" - add the line amounts up, then
-	 * round the VAT once - selected by MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND_SUPPLIER (the core reads the
-	 * generic MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND before Dolibarr 20). The supplier invoice card offers
-	 * the two as the "ReCalculate Mode1 / Mode2" link, and either is a legitimate way to bill.
-	 *
-	 * A received document leaves nothing to choose: BT-110 and BT-112 are given by the issuer, who
-	 * rounded them the way its own system does. Importing under the convention of the instance
-	 * therefore records an invoice that does not total what the document says - two cents on a real
-	 * 46 line invoice (issue #781), which the module then refuses to validate, telling the operator to
-	 * recalculate in the other mode. This does exactly that, on that one invoice, and leaves the
-	 * setting of the instance alone.
-	 *
-	 * The net amounts are never concerned: the core writes a rounding difference back onto the VAT of a
-	 * line, never onto its net amount, so the line net amounts (BT-131) and their sum (BT-106) are the
-	 * same under both conventions. And when neither of the two reproduces the announced totals the
-	 * difference is a real one rather than a rounding convention: the invoice is left exactly as the
-	 * import built it and nothing is said here, checkDolInvoiceAndEInvoiceConsistency() being what
-	 * reports such a gap.
+	 * Dolibarr rounds the VAT of an invoice per line then sums, or sums then rounds once, chosen for the whole
+	 * instance by MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND_SUPPLIER (the generic constant before Dolibarr 20). A received
+	 * document leaves nothing to choose - BT-110 and BT-112 come from the issuer - so the convention that
+	 * reproduces them is applied to that one invoice; when neither does, the invoice is left exactly as imported.
 	 *
 	 * @param	int					$supplierInvoiceId	Id of the invoice the import has just built
 	 * @param	array<string,mixed>	$parsedHeader		Header data of the received document
@@ -3713,24 +3549,10 @@ class CIIProtocol extends AbstractProtocol
 	/**
 	 * Carry the document level charges of a received document (BG-21) as lines of the supplier invoice.
 	 *
-	 * EN 16931 puts two symmetric groups at document level: BG-20, an allowance, which subtracts from the
-	 * total, and BG-21, a charge, which adds to it - freight, packaging, a handling fee. BR-CO-13 defines
-	 * the total of the invoice as
-	 * "Σ Invoice line net amount (BT-131) - Sum of allowances on document level (BT-107)
-	 *  + Sum of charges on document level (BT-108)",
-	 * so a charge is part of what is owed, exactly like a line is.
-	 *
-	 * In CII the two are the same element, ram:SpecifiedTradeAllowanceCharge, told apart only by
-	 * ram:ChargeIndicator/udt:Indicator. The allowances become a DiscountAbsolute, which is the object
-	 * Dolibarr has for them; the charges had nowhere to go, because a supplier invoice holds no positive
-	 * amount at document level, and they were dropped - the invoice then totalled less than the document
-	 * it came from, silently (issue #726).
-	 *
-	 * A line is what a human would key in, so that is what is written here: one line per charge, a single
-	 * unit at the charge amount (BT-99), with the VAT rate the charge declares (BT-103) and the reason it
-	 * gives (BT-104, or its reason code BT-105 when only that is present - BR-38 requires one of the two).
-	 * They are written through createSupplierInvoiceLinesIntoDatabase(), the same path as every other line
-	 * of the import, so nothing new touches the core.
+	 * A supplier invoice holds no positive amount at document level: the allowances (BG-20) became a
+	 * DiscountAbsolute while the charges were dropped, silently shrinking the invoice (issue #726), though BR-CO-13
+	 * counts BT-108 into the total. They are written as one line per charge, a single unit at BT-99, with the VAT
+	 * rate BT-103 and the reason BT-104 (or BT-105 when only that is present, BR-38 requiring one of the two).
 	 *
 	 * @param	int						$supplierInvoiceId			Id of the invoice being imported
 	 * @param	array<int,array<string,mixed>>	$headerAllowancesCharges	Parsed ram:SpecifiedTradeAllowanceCharge of the header

--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -107,19 +107,10 @@ trait CommonProtocol
 
 		// Determine suffix 1 (initial invoice) or 2 (already paid invoice) according to invoice status and payment information and if the invoice contain a line a deposit (prepayment) so final invoice after deposit then suffix is 4
 		//
-		// BT-23 describes the billing case of the document, it is not a payment status: in the AFNOR
-		// nominal use case (XP Z12-012 annexe B, UC1_F202500003) the invoice is issued in frame S1 and
-		// stays S1 while the CDAR lifecycle reports 211 "Paiement transmis" then 212 "Encaissée" — the
-		// document is never re-issued in S2. So "already paid" only covers an invoice whose amount was
-		// already received when it was issued, and BR-FR-CO-09 makes that concrete and mandatory:
-		// with B2/S2/M2 the amount already paid (BT-113) must equal the total (BT-112) and the amount
-		// due (BT-115) must be 0, both fatal.
-		//
-		// Deriving the suffix from Facture::STATUS_CLOSED alone broke that: an invoice closed as paid
-		// without matching payment records — what "Classify as paid" does, and what the deposit turned
-		// into a discount does — still reports BT-113 = 0, so the document declared itself already paid
-		// while claiming the full amount was due, and was rejected. Claim the frame only when the
-		// amount the document will actually carry in BT-113 covers the total.
+		// BT-23 is the billing case of the document, not a payment status: BR-FR-CO-09 makes B2/S2/M2
+		// fatal unless the amount already paid (BT-113) equals the total (BT-112) and the amount due
+		// (BT-115) is 0. Facture::STATUS_CLOSED alone does not say that, so claim the frame only when
+		// the amount the document will actually carry in BT-113 covers the total.
 		$totalTtc = (float) price2num($invoice->total_ttc, 'MT');
 		if ($alreadyPaid === null) {
 			$alreadyPaid = (float) $invoice->getSommePaiement();
@@ -321,15 +312,9 @@ trait CommonProtocol
 		$line->fk_product = 0;
 
 		include_once DOL_DOCUMENT_ROOT.'/core/lib/price.lib.php';
-		// The specimen has to read the same everywhere, so the discount rounding is pinned instead of
-		// following the instance. It is pinned to the default convention - round the line total - and
-		// not to 2, "round the discounted unit price first", because no two supported cores agree on
-		// what 2 means: 18 and 20 do not implement the option at all and round the total, 23 rounds the
-		// unit price up and 24 rounds it down. On the line below (5 x 100.05 less 10%) that is three
-		// different totals, 450.23 / 450.25 / 450.20, for one specimen. The default is the one value
-		// the four of them return.
-		// Restored right after: this is a specimen, it has no business changing how the rest of the
-		// request computes its prices.
+		// Pin the discount rounding so the specimen reads the same everywhere: no two supported cores
+		// agree on MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE... (18 and 20 do not implement it, 23 rounds the
+		// unit price up, 24 rounds it down). Restored right after: this is a specimen.
 		$savRoundDiscountOnUnitPrice = getDolGlobalString('MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY');
 		$conf->global->MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY = '0';
 
@@ -486,12 +471,8 @@ trait CommonProtocol
 		 * 4. If still not found, create new thirdparty with provided data - or refuse the document
 		 *    when the automatic creation of thirdparties is disabled
 		 *
-		 * By default a received document is attached to a thirdparty by a structured legal identifier
-		 * only. Name, commercial alias, ref_ext and email address are descriptive fields that several
-		 * companies can carry, so matching on them books a supplier invoice on a company that did not
-		 * issue it (issue #739). When the identifier of the seller matches nothing, the seller is
-		 * unknown, and an unknown seller is created rather than guessed - unless an expert turned
-		 * step 3 back on for a base whose thirdparties carry no legal identifier at all.
+		 * A received document is attached by structured legal identifier only: name, alias, ref_ext and
+		 * email are descriptive fields several companies can carry (issue #739).
 		 */
 		global $db, $langs, $user, $conf;
 		require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
@@ -589,15 +570,10 @@ trait CommonProtocol
 			}
 		}
 
-		// Step 3: If not found, try to find by findNearest function.
-		//
-		// A name is not an identity: distinct legal entities collide on it, and under EN 16931 the
-		// seller name (BT-27) and trading name (BT-28) are descriptive fields of the document, never
-		// routing ones. The last stage of findNearest() ORs name and commercial alias, so a thirdparty
-		// merely carrying the seller name collects the received invoice (issue #739). This step is
-		// therefore OFF by default and kept behind the hidden option EINVOICING_THIRDPARTIES_MATCH_ON_NAME
-		// (no entry in the setup page on purpose), for the bases whose thirdparties were recorded
-		// without any legal identifier and which need this fallback. It is enabled knowingly.
+		// Step 3: If not found, try to find by findNearest function. A name is not an identity: BT-27 and
+		// BT-28 are descriptive, and the last stage of findNearest() ORs name and commercial alias, so a
+		// thirdparty merely carrying the seller name collects the invoice (issue #739). OFF by default,
+		// behind the hidden option EINVOICING_THIRDPARTIES_MATCH_ON_NAME (no setup page entry on purpose).
 		if ($thirdpartyId < 0 && getDolGlobalString('EINVOICING_THIRDPARTIES_MATCH_ON_NAME')) {
 			// An email address is not an identity either: it can be shared by several third parties, and
 			// a third party that merely carries the sender's address is not necessarily the sender. It is
@@ -661,12 +637,9 @@ trait CommonProtocol
 			dol_syslog(get_class($this) . '::_syncOrCreateThirdpartyFromEInvoiceSeller Seller not found by its legal identifiers, and the name is not used as a match criterion (hidden option EINVOICING_THIRDPARTIES_MATCH_ON_NAME is off)');
 		}
 
-		// Identifier-based match: raise a NON-BLOCKING warning when the descriptive name carried by the
-		// e-invoice does not match the linked third party. Under EN 16931 / the French CTC framework, a
-		// supplier is identified and routed by its structured identifier (SIREN 0002, SIRET 0009, routing
-		// 0225) and VAT number, never by name. Seller name (BT-27) and trading name (BT-28) are descriptive
-		// fields, so a mismatch must not block import or routing, but it is a legitimate data-quality /
-		// mis-attachment / fraud signal worth surfacing. See issue #309.
+		// Identifier-based match: raise a NON-BLOCKING warning when the name carried by the e-invoice
+		// does not match the linked third party. A supplier is identified by its structured identifier,
+		// never by name (BT-27 and BT-28 are descriptive), so a mismatch only signals data quality (#309).
 		$nameMismatchWarning = '';
 		if ($thirdpartyId > 0 && $matchedByStructuredIdentifier) {
 			$invoiceNames = array($sellerInfo['sellername'] ?? '', $sellerInfo['sellerTradingName'] ?? '');
@@ -800,15 +773,11 @@ trait CommonProtocol
 				$allowmodcodeclient = 1;
 			}
 
-			// This function never sets an extrafield on a thirdparty, so it must not rewrite them.
-			// It has to say so explicitly: from Dolibarr 20 on, fetch() pre-fills array_options with a
-			// null entry for every declared extrafield, and update() then hands that array to
-			// insertExtraFields(), which refuses the WHOLE update as soon as one of those fields is
-			// mandatory and empty. Every thirdparty this very function created is in that state (a
-			// programmatic create() writes no extrafield row at all), and so is every thirdparty that
-			// predates the mandatory flag - so a mandatory extrafield on the thirdparty rejected every
-			// received document. Emptied, array_options makes insertExtraFields() return 0 without
-			// touching the stored row, so no value is lost either.
+			// This function never sets an extrafield on a thirdparty, so it must not rewrite them, and it has
+			// to say so explicitly: from Dolibarr 20 on, fetch() pre-fills array_options with a null entry for
+			// every declared extrafield, and update() hands that array to insertExtraFields(), which refuses
+			// the WHOLE update as soon as one of those fields is mandatory and empty. Emptied, array_options
+			// makes insertExtraFields() return 0 without touching the stored row.
 			$thirdparty->array_options = array();
 
 			$result = $thirdparty->update(0, $user, 1, $allowmodcodeclient, $allowmodcodefournisseur);
@@ -1525,14 +1494,9 @@ trait CommonProtocol
 	 * Refuse to build a line whose VAT category requires a Seller VAT identifier the seller has not got.
 	 *
 	 * BR-E-02 and its siblings BR-S-02, BR-Z-02 and BR-AE-02 are satisfied by either the Seller VAT
-	 * identifier (BT-31, schemeID VA) or the Seller tax registration identifier (BT-32, schemeID FC),
-	 * which is why a seller charging no VAT can identify itself with its SIREN. BR-G-02 and BR-IC-02
-	 * are not: their assertion reads schemeID = 'VA' alone, so an exportation or an intracommunity
-	 * supply demands a real VAT number and no fallback can stand in for it.
-	 *
-	 * Without this the document is built, sent, and refused by the platform on a rule the operator has
-	 * no way to connect to a missing field - the same reason BR-S-02 is reported here rather than left
-	 * to the platform (issue #560).
+	 * identifier (BT-31, schemeID VA) or the tax registration identifier (BT-32, schemeID FC). BR-G-02
+	 * and BR-IC-02 are not: their assertion reads schemeID = 'VA' alone. Reported here rather than left
+	 * to the platform, which refuses on a rule the operator cannot connect to a missing field (#560).
 	 *
 	 * @param	Societe		$seller		Selling company
 	 * @param	string		$rule		Business rule that will be broken, for the message
@@ -1664,13 +1628,10 @@ trait CommonProtocol
 		$exemptionReason = null;		// BT-120
 		$exemptionReasonCode = null;	// BT-121 - Must contain a VATEX code. https://docs.peppol.eu/poacc/billing/3.0/codelist/vatex/
 
-		// A line carrying recoverable non-collected VAT ("TVA non perçue récupérable", the overseas
-		// departments scheme of article 295 of the CGI) states a VAT rate, but that VAT is not collected:
-		// Dolibarr makes the total including tax of such a line equal to its net amount, and the amount
-		// due of the invoice follows. EN 16931 offers no way to declare a VAT that is not claimed - the
-		// total with VAT is the net total plus the VAT total (BR-CO-15), so anything declared here would
-		// be claimed from the buyer. The line is therefore issued exempt, which the standard covers with
-		// a reason code of its own for that very article (issue #508).
+		// A line carrying recoverable non-collected VAT (the overseas departments scheme of article 295 of
+		// the CGI) states a VAT rate that is not collected. EN 16931 offers no way to declare a VAT that is
+		// not claimed - BR-CO-15 makes the total with VAT the net total plus the VAT total - so the line is
+		// issued exempt, with the VATEX reason code of that very article (issue #508).
 		if (!empty($line->info_bits) && ((int) $line->info_bits & 1)) {
 			$categoryVAT = 'E';
 			if ($seller->country_code == 'FR') {
@@ -1960,14 +1921,10 @@ trait CommonProtocol
 	/**
 	 * Build the entity restriction of a read of the VAT dictionary table.
 	 *
-	 * The dictionary is per entity: a line of it belongs to the entity that declared it, and the core
-	 * reads it with "AND t.entity IN (".getEntity('c_tva').")" (see getTaxesFromId() in
-	 * htdocs/core/lib/functions.lib.php). Reading it without that clause answers a line another entity
-	 * declared, so the invoice carries an exemption reason (BT-121) that is not the seller's one.
-	 *
-	 * The column itself only exists from Dolibarr 19: it is added by the 18.0.0-19.0.0 migration, and
-	 * the core of 18 reads llx_c_tva with no entity clause at all. So on 18 there is nothing to restrict
-	 * and naming the column would only break the query.
+	 * The dictionary is per entity and the core reads it with "AND t.entity IN (getEntity('c_tva'))"
+	 * (getTaxesFromId(), htdocs/core/lib/functions.lib.php); without it the exemption reason (BT-121)
+	 * can be the one another entity declared. The column only exists from Dolibarr 19: the core of 18
+	 * reads llx_c_tva with no entity clause at all.
 	 *
 	 * @return	string		SQL clause to append to the WHERE, '' on Dolibarr 18
 	 */
@@ -2063,11 +2020,9 @@ trait CommonProtocol
 	 * Keep the order reference the supplier declared on the invoice it sent (BT-13) on the created
 	 * supplier invoice, whether or not it matched a purchase order of Dolibarr.
 	 *
-	 * Auto-linking only happens on an exact, unambiguous match for that supplier: on every other
-	 * case the reference used to be dropped, and the accountant had no way to know what the supplier
-	 * had declared, nor to reconcile the invoice by hand. It is stored into the table of the module
-	 * and not into an extrafield of the core, which a user could rename or delete. Never blocking:
-	 * an import must not fail because a piece of information could not be kept beside it.
+	 * Auto-linking only happens on an exact, unambiguous match for that supplier; on every other case
+	 * the reference would be dropped. Stored into the table of the module and not into an extrafield of
+	 * the core, which a user could rename or delete. Never blocking.
 	 *
 	 * @param FactureFournisseur	$supplierInvoice	Supplier invoice created by the import
 	 * @param string				$orderReference		Order reference declared by the supplier (BT-13)
@@ -2092,12 +2047,9 @@ trait CommonProtocol
 	/**
 	 * Link an inbound supplier invoice to its Dolibarr purchase order (commande fournisseur).
 	 *
-	 * Uses the purchase order reference (BT-13, BuyerOrderReferencedDocument/IssuerAssignedID) carried by
-	 * the invoice. The lookup is reference-exact (after trimming) AND scoped to the resolved supplier, so a
-	 * matching reference belonging to another supplier is never linked. The link is only created on a single
-	 * unambiguous match; several matches are flagged (no auto-link) and the absence of a match is silent.
-	 *
-	 * This is internal ERP reconciliation logic and must NEVER block import. See issue #303.
+	 * Uses BT-13 (BuyerOrderReferencedDocument/IssuerAssignedID). The lookup is reference-exact and
+	 * scoped to the resolved supplier, and only a single unambiguous match creates the link. Internal
+	 * ERP reconciliation logic: it must NEVER block import (issue #303).
 	 *
 	 * @param 	FactureFournisseur 	$supplierInvoice 	Freshly created supplier invoice (must expose ->id)
 	 * @param 	int 				$socId 				Resolved supplier third party id
@@ -2263,14 +2215,10 @@ trait CommonProtocol
 			if (isset(self::$UNTDID4461_TO_DOLIBARR_PAIEMENT_CODE[$untdidCode])) {
 				$dolibarrPaymentCode = self::$UNTDID4461_TO_DOLIBARR_PAIEMENT_CODE[$untdidCode];
 
-				// Read the dictionary through the core helper instead of forging the query here: it
-				// applies the multicompany filter (entity IN (getEntity('c_paiement'))) and caches the
-				// lookup. The extra filter keeps the "active entries only" behaviour the helper has no
-				// argument for; it is a hardcoded literal, never anything coming from the document.
-				// Only 7 arguments: the 8th ($useCache) does not exist on Dolibarr 19. From 19 on the
-				// core caches on [table][key][fieldid] only, so the entity and the filter above are not
-				// part of the cache key; harmless here, an import reads the dictionary in one entity
-				// with one filter.
+				// Read the dictionary through the core helper: it applies the multicompany filter and caches the
+				// lookup. The extra filter keeps the "active entries only" behaviour and is a hardcoded literal,
+				// never anything coming from the document. Only 7 arguments: the 8th ($useCache) does not exist
+				// on Dolibarr 19.
 				$paymentModeId = (int) dol_getIdFromCode($db, $dolibarrPaymentCode, 'c_paiement', 'code', 'id', 1, " AND active = 1");
 
 				if ($paymentModeId > 0) {

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -183,12 +183,9 @@ class FacturXProtocol extends CIIProtocol
 			// Source PDF deleted or never generated: regenerate it with the default PDF model before embedding.
 			$modelname = getDolGlobalString('FACTURE_ADDON_PDF') ?: 'crabe';
 
-			// That rebuild fires afterPDFCreation, whose job is to produce the e-invoice - which is exactly
-			// what this call is doing. Tell the hook to stand back for this invoice, or it generates the
-			// document a second time and cleans up the temporary XML this call still needs (issue #658).
-			// try/finally, not two plain assignments: a rebuild that throws must not leave the hook muted
-			// for the rest of the request, which would silently skip the e-invoice of the invoices a mass
-			// generation handles after this one.
+			// That rebuild fires afterPDFCreation, which would generate the document a second time and clean
+			// up the temporary XML this call still needs (issue #658), so the hook is told to stand back.
+			// try/finally: a rebuild that throws must not leave the hook muted for the rest of the request.
 			$resultpdf = -1;
 			EInvoicing::setEInvoiceGenerationInProgress($invoice->id, true);
 			try {
@@ -267,17 +264,11 @@ class FacturXProtocol extends CIIProtocol
 			$creator = (string) pdfExtractMetadata($orig_pdf, 'Creator');
 		}
 
-		// The choice below reads the global class FPDF, and must not depend on whether the request
-		// happened to render a PDF before reaching here. Below Dolibarr 24 the core declares its own
-		// "class FPDF extends TCPDF {}" in htdocs/includes/tcpdi/tcpdi.php, but only once its PDF stack
-		// is loaded: a generation that finds the source PDF already on disk - the mass generation of the
-		// invoice list, typically - never renders one, so the shim is absent and the branch below picks
-		// the horstoeko/setasign writer, which autoloads the real FPDF of the module. Both classes are
-		// named FPDF and only the first one of the request survives, so the next core PDF of that same
-		// request dies on "Cannot redeclare class FPDF ... in includes/tcpdi/tcpdi.php". Load the PDF
-		// stack of the core now, so the question is settled by the Dolibarr version alone. The instance
-		// is discarded: pdf_getInstance() is called for what it loads and for the K_* constants TCPDF
-		// needs, which no PDF render defined yet in this request.
+		// Below Dolibarr 24 the core declares its own "class FPDF extends TCPDF {}" in
+		// htdocs/includes/tcpdi/tcpdi.php, but only once its PDF stack is loaded. Load that stack now, so
+		// the branch below does not depend on whether this request rendered a PDF already: without it the
+		// module autoloads the real FPDF instead, and the next core PDF of the request dies on "Cannot
+		// redeclare class FPDF". The instance is discarded, only what it loads and the K_* constants matter.
 		if (!class_exists('FPDF', false)) {
 			require_once DOL_DOCUMENT_ROOT . '/core/lib/pdf.lib.php';
 			pdf_getInstance();
@@ -364,13 +355,9 @@ class FacturXProtocol extends CIIProtocol
 	/**
 	 * Check that the produced PDF really is a Factur-X file, and not a PDF with an attachment.
 	 *
-	 * Nothing in the standard makes the difference visible to the eye: both carry the XML and both
-	 * open normally. What a reader and a platform validator look for is the document level /AF array
-	 * and the PDF/A-3 output intent, and a file that has the embedded stream but neither of those is
-	 * refused - after being sent, which is the expensive moment to find out (issue #554).
-	 *
-	 * The check is on the produced file rather than on the code path that produced it, so it also
-	 * covers a merger that silently degrades for another reason.
+	 * A reader and a platform validator look for the document level /AF array and the PDF/A-3 output
+	 * intent, and refuse a file that has the embedded stream but neither of those - after it was sent
+	 * (issue #554). The check is on the produced file, so it also covers a merger that degrades silently.
 	 *
 	 * @param	string	$pathfacturxpdf		Full path of the generated Factur-X PDF
 	 * @return	void
@@ -644,12 +631,8 @@ class FacturXProtocol extends CIIProtocol
 		// Done before the duplicate/ref-docs checks below so those checks can be scoped to this supplier
 		// (ref_supplier is only unique per supplier, not globally - see issue about cross-supplier collisions).
 		//
-		// The vendor is reference data, not part of the invoice: it gets its own transaction, committed
-		// before the import starts. A business error raised further down - a product that cannot be
-		// auto-created, a referenced document missing - must not roll back the thirdparty the operator is
-		// precisely being asked to complete: the "create the product" and "map the product" links returned
-		// with that error carry its socid, so a rolled back vendor makes them point to a thirdparty that
-		// never existed.
+		// The vendor is reference data: it gets its own transaction, committed before the import starts,
+		// so a business error further down does not roll back the thirdparty the returned links point to.
 		$db->begin();
 		$this->openedTransactions++;
 
@@ -732,12 +715,9 @@ class FacturXProtocol extends CIIProtocol
 					return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($refDocInvoiceId, $refDoc, 'linked to document ' . ($parsedHeader['documentno'] ?? ''))];
 				}
 				if ($refDocInvoiceId == 0) {
-					// The invoice references a document this Dolibarr does not hold: the final invoice of a
-					// deposit, the invoice a credit note credits, the one a replacement replaces. Nothing has
-					// been created at this point, so the flow is postponed rather than failed: it is retried
-					// on the next synchronization, and the invoices queued behind it keep coming in. What the
-					// user has to do cannot be guessed from a technical message, so it is spelled out with a
-					// link to the screen where the missing invoice is created.
+					// The invoice references a document this Dolibarr does not hold (deposit, credited or
+					// replaced invoice). Nothing has been created yet, so the flow is postponed rather than
+					// failed, and the message spells out what to create with a link to the creation screen.
 					$langs->load("bills");
 					$action = $langs->trans('CreateTheMissingSupplierInvoiceToImport', $refDoc);
 					$action .= ' <a class="butAction small smallpaddingimp nomarginleft" href="' . DOL_URL_ROOT . '/fourn/facture/card.php?action=create&socid=' . (int) $socId . '&ref_supplier=' . urlencode($refDoc) . '" target="_blank">';

--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -217,12 +217,8 @@ abstract class AbstractPDPProvider
 	 * Providers that do not expose a directory lookup keep the default 'unsupported' status so
 	 * the feature degrades gracefully and never blocks them.
 	 *
-	 * A SIREN can hold several reception addresses in the directory (the bare SIREN and one per
-	 * establishment SIRET), and only one of them is written into the invoice as BT-49. Answering on
-	 * whichever line the directory returns first would then report the reachability of an address the
-	 * invoice is not sent to: pass that BT-49 address as $addressingidentifier and the answer is about
-	 * it alone. An address that is not declared for that SIREN is reported as its own status, never
-	 * silently replaced by another line that happens to be open.
+	 * A SIREN can hold several reception addresses (the bare SIREN and one per SIRET) but only the
+	 * BT-49 one receives the invoice: pass it as $addressingidentifier so the answer is about it alone.
 	 *
 	 * @param 	string 	$idprof1 				Recipient professional id 1 (SIREN for France)
 	 * @param 	string 	$addressingidentifier 	Routing address the invoice is actually sent to (BT-49). Empty to answer on any line declared for the SIREN, which is what a caller with no invoice at hand wants.
@@ -293,12 +289,9 @@ abstract class AbstractPDPProvider
 		}
 
 		if ($result['entries'] > 0) {
-			// A directory line exists, but only an enabled one can actually receive: the annuaire also
-			// carries lines that are declared and not open yet ('Upcoming', i.e. bound to a platform with
-			// a future effective date), or closed ('Disabled'). Counting every returned line as active
-			// would report 'routable' for a recipient the platform then refuses with a routing error
-			// (fr:213). A line whose status is missing proves nothing either way: it is counted apart so
-			// the caller can say so, instead of being silently trusted and shown as reachable.
+			// Only an 'Enabled' line can receive: 'Upcoming' (future effective date) and 'Disabled' ones
+			// would be refused by the platform with a routing error (fr:213). A missing status proves
+			// nothing either way, so it is counted apart rather than trusted.
 			$firstunknown = '';
 			$firstblocked = array('', '');
 			foreach ($lines as $line) {
@@ -329,14 +322,10 @@ abstract class AbstractPDPProvider
 				$result['status'] = 'routable';
 				$result['reachable'] = 1;
 			} elseif ($result['unknown'] > 0) {
-				// Lines are declared but the platform did not report their status, and it cannot be asked
-				// for: 'directoryLineStatus' is not part of the field list the search accepts (XP Z12-013
-				// only allows addressingIdentifier, siren, siret and addressingSuffix there), it is only
-				// returned as a bonus by the platforms that choose to. Fetching the line on its own
-				// (GET directory-line/code:<addressingIdentifier>) does not help either: on a platform
-				// that omits the status in the search, that answer omits it too. So an enabled address
-				// and one that merely takes effect later are indistinguishable here: stay non-conclusive
-				// (the caller keeps failing open) rather than claim the recipient is reachable.
+				// Lines declared without a status, and it cannot be asked for: XP Z12-013 does not allow
+				// directoryLineStatus as a search field, and a platform omitting it in the search omits it
+				// on GET directory-line too. Enabled and upcoming are indistinguishable here: stay
+				// non-conclusive so the caller fails open.
 				$result['status'] = 'undetermined';
 				$result['reachable'] = -1;
 				$result['identifier'] = $firstunknown;
@@ -356,11 +345,8 @@ abstract class AbstractPDPProvider
 
 		// 2) No directory line: tell apart a legal unit known to the directory but not able to receive
 		//    yet (inactive) from a SIREN that is unknown to the directory (absent).
-		//    The search form is used rather than the 'siren/code-insee:<siren>' consultation: both are
-		//    part of the same standardized service, but the consultation is not served by every Approved
-		//    Platform (one answers 404 on it while answering the search with the legal unit), so the
-		//    search is what keeps this second step meaningful everywhere. An unknown SIREN comes back
-		//    either as a 404 or as an empty result set depending on the platform, and both mean absent.
+		//    The search is used rather than the 'siren/code-insee:<siren>' consultation, which not every
+		//    Approved Platform serves. An unknown SIREN answers 404 or an empty result set: both absent.
 		$consultbody = json_encode(array('filters' => array('siren' => array('op' => 'strict', 'value' => $siren))));
 		$consult = $this->callApi('afnor-directory/v1/siren/search', 'POST', $consultbody, array(), 'precheck_directory');
 		$consultcode = (int) (isset($consult['status_code']) ? $consult['status_code'] : 0);
@@ -376,12 +362,8 @@ abstract class AbstractPDPProvider
 	/**
 	 * Normalize an electronic address so two writings of the same one compare equal.
 	 *
-	 * The address recorded in Dolibarr and the one the directory returns are the same string in
-	 * principle, but they do not always come written the same way: a user typing a SIRET-suffixed
-	 * address adds spaces to read it, and a platform may qualify the address with the scheme it
-	 * belongs to ('0225:' for the French SIREN scheme, which the legacy SuperPDP endpoint does). The
-	 * scheme is not part of the address, and Dolibarr records the address without it, so neither
-	 * difference may turn a match into a mismatch and report a declared address as unknown.
+	 * Dolibarr records the bare address, while a user adds spaces to read it and a platform may prefix
+	 * the scheme ('0225:' for the French SIREN scheme). Neither may turn a match into a mismatch.
 	 *
 	 * @param 	string 	$identifier 	Electronic address, as recorded or as returned by a platform
 	 * @return 	string 					Comparable form of that address, empty when there is none
@@ -466,18 +448,10 @@ abstract class AbstractPDPProvider
 	/**
 	 * Pick, among the documents the access point holds for a flow, the first one this module can read.
 	 *
-	 * A flow carries its invoice in several shapes: 'Converted' is the invoice rewritten into the
-	 * syntax configured on the access point account, 'Original' is what the issuer really sent, and
-	 * 'ReadableView' is the human readable copy - which, on an access point that builds it as a
-	 * Factur-X PDF, carries the same data again.
-	 *
-	 * 'Converted' comes first because it is the one that shields the import from an issuer emitting a
-	 * syntax this module does not read - UBL, in particular, belongs to the French socle but has no
-	 * implementation here. But it depends on a setting that lives on the access point account, outside
-	 * Dolibarr: left unset, the platform refuses to produce the document at all; set to a syntax this
-	 * module does not support, it produces one that cannot be imported. Neither case says anything
-	 * about the other documents of the same flow, so they are tried in turn rather than failing the
-	 * flow on the first miss.
+	 * 'Converted' (rewritten into the syntax set on the access point account) is tried first, as it
+	 * shields the import from an issuer emitting a syntax with no reader here, such as UBL. That
+	 * setting lives outside Dolibarr and may be unset or unsupported, so 'Original' then 'ReadableView'
+	 * are tried in turn rather than failing the flow on the first miss.
 	 *
 	 * @param	string			$flowId				Identifier of the flow to read
 	 * @param	ProtocolManager	$protocolManager	Protocol factory used to recognize the documents
@@ -553,19 +527,10 @@ abstract class AbstractPDPProvider
 	/**
 	 * The invoice a document carries, once its container has been opened, when this module can read it.
 	 *
-	 * detectProtocolFromContent() answers on the outside of a file: a PDF is 'FACTURX' on the strength
-	 * of its '%PDF-' header alone, whatever it holds. What it holds is a separate question, because the
-	 * embedded invoice is picked by file name and not by content - 'xrechnung.xml' is one of the names
-	 * accepted, and an XRechnung is commonly UBL, a syntax that has no reader here.
-	 *
-	 * Reading the outside only is how such a payload reaches the reader of another syntax. The CII
-	 * reader then finds none of the elements it expects and reports a business error that names nothing
-	 * the user can act on, which is counted as a failure and stops the whole synchronization batch; and
-	 * on the consistency check, the same document reaches code that dereferences a protocol which was
-	 * never built.
-	 *
-	 * The document is not re-typed on what is found inside: a Factur-X PDF is imported as Factur-X,
-	 * whose reader does the extraction itself. Only the question "can this be read at all" is answered.
+	 * detectProtocolFromContent() answers on the container alone: a PDF is 'FACTURX' on its '%PDF-'
+	 * header, while the embedded invoice is picked by file name and may be UBL ('xrechnung.xml'), which
+	 * has no reader here. Only "can this be read at all" is answered: the document keeps its container
+	 * type, a Factur-X PDF is still imported as Factur-X.
 	 *
 	 * @param	string				$content			Raw document, as the access point returned it
 	 * @param	AbstractProtocol	$protocol			Protocol recognized on the container
@@ -1001,12 +966,8 @@ abstract class AbstractPDPProvider
 	/**
 	 * Log an API call into llx_einvoicing_call using a SEPARATE database connection.
 	 *
-	 * The call trace must survive even when the caller's main transaction is rolled
-	 * back on error (see issue #291): a failed send_invoice rolls back the doActions()
-	 * transaction, which would otherwise wipe the very log we need to diagnose it.
-	 * Writing the log through an independent connection ($dbhistory) decouples it from
-	 * the business transaction, so it is committed whether the action succeeds or fails,
-	 * without ever forcing a commit on the rest. Same approach as the webhook logging.
+	 * The trace must survive a rollback of the caller's transaction (issue #291), so it is written on
+	 * an independent connection ($dbhistory) and committed whether the action succeeds or fails.
 	 *
 	 * Request/response payloads are redacted (@see redactSensitiveData()) before being
 	 * persisted: this log is readable by any user with the 'einvoicing' read right, so

--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -304,13 +304,9 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 
 		// OAuth2 client_credentials — RFC 6749, application/x-www-form-urlencoded
 		// Replace old POST /v1/token (JSON username/password) disabled since v1.2.6 (2026-07).
-		// grant_type is REQUIRED by RFC 6749 section 4.4.2, whatever the client authentication
-		// method is: without it the endpoint answers 400 {"error":"Bad Request","message":"must
-		// not be blank"} and no token can ever be issued.
-		// Default is the credentials in the body, the only form checked against the platform.
-		// ESALINK_AUTHENT_USING_BASIC_AUTH switches to HTTP Basic (RFC 6749 section 2.3.1) for
-		// an access point that would require it: credentials then go in the header only, as a
-		// client must not use more than one authentication method in the same request.
+		// grant_type is REQUIRED by RFC 6749 section 4.4.2 whatever the client authentication method is:
+		// without it the endpoint answers 400 and no token is ever issued. Credentials go in the body, or in
+		// an HTTP Basic header (RFC 6749 section 2.3.1) with ESALINK_AUTHENT_USING_BASIC_AUTH, never in both.
 		if (getDolGlobalString('ESALINK_AUTHENT_USING_BASIC_AUTH')) {
 			$param = http_build_query(array(
 				'grant_type'    => 'client_credentials',
@@ -1349,12 +1345,9 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 					break;
 				}
 
-				// Retrieve the invoice of the flow in whichever shape this module is able to read: the
-				// 'Converted' document first, then the 'Original', then the readable view. Asking only for
-				// the 'Converted' one makes the import depend on a setting that lives on the access point
-				// account: pointed at a syntax with no reader here - UBL - every received invoice of the
-				// instance becomes unreadable, even when the issuer sent a CII or a Factur-X the module
-				// reads perfectly.
+				// Retrieve the invoice of the flow in whichever shape this module can read: 'Converted' first,
+				// then 'Original', then the readable view. Asking only for 'Converted' makes the import depend
+				// on a setting of the access point account: pointed at UBL, every received invoice is lost.
 				$tmpProtocolManager = new ProtocolManager($this->db);
 				$importable = $this->fetchImportableFlowDocument($flowId, $tmpProtocolManager);
 
@@ -1477,11 +1470,9 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 				*/
 
 				// 2. Read CDAR and update status of linked customer invoice
-				// The CDAR is normally read as the "Original" document. Some flows have no original on the
-				// platform, only the converted copy, and the synchronization then stops on that flow and on
-				// every flow behind it with no way to go past it. Both documents carry the same CDAR, so fall
-				// back on the converted one rather than blocking. docType can be 'Metadata', 'Original',
-				// 'Converted' or 'ReadableView'.
+				// Some flows have no 'Original' on the platform, only the converted copy, and the sync then
+				// stops on that flow and on every flow behind it. Both carry the same CDAR, so fall back on
+				// the converted one. docType can be 'Metadata', 'Original', 'Converted' or 'ReadableView'.
 				$flowResponse = $this->fetchFlowData($flowId, 'Original');
 
 				if ($flowResponse['status_code'] != 200) {

--- a/einvoicing/class/providers/PDPProviderManager.class.php
+++ b/einvoicing/class/providers/PDPProviderManager.class.php
@@ -172,17 +172,10 @@ class PDPProviderManager
 	/**
 	 * Complete the list of providers with the ones declared by external modules.
 	 *
-	 * An external module declares the hook context 'einvoicingproviders' in its descriptor
-	 * ($this->module_parts['hooks'] = array('einvoicingproviders');) and implements a method
-	 * addPDPProviders() into its /mymodule/class/actions_mymodule.class.php. The method fills
-	 * $this->results with entries keyed by the provider code, each one holding at least a 'class'
-	 * (a class extending AbstractPDPProvider) and a 'classpath' (directory of the class file,
-	 * relative to the Dolibarr document root).
+	 * An external module declares the hook context 'einvoicingproviders' in its descriptor and implements
+	 * addPDPProviders(), which fills $this->results with entries keyed by provider code, each holding at
+	 * least a 'class' (extending AbstractPDPProvider) and its 'classpath' relative to the document root.
 	 * See einvoicing/doc/ADD-A-PDP-PROVIDER.md for the complete contract.
-	 *
-	 * A hook is used rather than a scan of the module directories because it lists only the providers
-	 * of the modules that are enabled, it costs nothing when no module implements it, and it let the
-	 * module build its own entry (position, urls, label translated in the language of the user).
 	 *
 	 * @return void
 	 */

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -1551,11 +1551,9 @@ class SuperPDPProvider extends AbstractPDPProvider
 		}
 
 		// Standardized lookup unavailable or errored: fall back to the SuperPDP specific endpoint.
-		// That answer is weaker (a boolean with no effective date, so it cannot conclude 'routable' on
-		// its own) and it must say so: without the provenance, the non-conclusive badge it produces
-		// reads as a verdict on the recipient, when what it really reports is a call that did not go
-		// through on this instance. Issue #698 was exactly that misreading, and it cost a round trip
-		// with the recipient's platform before the API call log settled it.
+		// That answer is weaker (a boolean with no effective date, so it cannot conclude 'routable' on its
+		// own) and it must say so: without the provenance, the non-conclusive badge reads as a verdict on
+		// the recipient instead of a call that did not go through on this instance (issue #698).
 		$legacy = $this->checkRecipientDirectoryLegacy($idprof1, $addressingidentifier);
 		if ($legacy['status'] !== 'error') {
 			// Only when the fallback itself answered: its own error message is what the caller must
@@ -1576,19 +1574,9 @@ class SuperPDPProvider extends AbstractPDPProvider
 	 * Settle a standardized directory answer that came back without line statuses, using the SuperPDP
 	 * specific french_directory endpoint as a tie-breaker.
 	 *
-	 * The status is missing from some standardized answers of this platform (observed on the lines
-	 * addressed by the bare SIREN and not open yet), and it cannot be requested: 'directoryLineStatus'
-	 * is not one of the values the search accepts in 'fields', and reading the line on its own omits it
-	 * as well. The platform's own endpoint answers about the very same lines, at the same moment, and
-	 * does carry the flag: on every line where both answers report it, the boolean matches the
-	 * standardized status (true for 'Enabled', false for 'Upcoming'). So it is used here to conclude,
-	 * and only here:
-	 * - it settles a non-conclusive answer, it never overrides a status the standardized answer gave ;
-	 * - it stays silent (the answer remains non-conclusive) when it knows nothing of that SIREN or
-	 *   fails, since the standardized annuaire does hold lines for it.
-	 *
-	 * The boolean does not tell a line waiting for its effective date from a closed one, so a negative
-	 * verdict says the recipient cannot receive without claiming which of the two it is.
+	 * The line status cannot be requested ('directoryLineStatus' is not accepted in 'fields'). The
+	 * specific endpoint carries a boolean that matches it (true for 'Enabled', false for 'Upcoming'), so
+	 * it only settles a non-conclusive answer and never overrides a status given.
 	 *
 	 * @param 	string 	$idprof1 				Recipient SIREN (idprof1)
 	 * @param 	array{status:string,reachable:int,entries:int,active:int,unknown:int,identifier:string,linestatus:string,platform:string,effectivedate:int,message:string,messageparam:string,httpcode:int} 	$result 	Non-conclusive result of the standardized check
@@ -1641,9 +1629,8 @@ class SuperPDPProvider extends AbstractPDPProvider
 	 * endpoint (GET french_directory/entries on the v1.beta base). Kept for platforms or environments
 	 * where the standardized AFNOR Directory Service is not reachable.
 	 *
-	 * This endpoint only exposes a boolean 'is_active', which does not tell an open reception address
-	 * from one that is merely declared with a future effective date: it cannot conclude 'routable' on
-	 * its own, see below.
+	 * This endpoint only exposes a boolean 'is_active', which does not tell an open reception address from
+	 * one merely declared with a future effective date: it cannot conclude 'routable' on its own.
 	 *
 	 * @param 	string 	$idprof1 				Recipient SIREN (idprof1)
 	 * @param 	string 	$addressingidentifier 	Routing address the invoice is actually sent to (BT-49), empty to answer on any entry of the SIREN
@@ -2355,12 +2342,9 @@ class SuperPDPProvider extends AbstractPDPProvider
 					break;
 				}
 
-				// Retrieve the invoice of the flow in whichever shape this module is able to read: the
-				// 'Converted' document first, then the 'Original', then the readable view. Asking only for
-				// the 'Converted' one makes the import depend on a setting that lives on the access point
-				// account: pointed at a syntax with no reader here - UBL - every received invoice of the
-				// instance becomes unreadable, even when the issuer sent a CII or a Factur-X the module
-				// reads perfectly.
+				// Retrieve the invoice of the flow in whichever shape this module can read: 'Converted' first,
+				// then 'Original', then the readable view. Asking only for 'Converted' makes the import depend
+				// on a setting of the access point account: pointed at UBL, every received invoice is lost.
 				$tmpProtocolManager = new ProtocolManager($this->db);
 				$importable = $this->fetchImportableFlowDocument($flowId, $tmpProtocolManager);
 
@@ -2654,12 +2638,9 @@ class SuperPDPProvider extends AbstractPDPProvider
 				require_once DOL_DOCUMENT_ROOT . '/fourn/class/fournisseur.facture.class.php';
 				$document->fk_element_type = 'invoice_supplier';
 
-				// An incoming one is a different thing entirely: it is a status the VENDOR issues about
-				// one of its own invoices - "Cashed in" (212) above all, which is the answer to the
-				// payment we reported with a 211. We never sent it, so it has no row in
-				// einvoicing_lifecycle_msg and the flowId lookup below cannot resolve it: it used to end
-				// up stored with neither its lifecycle code nor its supplier invoice, so nothing ever
-				// surfaced on the invoice.
+				// An incoming one is a status the VENDOR issues about one of its own invoices - "Cashed in"
+				// (212) above all, the answer to the payment we reported with a 211. We never sent it, so it
+				// has no row in einvoicing_lifecycle_msg and the flowId lookup below cannot resolve it.
 				if ($document->flow_direction == 'In') {
 					$resIncoming = $this->processIncomingSupplierInvoiceStatus($flowId, $document, $einvoicing);
 
@@ -2823,13 +2804,9 @@ class SuperPDPProvider extends AbstractPDPProvider
 	 * Record a lifecycle status the vendor issued about one of its invoices, onto the supplier
 	 * invoice it refers to.
 	 *
-	 * This is the mirror of what the CustomerInvoiceLC case does for the statuses our own customers
-	 * send us: read the CDAR, resolve the invoice it points at, and store the status on it.
-	 *
-	 * Never returns a negative result for a status it cannot attach: a vendor may perfectly well
-	 * report on an invoice this Dolibarr does not hold (the invoice was refused, or the same access
-	 * point account is shared with another system), and failing the flow would stall the whole
-	 * synchronization on it, run after run. The flow is stored either way, so nothing is lost.
+	 * Never returns a negative result for a status it cannot attach: a vendor may report on an invoice this
+	 * Dolibarr does not hold (refused, or an access point account shared with another system), and failing
+	 * the flow would stall the whole synchronization on it, run after run. The flow is stored either way.
 	 *
 	 * @param	string		$flowId			Flow identifier of the lifecycle message
 	 * @param	Document	$document		Flow document being built, completed here with the CDAR data

--- a/einvoicing/class/providers/TestPDPProvider.class.php
+++ b/einvoicing/class/providers/TestPDPProvider.class.php
@@ -31,15 +31,10 @@ dol_include_once('einvoicing/class/call.class.php');
 /**
  * Reference implementation of a PDP provider.
  *
- * This class is the skeleton to copy to integrate a new platform, either here or from an external
- * module (see einvoicing/doc/ADD-A-PDP-PROVIDER.md). It implements every method the rest of the
- * module calls, with the smallest body that is still honest: nothing here reaches the network, and
- * the methods that would need a platform to answer return an explicit error instead of pretending.
- *
- * What it does exercise for real, because it needs no platform: the configuration form of the setup
- * page, the storage of a token, the generation of a sample invoice by the exchange protocol, and the
- * logging of the API calls. That is enough to check that a new provider is correctly declared before
- * writing a single line of HTTP.
+ * The skeleton to copy to integrate a new platform, here or from an external module (see
+ * einvoicing/doc/ADD-A-PDP-PROVIDER.md). Nothing here reaches the network: the methods that would need a
+ * platform to answer return an explicit error. Only the setup form, the token storage, the sample invoice
+ * generation and the API call logging are exercised for real.
  */
 class TestPDPProvider extends AbstractPDPProvider
 {

--- a/einvoicing/class/utils/CdarHandler.class.php
+++ b/einvoicing/class/utils/CdarHandler.class.php
@@ -294,12 +294,9 @@ class CdarHandler
 		// We use same as ID for Name as its not required to be different
 		$Name = $ID;
 
-		// 212 (Encaissee) is the only status we send on one of OUR OWN invoices: we are then the seller and
-		// the CDAR is addressed to our customer. Every other status is sent on a supplier invoice, where we
-		// are the buyer and the CDAR goes back to the vendor. Getting those two parties the wrong way round
-		// makes the platform answer "no matching invoices found": it cannot find the invoice the status is
-		// about. See the XP Z12-012 annex B examples, UC1 205/211 (issued by the buyer) versus UC1 212
-		// (issued by the seller).
+		// 212 (Encaissee) is the only status sent on one of OUR OWN invoices: we are then the seller and the
+		// CDAR goes to our customer, every other status is sent on a supplier invoice where we are the buyer.
+		// Swapping the two makes the platform answer "no matching invoices found" (XP Z12-012 annex B, UC1).
 		$isOurOwnInvoice = ($statusCode == CdarHandler::PROC_PAID);
 
 		// SIREN (0002)
@@ -354,19 +351,11 @@ class CdarHandler
 		$ProcessCondition = str_replace(' ', '_', dol_string_unaccent($ProcessCondition));
 		$ProcessCondition = preg_replace('/[^A-Za-z0-9_]/', '', $ProcessCondition); // Clean special chars
 
-		// Electronic address (MDT-73) of the CDAR recipient. Every status but the cash-in (212) is sent on a
-		// supplier invoice: we are the buyer and the CDAR goes back to the vendor. Sending its SIREN blindly
-		// only works when the platform happens to know the vendor under that very address, and gets the
+		// Electronic address (MDT-73) of the CDAR recipient - the vendor, for every status but the cash-in
+		// (212). Its SIREN only works when the platform knows the vendor under that address, and gets the
 		// message refused with "Electronic address (MDT-73) is invalid" otherwise.
-		//
-		// The status is a reply, so the address to reply to is the one the vendor exchanges under:
-		//   1. a routing recorded in Dolibarr for that vendor, which is a deliberate choice of ours;
-		//   2. otherwise the electronic address (BT-34) carried by the e-invoice we received, which is the
-		//      vendor telling us where it exchanges from;
-		//   3. otherwise the platform directory, which may list another address of the same SIREN;
-		//   4. otherwise the SIREN guessed by getBuyerCommunicationURI(). It is called on the third party
-		//      alone: the invoice-level routing override it also knows about is looked up among the customer
-		//      invoices (element_type = 'facture'), which a supplier invoice must not read.
+		// Reply-to address, in order: routing recorded in Dolibarr, BT-34 of the received e-invoice, directory,
+		// then getBuyerCommunicationURI() on the third party alone (its override reads element_type='facture').
 		$RecipientURIID = $InvoiceIssuerGlobalID;
 		$RecipientURISchemeID = CdarHandler::SCHEME_SIREN_0225;
 		$this->recipientURIIDOrigin = 'issuerid';
@@ -685,12 +674,9 @@ class CdarHandler
 	/**
 	 * Build the MDG-43 "cashed amount" (MEN) blocks of a status 212 (Encaissee) CDAR.
 	 *
-	 * The reform asks the seller to declare what was actually cashed, broken down by VAT rate: one block per
-	 * rate, holding the TTC amount (MDT-215) and the rate itself (MDT-224). Dolibarr only records a payment as
-	 * a single TTC amount, so the amount is spread over the VAT rates of the invoice proportionally to their
-	 * TTC weight: exact for a fully paid invoice, prorata otherwise (a partial payment is not attached to
-	 * given lines in Dolibarr). Rounding differences are absorbed by the largest block so the blocks always
-	 * sum up to the cashed amount.
+	 * One block per VAT rate, holding the TTC amount (MDT-215) and the rate itself (MDT-224). Dolibarr only
+	 * records a payment as a single TTC amount, so it is spread over the VAT rates proportionally to their
+	 * TTC weight; rounding differences go to the largest block, so the blocks always sum up to the amount.
 	 *
 	 * @param  Facture|FactureFournisseur $object       Invoice the payment belongs to
 	 * @param  array{amount?:float,breakdown?:array<array{vatrate:float,amount:float}>}  $paymentData  Cashed amount (TTC, company currency) and/or a ready-made breakdown. Defaults to the sum of the payments of the invoice.

--- a/einvoicing/class/utils/CtcFrPdfMerger.class.php
+++ b/einvoicing/class/utils/CtcFrPdfMerger.class.php
@@ -30,18 +30,10 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 /**
  * ZugferdDocumentPdfMerger that tolerates the EXTENDED-CTC-FR guideline.
  *
- * The parent class embeds the XML into the PDF and writes the Factur-X XMP block. To do so it needs
- * three parameters — the attachment filename, the XMP conformance level and the XMP version — which
- * it looks up by matching the guideline URN found in the XML against ZugferdProfiles::PROFILEDEF.
- * That table has no entry for `urn:cen.eu:en16931:2017#conformant#urn.cpro.gouv.fr:1p0:extended-ctc-fr`,
- * so a CTC-FR document makes it throw ZugferdUnknownProfileException and no Factur-X file is produced.
- *
- * EXTENDED-CTC-FR is a conformant extension built on top of the Factur-X EXTENDED profile, and the
- * Factur-X XMP `ConformanceLevel` has no CTC-FR value of its own, so the EXTENDED parameters are the
- * ones to use: attachment `factur-x.xml`, conformance level `EXTENDED`, version `1.0`.
- *
- * The lookup is only bypassed when the parent fails, so every profile the library does know keeps its
- * own parameters, and the day horstoeko/zugferd learns about CTC-FR this class becomes a no-op.
+ * ZugferdProfiles::PROFILEDEF has no entry for the CTC-FR guideline URN, so the parent throws
+ * ZugferdUnknownProfileException and embeds nothing. CTC-FR is a conformant extension of the
+ * Factur-X EXTENDED profile, so the EXTENDED parameters apply. The lookup is only bypassed when the
+ * parent fails, so every profile the library knows keeps its own parameters.
  */
 class CtcFrPdfMerger extends ZugferdDocumentPdfMerger
 {

--- a/einvoicing/class/utils/En16931Validator.class.php
+++ b/einvoicing/class/utils/En16931Validator.class.php
@@ -255,15 +255,9 @@ class En16931Validator
 		}
 
 		// ---------------------------------------------------------------
-		// CTC-FR SIREN format, as published in the FNFE "BR-FR-Flux2-Schematron-CII" V1.4.0:
-		//  - BR-FR-10/BT-30 targets the seller SIREN,
-		//  - BR-FR-32/LEGALID targets the legal identifier (scheme 0002) of ANY party,
-		//  - BR-FR-32/GLOBALID targets any party identifier with scheme 0002 or 0231.
-		// The platform reports each of them separately, so the same value can raise both a
-		// BR-FR-10 and a BR-FR-32 message: this mirrors the report the operator will get back.
-		// BR-FR-10 also makes the seller SIREN mandatory, which only holds for a French seller
-		// (the module also serves other countries) and an empty professional id is already
-		// refused when the invoice data is built, so only the format is checked here.
+		// CTC-FR SIREN format (FNFE "BR-FR-Flux2-Schematron-CII" V1.4.0): BR-FR-10/BT-30 for the seller
+		// SIREN, BR-FR-32/LEGALID for any legal identifier (0002), BR-FR-32/GLOBALID for any party id with
+		// scheme 0002 or 0231. Reported separately, as the platform does; only the format is checked here.
 		// ---------------------------------------------------------------
 		$sellerSirens = $xp->query('//ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:SpecifiedLegalOrganization/ram:ID[@schemeID="0002"]');
 		if ($sellerSirens !== false) {

--- a/einvoicing/class/utils/FacturxTcpdfMerger.class.php
+++ b/einvoicing/class/utils/FacturxTcpdfMerger.class.php
@@ -30,25 +30,10 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 /**
  * Factur-X merger built on TCPDF instead of FPDF.
  *
- * Why a second merger. CtcFrPdfMerger, like the whole horstoeko/zugferd writer, descends from
- * setasign/fpdi, which descends from the global class FPDF. Below Dolibarr 24, the core file
- * htdocs/includes/tcpdi/tcpdi.php declares its own "class FPDF extends TCPDF {}" shim, without a
- * class_exists() guard. The first declaration in the request wins and the other one can never be
- * loaded: a request that has already rendered a PDF (the invoice PDF produced at validation, right
- * before our hook runs) holds the core shim, and the zugferd writer then inherits from TCPDF, whose
- * internals it does not have (Call to undefined method ZugferdPdfWriter::_getpagesize()).
- *
- * The two classes cannot coexist in one PHP request, whatever the order, so the way out is not to
- * need FPDF at all. setasign/fpdi also ships a TCPDF flavour of its page importer, which is
- * namespaced and therefore immune to the shim, and TCPDF has native PDF/A-3 support. This class puts
- * the two together and produces the same structure as the v24 path: PDF/A-3 output intent, the XML
- * as an embedded file, the document level /AF array and the Factur-X XMP extension schema.
- *
- * What used to happen instead was a plain TCPDF FileAttachment annotation: the XML was carried, but
- * with no /AF and no PDF/A-3 output intent, which is not a Factur-X file - only a PDF with something
- * attached to it (issue #554).
- *
- * The public surface mirrors CtcFrPdfMerger so both branches of FacturXProtocol read the same.
+ * CtcFrPdfMerger descends from the global class FPDF, which cannot coexist with the unguarded
+ * "class FPDF extends TCPDF {}" shim of htdocs/includes/tcpdi/tcpdi.php below Dolibarr 24 (issue #554).
+ * This merger uses the namespaced TCPDF flavour of setasign/fpdi and produces the same structure as the
+ * v24 path. Its public surface mirrors CtcFrPdfMerger.
  */
 class FacturxTcpdfMerger extends TcpdfFpdi
 {
@@ -416,15 +401,10 @@ class FacturxTcpdfMerger extends TcpdfFpdi
 	/**
 	 * Graft the Factur-X schema entry into the PDF/A extension schema bag TCPDF writes.
 	 *
-	 * The properties added by setExtraXMPRDF() are external to PDF/A, so PDF/A-3 (ISO 19005-3, 6.6.2.3)
-	 * only accepts them when an extension schema declares them. The template shipped by
-	 * horstoeko/zugferd carries that declaration as a rdf:Description of its own, which is right for
-	 * the v24 path - horstoeko/zugferd writes the whole XMP block and writes none of its own - and
-	 * wrong here: TCPDF has already written a pdfaExtension:schemas for the pdf, xmpMM and pdfaid
-	 * schemas, on the same rdf:about="" subject. Two descriptions then repeat one property of one
-	 * subject, which the XMP specification forbids, and the packet stops parsing: a reader that gives
-	 * up there sees no pdfaid either, so the file is no longer even identified as PDF/A (veraPDF
-	 * 1.30.2 on the output of this class: clauses 6.6.2.1 and 6.6.4). One bag, one entry more.
+	 * PDF/A-3 (ISO 19005-3, 6.6.2.3) accepts the properties of setExtraXMPRDF() only when an extension
+	 * schema declares them. Adding it as its own rdf:Description, the way horstoeko/zugferd does,
+	 * would repeat a property of the rdf:about="" subject TCPDF already described, which XMP forbids:
+	 * the packet stops parsing and the file is no longer identified as PDF/A. One bag, one entry more.
 	 *
 	 * @param  string $s Body of the metadata object about to be written
 	 * @return string	 The same body, with the entry grafted and the stream length brought back in line
@@ -461,22 +441,10 @@ class FacturxTcpdfMerger extends TcpdfFpdi
 	/**
 	 * Complete the two objects TCPDF does not write the way Factur-X needs them.
 	 *
-	 * This is the one place where every PDF object passes before it reaches the buffer, and the object
-	 * offsets of the cross-reference table are recorded when an object starts, not when it ends, so
-	 * lengthening the body here shifts nothing.
-	 *
-	 * - the catalog gets the document level /AF array. TCPDF writes the /Names /EmbeddedFiles tree,
-	 *   which makes the file downloadable, but a Factur-X reader looks up /AF: without it the XML is
-	 *   an ordinary attachment and the document is not a Factur-X file.
-	 * - the file specification gets /AFRelationship /Data. TCPDF hardcodes /Source, and the v24 path
-	 *   emits /Data, so this keeps the two outputs comparable.
-	 * - the metadata stream gets the Factur-X entry grafted into its extension schema bag, see
-	 *   graftFacturxSchemaEntry().
-	 * - the embedded file stream gets its /Filter back. In PDF/A-3 mode TCPDF overwrites the filter
-	 *   entry with the /Subtype of the attachment instead of adding it, so a compressed attachment is
-	 *   written deflated and declared as plain: readers then hand over binary noise instead of the
-	 *   XML. TCPDF never meets the case because it also refuses to compress in PDF/A mode, which we
-	 *   turn back on.
+	 * Safe here because the cross-reference offsets are recorded when an object starts, not when it ends.
+	 * The catalog gets the document level /AF, the file specification /AFRelationship /Data instead of
+	 * /Source, the metadata stream the Factur-X entry, and the embedded file its /Filter back, which
+	 * TCPDF overwrites with the /Subtype and so declares a deflated attachment as plain.
 	 *
 	 * @param  string $s Object body about to be written
 	 * @return void

--- a/einvoicing/class/utils/SupplierInvoiceHelper.class.php
+++ b/einvoicing/class/utils/SupplierInvoiceHelper.class.php
@@ -419,12 +419,9 @@ class SupplierInvoiceHelper
 		$db->free($resql);
 
 		if ($num > 1) {
-			// Several e-invoicing documents for the same supplier invoice is a data integrity problem that
-			// needs a manual fix in database: the same invoice may hold diverging statuses coming from two
-			// access points. The answer to "is this an e-invoice" is still yes, so this predicate says yes
-			// and reports the duplicate. Throwing from here would not help: run_triggers() calls runTrigger()
-			// without a try/catch, so the exception used to surface as an uncaught PHP fatal instead of the
-			// message the user needs. Refusing the operation belongs to the caller.
+			// Several e-invoicing documents for one supplier invoice is a data integrity problem needing a
+			// manual fix: the invoice may hold diverging statuses from two access points. The predicate still
+			// answers yes and reports it; run_triggers() has no try/catch, so throwing here would be fatal.
 			$duplicate = true;
 			dol_syslog(__METHOD__ . ' duplicate entry in einvoicing_document for supplier invoice with id ' . $supplierInvoiceId, LOG_ERR);
 		}
@@ -497,18 +494,9 @@ class SupplierInvoiceHelper
 	/**
 	 * Tell whether a received supplier invoice is a credit note correcting an invoice we refused.
 	 *
-	 * Refusing a received invoice cancels it: it owes nothing any more, and the vendor answers by
-	 * issuing the credit note that closes the matter on its side. Accepting that credit note would
-	 * acknowledge the reversal of a debt that never entered our accounts, and would leave the exchange
-	 * saying two contradictory things about the same operation. The credit note follows its invoice:
-	 * refused (issue #594).
-	 *
-	 * Only credit notes. A replacement invoice (BT-3 = 384) also references the document it corrects,
-	 * and there the answer is the opposite one: it is the corrected invoice the vendor sends after a
-	 * refusal, which is exactly what one has to be able to accept.
-	 *
-	 * The lookup is a single query on the invoice rather than a fetch: this runs on every display of a
-	 * received supplier invoice card, and all it needs is the type and the reference to the source.
+	 * Refusing a received invoice cancels it, so the credit note the vendor issues to close the matter
+	 * follows it and is refused too (issue #594). Only credit notes: a replacement invoice (BT-3 = 384)
+	 * also references the document it corrects, and that one is exactly what has to remain acceptable.
 	 *
 	 * @param	int		$supplierInvoiceId	Id of the received supplier invoice
 	 * @return	int							Id of the refused source invoice, 0 when the rule does not apply
@@ -552,20 +540,10 @@ class SupplierInvoiceHelper
 	/**
 	 * Close the supplier invoice that a newly validated replacement invoice replaces.
 	 *
-	 * Dolibarr does this on the customer side - Facture::validate() cancels the replaced invoice with
-	 * the close code "replaced" - but FactureFournisseur::validate() does not, so a replaced supplier
-	 * invoice stayed validated, with nothing saying it had been superseded and nothing stopping it
-	 * from being paid a second time (issue #549).
-	 *
-	 * Scope. Only the invoices this module is responsible for are touched, i.e. those exchanged
-	 * through the platform: either the replacement or the invoice it replaces has to be an e-invoice.
-	 * A replacement recorded by hand between two ordinary supplier invoices is left to the core.
-	 *
-	 * Three states are deliberately left alone:
-	 * - a paid replaced invoice, because abandoning it would contradict the payment already recorded;
-	 * - a draft one, which cannot be paid nor transferred to accountancy anyway, and which validating
-	 *   just to cancel would give a reference it never earned;
-	 * - one already closed by this same rule, so the method is idempotent.
+	 * Facture::validate() does it on the customer side, FactureFournisseur::validate() does not, so a
+	 * replaced supplier invoice stayed validated and payable a second time (issue #549). Only invoices
+	 * exchanged through the platform are touched. Left alone: a paid replaced invoice, a draft one, and
+	 * one already closed by this same rule, so the method is idempotent.
 	 *
 	 * @param	FactureFournisseur	$replacement	Replacement invoice that has just been validated
 	 * @param	User				$user			User validating it
@@ -618,19 +596,10 @@ class SupplierInvoiceHelper
 	/**
 	 * Tell whether validating this supplier invoice has to answer its vendor with "Approved" (fr:205).
 	 *
-	 * Validating a received invoice in Dolibarr is the act of accepting it - it leaves the draft state to
-	 * enter the accounts and become payable - so it is what the buyer answers 205 for. Four things can
-	 * make the answer no:
-	 *
 	 *   - EINVOICING_SEND_APPROVED_ON_VALIDATION, for an instance where validating an invoice
 	 *     mean approving it. The status stays available by hand from the invoice card.
-	 *   - EINVOICING_DISABLE_SYNC_DOLI_TO_AP, which switches off everything this module sends.
-	 *   - an invoice that never came from the platform: its vendor is not waiting for any status.
-	 *   - a lifecycle already closed by a 205 or a 210 sent earlier: neither is repeated, and a refusal
-	 *     is not silently turned into an approval by a later validation. Same rule as the card, which
-	 *     stops offering the buttons once one of the two has been sent and confirmed.
-	 *   - a credit note correcting an invoice we refused: it credits an invoice that owes nothing, so
-	 *     validating it in the accounts must not answer its vendor that we accept it (issue #594).
+	 *   - the answer is no with EINVOICING_DISABLE_SYNC_DOLI_TO_AP set, on an invoice that never came from
+	 *     the platform, when a 205 or a 210 was already sent, or on a credit note of a refused one (#594).
 	 *
 	 * @param	EInvoicing	$einvoicing		Module object, for the lifecycle message lookup
 	 * @param	int			$supplierInvoiceId	Id of the supplier invoice being validated
@@ -706,19 +675,10 @@ class SupplierInvoiceHelper
 	/**
 	 * Find the supplier invoice of a given supplier whose ref_supplier is the given reference.
 	 *
-	 * The default is an exact match, which is the only safe rule while the quality of the incoming
-	 * data is unknown: a wrong match on a duplicate check silently drops an invoice that is then
-	 * never imported, and a wrong match on a referenced document links the new invoice to the wrong
-	 * one. With the option below off, this is exactly the query the callers used to run inline.
-	 *
-	 * The hidden option EINVOICING_TOLERANT_SUPPLIER_REF_MATCH adds a fallback, tried only when the
-	 * exact match found nothing. It accepts a ref_supplier that was typed manually with extra text
-	 * around the reference, or with stray whitespace inside it, e.g.
-	 * "PLTHDDD5OAAABBB - TEST-GROUP-2026-07-06-19407 - EVENEMENT 30/06/2026 A PARIS" for a document
-	 * whose reference in the XML is only "TEST-GROUP-2026-07-06-19407". That fallback stays narrow:
-	 * a reference shorter than EINVOICING_TOLERANT_SUPPLIER_REF_MIN_LENGTH (8) or purely numeric is
-	 * never searched for as a substring, the substring must be delimited so that "FA202610" does not
-	 * match "FA2026100", and an ambiguity is reported instead of guessed.
+	 * Exact match by default: a wrong match silently drops an invoice or links it to the wrong document.
+	 * EINVOICING_TOLERANT_SUPPLIER_REF_MATCH adds a narrow fallback, tried only when the exact match found
+	 * nothing: a short or purely numeric reference is never searched as a substring, the substring must be
+	 * delimited, and an ambiguity is reported rather than guessed.
 	 *
 	 * @param	string|null	$ref		Reference to look for (ExchangedDocument/ID or IssuerAssignedID of the XML)
 	 * @param	int			$socId		Id of the supplier thirdparty
@@ -844,11 +804,9 @@ class SupplierInvoiceHelper
 	/**
 	 * Tell whether a ref_supplier embeds a reference as a delimited substring.
 	 *
-	 * Both values are compared without their whitespace, so that a ref_supplier typed as
-	 * "FA 2026 10" matches the reference "FA202610". The reference must be bounded on both sides by
-	 * a non alphanumeric character, by a removed gap or by an edge of the string, so that "FA202610"
-	 * matches "PAY123 - FA202610 - dinner" but not "FA2026100". Comparison is case insensitive, as
-	 * the SQL prefilter of findIdByRef() is under the usual collations.
+	 * Both values are compared without their whitespace, so "FA 2026 10" matches "FA202610". The reference
+	 * must be bounded by a non alphanumeric character, a removed gap or an edge, so that "FA202610" matches
+	 * "PAY123 - FA202610 - dinner" but not "FA2026100". Case insensitive, like the SQL prefilter.
 	 *
 	 * @param	string|null	$refSupplier	ref_supplier value read from database
 	 * @param	string|null	$ref			Reference looked for

--- a/einvoicing/class/utils/SupportExport.class.php
+++ b/einvoicing/class/utils/SupportExport.class.php
@@ -32,13 +32,9 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
  * Build a support archive out of a selection of flows (llx_einvoicing_document) or of API calls
  * (llx_einvoicing_call).
  *
- * Diagnosing a refusal today means walking the user through four screens - the flow, the API call,
- * the setup constants, the versions - and having them turn an option on, because the two most
- * useful columns (llx_einvoicing_call.response and llx_einvoicing_document.response_for_debug) are
- * only written when EINVOICING_DEBUG_MODE is set. This class packs all of that into one file.
- *
- * It lives apart from the two list pages on purpose: page code cannot be exercised by PHPUnit, and
- * the redaction this class performs is exactly what has to be covered by a test.
+ * The two most useful columns (llx_einvoicing_call.response and llx_einvoicing_document.response_for_debug)
+ * are only written when EINVOICING_DEBUG_MODE is set. This packs the flow, the API call, the setup
+ * constants and the versions into one file, apart from the list pages so PHPUnit can cover the redaction.
  */
 class SupportExport
 {
@@ -182,14 +178,9 @@ class SupportExport
 	/**
 	 * Send the archive to the browser, then remove it from the server.
 	 *
-	 * Handing the file over straight away rather than leaving it for the "generated documents" box
-	 * of the list is deliberate. That box downloads through document.php with the modulepart
-	 * massfilesarea_einvoicing, and dol_check_secure_access_document() grants that modulepart on
-	 * hasRight(<module>, 'lire') up to Dolibarr 21 (it moved to 'read' in 22): the module declares
-	 * 'read', like every module builder module, so the link would answer "access forbidden" on the
-	 * whole lower half of the supported range. Deleting the file afterwards also keeps archives
-	 * full of invoice XML - names, addresses, contact details - from piling up in the temporary
-	 * area of the instance.
+	 * Not left in the "generated documents" box: dol_check_secure_access_document() grants the modulepart
+	 * massfilesarea_einvoicing on hasRight(<module>, 'lire') up to Dolibarr 21 and on 'read' from 22,
+	 * while the module declares 'read', so that link is forbidden on 18 to 21.
 	 *
 	 * Headers are sent here, so the caller must have written nothing yet and must exit right after.
 	 *
@@ -248,9 +239,8 @@ class SupportExport
 	/**
 	 * The EINVOICING_* constants of the current entity, secrets replaced by whether they are set.
 	 *
-	 * Read from $conf->global rather than from llx_const: that is the very object the module reads
-	 * its options from, so the manifest shows what the code saw, entity resolution and decryption
-	 * (dolDecrypt) included - which is also why the values have to be filtered here.
+	 * Read from $conf->global rather than from llx_const: the manifest then shows what the code saw,
+	 * entity resolution and decryption (dolDecrypt) included - which is why the values are filtered here.
 	 *
 	 * @return array<string,string> Constant name => value or placeholder, sorted by name
 	 * @phan-suppress PhanPluginMoreSpecificActualReturnType
@@ -379,11 +369,10 @@ class SupportExport
 	/**
 	 * Keep, of the posted selection, the rows the current entity may read.
 	 *
-	 * The filter has to be a query of its own: fetch() answers on the rowid alone, and the entity
-	 * column never even reaches the object, because CommonObject::getFieldList() leaves it out of
-	 * the SELECT it builds (checked on Dolibarr 18 and 24). So an export driven by ids posted in a
-	 * form is filtered here, on getEntity(), exactly the way the two list pages filter their own
-	 * query. Anything dropped is counted as skipped, and the manifest says so.
+	 * The filter has to be a query of its own: fetch() answers on the rowid alone and the entity column
+	 * never reaches the object, CommonObject::getFieldList() leaving it out of the SELECT it builds
+	 * (Dolibarr 18 to 24). So ids posted in a form are filtered here, on getEntity(), the way the list
+	 * pages filter their own query. Anything dropped is counted as skipped in the manifest.
 	 *
 	 * @param	Document|Call	$object		An instance of the class being exported, for its table
 	 * @param	int[]			$ids		Rowids as they were posted

--- a/einvoicing/compat/functions.lib.php
+++ b/einvoicing/compat/functions.lib.php
@@ -47,14 +47,9 @@ if (!function_exists('GETPOSTDATE')) {
 	 *  Return a timestamp built from the year, month, day (and optionally hour, minute, second) fields
 	 *  posted by a Dolibarr date selector (Form::selectDate()).
 	 *
-	 *  Copy of the function added to htdocs/core/lib/functions.lib.php in Dolibarr 18, kept identical so
-	 *  a date read on 17 is the same timestamp it would be anywhere else. GETPOSTINT() and dol_mktime(),
-	 *  the two helpers it calls, are both already there on 17.
-	 *
-	 *  The 18 implementation is the one to copy, not a later one: it reads the 'hour', 'min' and 'sec'
-	 *  fields, which are the names Form::selectDate() posts on 17. Dolibarr 19, 20 and 21 read 'minute'
-	 *  and 'second' there instead, names their own selector does not post; 22 came back to 'min'/'sec'
-	 *  and added a fourth argument this module does not use.
+	 *  Copy of the Dolibarr 18 implementation, not a later one: it reads the 'hour', 'min' and 'sec'
+	 *  fields, the names Form::selectDate() posts. Dolibarr 19 to 21 read 'minute' and 'second' instead,
+	 *  names their own selector does not post.
 	 *
 	 *  @param	string	$prefix		Prefix used to build the date selector
 	 *  @param	string	$hourTime	'getpost' to read the hour, minute and second from the request,
@@ -126,11 +121,9 @@ if (!function_exists('dolPrintHTMLForAttribute')) {
 	 * With dolPrintHTMLForAttribute(), the content is HTML encode, even if it is already HTML content.
 	 *
 	 * Copy of the function added to htdocs/core/lib/functions.lib.php in Dolibarr 19. It calls
-	 * dol_escape_htmltag() with six arguments, and that function only takes five on 17: PHP passes the
-	 * extra one to a userland function without complaining, so the sixth ($cleanalsojavascript) is
-	 * simply not read there. It changes nothing for this use - the fifth argument is 0, which already
-	 * escapes the whole string - and the output on 17 and 18 was checked to be the one the core returns
-	 * on 19 for plain text, accents, html tags, quotes, a javascript: link and an onerror attribute.
+	 * dol_escape_htmltag() with six arguments, and that function only takes five on 17, which PHP
+	 * accepts: the sixth ($cleanalsojavascript) is simply not read there, and changes nothing for this
+	 * use since the fifth argument is 0 and already escapes the whole string.
 	 *
 	 * @param	string		$s						String to print
 	 * @param	int			$escapeonlyhtmltags		1=Escape only html tags, not the special chars like accents.

--- a/einvoicing/compat/societe.lib.php
+++ b/einvoicing/compat/societe.lib.php
@@ -30,20 +30,10 @@ if (!function_exists('calculateVATNumberFromProperties')) {
 	/**
 	 *  Calculate VAT intracommunity number for a thirdparty if missing, from the professional ID.
 	 *
-	 *  Copy of Societe::calculateVATNumberFromProperties(), added to
-	 *  htdocs/societe/class/societe.class.php in Dolibarr 24, kept identical so a VAT number built on
-	 *  18 to 23 is the number the core would build. Measured: the method is absent from 18.0.10,
-	 *  19.0.4, 20.0.4, 21.0.4, 22.0.5 and 23.0.4, and present in 24.0.1.
-	 *
-	 *  The core exposes it as a *method* of Societe, and a method cannot be added to a core class from
-	 *  outside without patching the core, which a module must never do. So the backport takes the only
-	 *  shape a shim can take here: a free function carrying the name and the signature of the core
-	 *  symbol, guarded like every other shim of this directory. The module never reaches it when the
-	 *  real method is there - EInvoicing::thirdpartyCalcVATIntra() tests the method first, and calls
-	 *  this only as a fallback.
-	 *
-	 *  Note that the core method takes the thirdparty as an argument rather than working on $this,
-	 *  which is what makes it transposable to a function without changing what it does.
+	 *  Copy of Societe::calculateVATNumberFromProperties(), added to the core in Dolibarr 24, kept
+	 *  identical so a VAT number built on 18 to 23 is the one the core would build. Shimmed as a free
+	 *  function because a method cannot be added to a core class from outside;
+	 *  EInvoicing::thirdpartyCalcVATIntra() tests the real method first and falls back here.
 	 *
 	 *  @param	mixed	$thirdparty		A thirdparty object
 	 *  @return	string					A VAT number, '' if none can be built

--- a/einvoicing/core/modules/modEInvoicing.class.php
+++ b/einvoicing/core/modules/modEInvoicing.class.php
@@ -118,11 +118,8 @@ class modEInvoicing extends DolibarrModules
 			),
 			// Set here all hooks context managed by module. To find available hook context, make a "grep -r '>initHooks(' *" on source code. You can also set hook context to 'all'
 			/* BEGIN MODULEBUILDER HOOKSCONTEXTS */
-			// The module reacts on the invoice, supplier invoice, thirdparty and product cards, on the lists
-			// that carry its columns, on the document generation, and on the REST API (thirdparty merge and
-			// invoice set back to draft go through hooks there too). Contexts are listed one by one on purpose:
-			// 'all' loads this class into every HookManager of the request, including the ones other modules
-			// build for their own contexts.
+			// Contexts are listed one by one on purpose: 'all' loads this class into every HookManager of the
+			// request, including the ones other modules build for their own contexts.
 			'hooks' => [
 				'invoicecard', 'invoicesuppliercard', 'thirdpartycard', 'thirdpartycomm', 'productcard',
 				'invoicelist', 'supplierinvoicelist', 'thirdpartylist', 'societelist', 'productlist',
@@ -600,10 +597,9 @@ class modEInvoicing extends DolibarrModules
 
 		// Chorus fields
 		// TODO : Remove Chorus extrafields and move them to einvoicing_extlinks table
-		// The text fields are declared printable = 2, "print it only when it holds something", and not 1,
-		// "always print it": CommonDocGenerator::getExtrafieldsInHtml() reads the 'enabled' condition
-		// before printing on 18, 22, 23 and 24, but not on 17, 19, 20 and 21, where a field of a feature
-		// nobody turned on still reached the PDF of every invoice and every order (issue #614).
+		// The text fields are declared printable = 2 ("print only when filled") and not 1: on cores 19, 20
+		// and 21 getExtrafieldsInHtml() ignores the 'enabled' condition, so a field of a feature nobody
+		// turned on still reached the PDF of every invoice and every order (issue #614).
 		$result = $extrafields->addExtraField('d4d_separator', $langs->trans('ChorusSeparator'), 'separate', 95024, '', 'facture', 0, 1, '', $param, 1, '', '1', '0', '', '', 'einvoicing@einvoicing', 'getDolGlobalInt("EINVOICING_USE_CHORUS")');
 		$result = $extrafields->addExtraField('d4d_service_code', $langs->trans('ChorusServiceCode'), 'varchar', 95026, '100', 'facture', 0, 0, '', '', 1, '', '1', '0', '', '', 'einvoicing@einvoicing', 'getDolGlobalInt("EINVOICING_USE_CHORUS")', 0, 2);
 		$result = $extrafields->addExtraField('d4d_contract_number', $langs->trans('ChorusContractNumber'), 'varchar', 95028, '50', 'facture', 0, 0, '', '', 1, '', '1', '0', '', '', 'einvoicing@einvoicing', 'getDolGlobalInt("EINVOICING_USE_CHORUS")', 0, 2);
@@ -631,12 +627,10 @@ class modEInvoicing extends DolibarrModules
 		);
 
 		// Update extrafield par rapport au module openDSI, il faut pouvoir éditer le champ ChorusId
-		// The $param below is '' and not array(): the empty array is only tolerated from Dolibarr 18,
-		// which added an "elseif (is_array($param))" branch to ExtraFields::update_label(). On 17 an
-		// empty array falls through to strlen($param) and kills the whole module installation on PHP 8.
-		// Both forms store exactly the same thing - an empty parameter string - on every version, and
-		// the parameter was itself declared as '' up to 19 before becoming array() in 20, which is the
-		// signature the phan stub carries and the reason for the suppression.
+		// The $param below is '' and not array(): before Dolibarr 18, ExtraFields::update_label() lets an
+		// empty array fall through to strlen($param), which kills the module installation on PHP 8. Both
+		// forms store the same empty string, and the parameter was declared '' up to 19, hence the phan
+		// annotation below.
 		$result = $extrafields->update(
 			'd4d_chorus_id', //$attrname	// @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
 			$langs->trans('ChorusId'), //$label

--- a/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
+++ b/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
@@ -96,11 +96,10 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 			}
 
 			// Default product for import.
-			// The combo posts '-1' when the empty entry is picked, and '' when the ajax search input is
-			// cleared: both mean "no default product any more", so the routing has to be deleted. Two
-			// saves must leave the current value untouched: one that does not carry the field at all
-			// (thirdparty updated from the API, a mass action, an import...), and one whose field could
-			// not show the current value, which routing_product_id_shown tells apart.
+			// The combo posts '-1' for the empty entry and '' for a cleared ajax input: both mean "no
+			// default any more" and delete the routing. A save that does not carry the field at all (API,
+			// mass action, import) or whose field could not show the current value (routing_product_id_shown)
+			// must leave it untouched.
 			if (GETPOSTISSET('routing_product_id')) {
 				$routingProductId = GETPOST('routing_product_id', 'aZ09');
 				if ($routingProductId === '-1' || $routingProductId === '0') {
@@ -402,20 +401,11 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 					return -1;
 				}
 
-				// A draft is a local booking, not the electronic invoice: it holds no accounting entry and
-				// says nothing to the platform, so removing it repudiates nothing. It is also the only way
-				// out of an import that landed on the wrong third party, since the vendor of an existing
-				// supplier invoice cannot be changed. Re-read the invoice: the object handed to a trigger
-				// is not always freshly fetched. It is re-read through the core class rather than by a
-				// query of our own, so the fk_statut column name and its mapping stay the business of
-				// Dolibarr. The property to read is ->status: fetch() selects "fk_statut as status" and
-				// fills ->status on every supported version (18 to 24), while ->statut is only kept as a
-				// backward compatibility alias, marked @deprecated since 19.
-				// A supplier invoice that cannot be re-read leaves the status at its initial -1, which is
-				// no draft, so the deletion is refused - exactly what the query it replaces did when it
-				// returned no row.
-				// The incoming flow itself is kept, detached from the invoice that is about to disappear,
-				// so the document stays in the flow list and can be imported again.
+				// A draft holds no accounting entry and says nothing to the platform, so removing it
+				// repudiates nothing, and it is the only way out of an import booked on the wrong vendor.
+				// Re-read through the core class: the object handed to a trigger is not always fresh, and
+				// ->status is the property to read (->statut is a @deprecated alias since 19). An invoice
+				// that cannot be re-read keeps status -1, which is no draft, so the deletion is refused.
 				$status = -1;
 				$invoicetodelete = new FactureFournisseur($this->db);
 				if ($invoicetodelete->fetch((int) $object->id) > 0) {
@@ -446,14 +436,10 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 			'@phan-var-force Document $object';
 			$duplicate = false;
 
-			// A flow does not always carry a supplier invoice id: a lifecycle message (flow_type
-			// 'SupplierInvoiceLC') sets fk_element_type without ever resolving an invoice, an import that
-			// failed never booked one, and deleting the local invoice detaches the flow it came from
-			// (see detachEInvoicingRecordsOfSupplierInvoice() below, which sets the column to 0). The
-			// column is nullable, so the value read here is null in the first two cases: passing it on
-			// used to raise an uncaught TypeError on the int parameter of isEInvoice() and end the mass
-			// deletion on a PHP fatal. Such a flow is linked to nothing, so there is nothing to protect
-			// and the deletion is allowed - as it already was for the detached (0) case.
+			// A flow does not always carry a supplier invoice id: a lifecycle message never resolves one,
+			// a failed import never booked one, and the column is nullable. Passing null on raises a
+			// TypeError on the int parameter of isEInvoice() and ends a mass deletion on a PHP fatal.
+			// Such a flow is linked to nothing, so the deletion is allowed, as for the detached (0) case.
 			$linkedsupplierinvoiceid = (int) $object->fk_element_id;
 
 			if ($object->fk_element_type == 'invoice_supplier' && $linkedsupplierinvoiceid > 0 && SupplierInvoiceHelper::isEInvoice($linkedsupplierinvoiceid, true, $duplicate)) {
@@ -491,10 +477,8 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 	 * Report a cash-in (status 212 "Encaissee") of a customer invoice to the Approved Platform.
 	 *
 	 * Errors are never escalated to $this->errors / a negative return: that would roll back the payment
-	 * Dolibarr just recorded (Paiement::create() aborts on a trigger failure) and a platform notification
-	 * failure must never undo a real payment. dol_syslog is the only channel that reliably surfaces the
-	 * problem outside an interactive session (cron, API, bank import, ...), since setEventMessage() only
-	 * shows up on the next HTML page render.
+	 * Dolibarr just recorded (Paiement::create() aborts on a trigger failure). dol_syslog is the only
+	 * channel that surfaces the problem outside an interactive session (cron, API, bank import, ...).
 	 *
 	 * @param  Facture   $invoice Invoice that has been cashed in
 	 * @param  float     $amount  Amount cashed in (TTC) by this payment, reported as the MEN blocks of the CDAR
@@ -520,14 +504,10 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 			return;
 		}
 
-		// A deposit the platform refused is not a deposit. 'transmitted' is true of every status but the
-		// local ones, and STATUS_ERROR is among those it lets through: it is exactly what an
-		// acknowledgement "Error" leaves behind, see getDolibarrStatusCodeFromPdpLabel(). The platform
-		// holds no invoice to attach a cash-in to, so the status would be refused; and reporting it as
-		// sent would be worse than not sending it, since the reform expects that cash-in once the
-		// invoice is deposited. The invoice has to be corrected and re-sent first, which is what the
-		// "Send" button of the card offers on that very status, and the cash-in reported by hand
-		// afterwards.
+		// A deposit the platform refused is not a deposit. 'transmitted' lets STATUS_ERROR through, which
+		// is what an acknowledgement "Error" leaves behind (see getDolibarrStatusCodeFromPdpLabel()).
+		// The platform holds no invoice to attach a cash-in to: it must be corrected, re-sent, and the
+		// cash-in reported by hand afterwards.
 		if ((int) $currentStatusDetails['code'] === EInvoicing::STATUS_ERROR) {
 			dol_syslog(__METHOD__ . ' Cash-in not reported for invoice id=' . $invoice->id . ': the platform refused its deposit (status ' . EInvoicing::STATUS_ERROR . '), there is nothing to report the payment on', LOG_WARNING, 0, '_einvoicing');
 			setEventMessage($langs->trans("ModuleEInvoicingName") . ' : ' . $langs->trans('EInvoiceCashInNotReportedDepositRefused', $invoice->ref), 'warnings');
@@ -590,13 +570,9 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 	/**
 	 * Detach the e-invoicing records of a supplier invoice that is about to be deleted.
 	 *
-	 * The incoming flow is not the Dolibarr invoice: it belongs to the platform and keeps its
-	 * lifecycle, so it is kept and only unlinked (fk_element_id emptied). The extlinks row, on the
-	 * other hand, describes the local element itself and is removed with it - leaving it behind
-	 * would make the flow list show a link to an invoice that no longer exists.
-	 *
-	 * Runs inside the transaction opened by FactureFournisseur::delete(), which rolls back when
-	 * this trigger fails.
+	 * The incoming flow belongs to the platform and keeps its lifecycle, so it is only unlinked
+	 * (fk_element_id emptied). The extlinks row describes the local element and is removed with it.
+	 * Runs inside the transaction opened by FactureFournisseur::delete(), which rolls back on failure.
 	 *
 	 * @param	int		$supplierInvoiceId	Id of the supplier invoice being deleted
 	 * @return	int							Return integer <0 if KO, >0 if OK

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -136,11 +136,8 @@ $myUri             = $einvoicing->getSellerCommunicationURI(0);
 $mySchemeUri       = $this->getIEC6523Code($mysoc->country_code, 2);
 
 // Buyer party resolution.
-// The billing contact of the invoice (external BILLING contact) always describes the buyer contact
-// group (BG-9): it is the point of contact the customer declared for its invoices, and nothing else
-// fills that group. Whether that contact also *replaces* the buyer party itself is another matter,
-// and stays opt-in behind EINVOICING_USE_BILLING_CONTACT_AS_BUYER (e.g. invoice addressed to the head
-// office / "siège social"):
+// The external BILLING contact always fills the buyer contact group (BG-9). Whether it also *replaces*
+// the buyer party stays opt-in behind EINVOICING_USE_BILLING_CONTACT_AS_BUYER (head office case):
 //   - Case B: the contact belongs to a different thirdparty (distinct legal entity) -> rebuild the
 //     whole buyer (name, address, SIREN/SIRET, VAT, routing) from that thirdparty.
 //   - Case A: same thirdparty -> keep its SIREN/VAT/routing, only override name/address.
@@ -261,18 +258,11 @@ if (!empty($newlang)) {
 }
 $outputlangs->load("einvoicing@einvoicing");
 
-// Buyer routing code: the Chorus Pro "code service exécutant", which BR-FR-CPRO-11 and BR-FR-CPRO-13
-// of XP Z12-012 read as a private identifier of the buyer (BT-46 under scheme 0224). Without it, a
-// B2G invoice to a buyer whose directory record demands a service code is rejected (issue #678).
-//
-// It is a SECOND ram:GlobalID on the buyer party, and only the EXTENDED profiles accept one: the
-// Factur-X EN16931 Schematron caps that element at a single occurrence (FX-SCH-A-000164,
-// "Element 'ram:GlobalID' may occur at maximum 1 times"), so emitting it below EXTENDED makes the
-// document invalid - measured on the FNFE validator, which answers "valid, 0 failure" on the very
-// same invoice built as EXTENDED-CTC-FR. The Annexe B examples say the same thing: the routing code
-// appears in the EXTENDED and EXTENDED-CTC-FR files of an invoice and not in its EN16931 twin.
-// Below EXTENDED the code is simply not sent, and the user is told why rather than handed a document
-// an access point refuses.
+// Buyer routing code: the Chorus Pro "code service exécutant", read by BR-FR-CPRO-11 and BR-FR-CPRO-13
+// of XP Z12-012 as a private identifier of the buyer (BT-46 under scheme 0224). Without it a B2G
+// invoice to a buyer whose directory record demands a service code is rejected (issue #678).
+// It is a SECOND ram:GlobalID on the buyer party, and the Factur-X EN16931 Schematron caps that element
+// at one occurrence (FX-SCH-A-000164): below EXTENDED the code is not sent and the user is told why.
 $buildProfile = $this->getBuildXmlProfile();
 $buyerRoutingCode = trim((string) ($object->array_options['options_d4d_service_code'] ?? ''));
 if ($buyerRoutingCode !== '' && $buyerParty->country_code != 'FR') {
@@ -294,11 +284,9 @@ if ($buyerRoutingCode !== '' && !$this->isExtendedProfile($buildProfile)) {
 }
 
 // Buyer reference (BT-10): a reference owned by the buyer, used to route the invoice inside its own
-// organisation (business unit, service reference, internal mailbox...). A core EN 16931 term with no
-// relation to the public sector, which no field of the module let a private issuer fill until now.
-// The Chorus Pro service code keeps feeding it when that dedicated property is empty: Annexe A of
-// XP Z12-012 documents BT-10 as the "Service Executant" of the public sector, so the historical
-// mapping is a documented usage of the term and is left untouched (issue #678).
+// organisation. The Chorus Pro service code keeps feeding it when the dedicated property is empty:
+// Annexe A of XP Z12-012 documents BT-10 as the "Service Executant" of the public sector, so that
+// mapping is a documented usage of the term (issue #678).
 $buyerReference = $einvoicing->getExtraFieldValue($object->id, $object->element, EInvoicing::EXTRAFIELD_BUYER_REFERENCE);
 if (trim((string) $buyerReference) === '') {
 	$buyerReference = $object->array_options['options_d4d_service_code'] ?? null;
@@ -605,12 +593,10 @@ foreach ($object->lines as $line) {
 	}
 	$line_unit_price_with_discount = price2num($line_unit_price_with_discount, getDolGlobalString('MAIN_APPLY_DISCOUNT_ON_UNIT_PRICE_THEN_ROUND_BEFORE_MULTIPLICATION_BY_QTY', 'MU'));
 
-	// The amounts of the line are asked to the very function that computed the invoice
-	// (calcul_price_total(), the one update_price() calls), instead of being computed a second time
-	// here: the document has to state the amount the invoice states, and a second implementation
-	// misses the accuracies and the options of the instance, silently, by a few cents (issue #505).
-	// They are then rounded to the two decimals EN 16931 allows on an amount, which is a no-op on an
-	// instance keeping the default currency accuracy.
+	// Ask the amounts to the very function that computed the invoice (calcul_price_total(), the one
+	// update_price() calls) rather than computing them again: a second implementation silently misses
+	// the accuracies and options of the instance by a few cents (issue #505). Round to the two decimals
+	// EN 16931 allows on an amount.
 	$localtaxes_array = array($line->localtax1_type, $line->localtax1_tx, $line->localtax2_type, $line->localtax2_tx);
 	$tmpcal = calcul_price_total($line->qty, $line->subprice, $line->remise_percent, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, 0, 'HT', $line->info_bits, $line->product_type, $mysoc, $localtaxes_array, $line_progress);
 
@@ -669,15 +655,10 @@ foreach ($object->lines as $line) {
 		'prodOriginCountry'         => null,
 
 		// Mandatory by Factur-X, EN 16931
-		// This is the unit price, excluding tax. The discount of the line is deliberately left out
-		// of it: it is stated as a line allowance (BG-27) further down, whose basis is this price
-		// times the quantity, which is the other way EN 16931 offers to write a discounted line and
-		// the one this module has always used. Stating $line_unit_price_with_discount here instead
-		// would need the TradeAllowanceCharge block of BT-148 / BT-147.
-		// The progress of a situation line, on the contrary, belongs to this price: without it the
-		// document states a price and a quantity whose product is not its own line amount (BT-131),
-		// and a receiver rebuilding the amounts from them - this module does exactly that when it
-		// imports - reads the whole line instead of the part that is invoiced (issue #672).
+		// Unit price excluding tax, discount left out: the line discount is stated as a line allowance
+		// (BG-27) further down, whose basis is this price times the quantity.
+		// The progress of a situation line belongs to this price: without it price times quantity is not
+		// the line amount (BT-131), and a receiver rebuilding the amounts reads the whole line (#672).
 		'netpriceamount'            => (float) ($line_progress != 100 ? price2num($line_unit_price * $line_progress / 100, 'MU') : $line_unit_price),		// BT-146
 		'netpricebasisquantity'     => null,
 		'netpricebasisquantityunitcode' => null,
@@ -738,18 +719,11 @@ foreach ($object->lines as $line) {
 	$numligne++;
 }
 
-// A situation invoice states, on each of its lines, the cumulative amount of the work done, and the
-// core deducts the situations already invoiced from the header of the invoice
-// (CommonObject::update_price(), block "Situations totals"): llx_facture.total_ttc holds the
-// instalment, which is what the customer owes and what the payment screen expects. The document has
-// to state the same amount, so what the previous situations already asked for is carried as a
-// document level allowance: the lines keep saying what has been done, BT-106 keeps summing them, and
-// BT-107 brings BT-109 (and the VAT breakdown with it) back onto the instalment (issue #674).
-// The amount deducted for a line is the one its predecessor recorded, read from the invoice that
-// carries it - not recomputed here, so the document deducts exactly what was invoiced before, cents
-// included.
-// With INVOICE_USE_SITUATION = 2 each invoice states its own share of the progress, the core deducts
-// nothing and the lines already hold the instalment: there is nothing to deduct.
+// A situation invoice states the cumulative work done on each line while the core deducts the previous
+// situations in the header (update_price(), "Situations totals"), so what they already asked for is
+// carried as a document level allowance: BT-107 brings BT-109 back onto the instalment (issue #674).
+// The amount deducted per line is the one its predecessor recorded, read back, not recomputed here.
+// With INVOICE_USE_SITUATION = 2 the lines already hold the instalment: there is nothing to deduct.
 if (!empty($object->situation_counter) && $object->situation_counter > 1
 	&& isset($object->type) && $object->type == $object::TYPE_SITUATION
 	&& getDolGlobalInt('INVOICE_USE_SITUATION') == 1) {
@@ -815,16 +789,11 @@ if (!empty($object->situation_counter) && $object->situation_counter > 1
 	}
 }
 
-// Rounding convention of the totals.
-// Dolibarr sums the amounts already rounded on each line ("total of round", the default), unless
-// MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND is set, in which case it rounds the sum instead ("round of
-// total"). update_price() then writes the difference back onto the last line of the VAT rate, so on
-// such an instance the invoice recorded, printed, booked and paid carries the second convention.
-// The loop above always applied the first one, so the document transmitted claimed a cent less (or
-// more) than the invoice it stands for, and nothing reported it: the document stays internally
-// consistent, and the tolerance BR-CO-17 allows absorbs the gap (issue #378).
-// Only the VAT is concerned: on a document priced without tax update_price() never adjusts the net
-// amount of a line, so the line net amounts (BT-131) and their sum (BT-106) are the same either way.
+// Rounding convention of the totals: Dolibarr sums the amounts already rounded on each line ("total of
+// round", the default), unless MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND rounds the sum instead. The loop
+// above always applies the first one, so follow the instance or the document claims a cent less than
+// the invoice it stands for (issue #378). Only the VAT is concerned: update_price() never adjusts the
+// net amount of a line, so BT-131 and BT-106 are the same either way.
 $roundTotalConstName = 'MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND';
 if (in_array($object->element, array('facture_fourn', 'invoice_supplier'))) {
 	$roundTotalConstName .= '_SUPPLIER';
@@ -1049,22 +1018,11 @@ if ($object->mode_reglement_code) {
 }
 
 
-// Delivery address (CII ShipToTradeParty / BG-15)
-// Resolve a deliver-to address and expose it so the CII builder can emit a dedicated deliver-to
-// party. Resolution priority:
-//   1) external "SHIPPING" contact attached to the invoice;
-//   2) fallback: delivery address carried by a linked shipment (expedition.fk_delivery_address).
+// Delivery address (CII ShipToTradeParty / BG-15): external "SHIPPING" contact, else a linked shipment.
 // buildShipToTradePartyBuilder function only emits the node when the resolved address
-// actually differs from the buyer (bill-to) address and carries a country code; otherwise it falls
-// back to the buyer party. Nothing resolved => keys stay unset => ship-to = buyer is preserved.
-//
-// A shipping contact is a person, and BT-70 is the name of a party: what the document has to name is
-// the company the delivery is made to. The core says the same, and says it in the shipping frame of
-// the invoice PDF - pdfBuildThirdpartyName() given a Contact returns the name of its thirdparty, and
-// pdf_build_address() reads the address of the contact when it carries one, else the address of the
-// company the contact belongs to (core/lib/pdf.lib.php). einvoicingShipToFromContact() below builds
-// BG-15 the same way, so the XML and the PDF of one invoice no longer name two different things
-// (issue #683).
+// actually differs from the buyer address and carries a country code; nothing resolved => ship-to = buyer.
+// A shipping contact is a person and BT-70 names a party, so BG-15 names its thirdparty like the PDF
+// does (pdfBuildThirdpartyName(), pdf_build_address(), issue #683).
 $shipAddress = null;
 
 if (method_exists($object, 'liste_contact')) {

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -145,12 +145,10 @@ function pdpShowWarning($einvoicing)
 		$ret .= '</div>';
 	}
 
-	// public/proxy_oauthcallback.php answers without authentication and hands the caller back to the
-	// address it supplied itself in redirect_uri; on the callback branch that address receives the
-	// access token and the refresh token in its query string. On a proxy instance, the domains listed
-	// in EINVOICING_SUPERPDPVIAPARTNER_ONLY_DOMAIN are the only thing separating a customer instance
-	// from anyone else on the internet, and an empty list is still accepted for one transition step
-	// (see einvoicingIsAllowedRedirectUrl). Say so loudly, on both setup pages, for as long as it is.
+	// In proxy mode public/proxy_oauthcallback.php answers without authentication and hands the access
+	// and refresh tokens to the redirect_uri the caller supplied, so the domains listed in
+	// EINVOICING_SUPERPDPVIAPARTNER_ONLY_DOMAIN are the only thing separating a customer instance from
+	// anyone else. An empty list is still accepted for one transition step, so warn on both setup pages.
 	if (getDolGlobalString('EINVOICING_SUPERPDP_VIAPARTNER') == 'proxy' && !getDolGlobalString('EINVOICING_SUPERPDPVIAPARTNER_ONLY_DOMAIN')) {
 		$ret .= '<div class="error">';
 		$ret .= img_warning().' <b>'.$langs->trans("ProxyRedirectDomainsNotSet").'</b>';
@@ -219,18 +217,10 @@ function thirdpartyidprof($object)
 /**
  * Remove every space of an identifier, whatever kind of space it is.
  *
- * French people write a long number in groups to read it back - SIREN "844 431 239", SIRET
- * "844 431 239 00020", VAT number "FR 43 844431239" - and a value copied from a web page or from a
- * PDF very often carries a non-breaking space (U+00A0), a thin space or a zero-width character
- * rather than the ordinary one. None of them belongs to the identifier, and a '/\s+/' pattern
- * written without the /u modifier sees none of them.
- *
- * This is the one and only place where the module strips those spaces, so the identifier it emits
- * (idprof(), the routing id sent to the platform) and the identifier it checks back
- * (EInvoicing::getSellerCommunicationURI() and the configuration pre-checks) are always cleaned the
- * same way. It lives here, in the module library, rather than in a class: idprof() and the provider
- * classes call it as a free function, and it needs no object to do its job. See the deprecated
- * EInvoicing::removeSpaces(), which now delegates here.
+ * A value copied from a web page or a PDF often carries a non-breaking (U+00A0), thin or zero-width
+ * space, which a '/\s+/' pattern written without the /u modifier does not see. Single place where the
+ * module strips them, so the identifier it emits and the one it checks back agree; the deprecated
+ * EInvoicing::removeSpaces() delegates here.
  *
  * @param  ?string $str					String to be cleaned. null is accepted and gives ''.
  * @param  ?string $original_encoding	Encoding of $str, null to detect it. The result is given back in that same encoding.
@@ -296,13 +286,8 @@ function removeAllSpaces($str, $original_encoding = null)
  * Return the full path of the directory where a module (or an object of a module) stores its files.
  * Path may depends on the entity if a multicompany module is enabled.
  *
- * Since Dolibarr 20.0.0 the core getMultidirOutput() takes the four arguments this module needs, so
- * the call is simply handed over to it and the module benefits from every later core fix. On
- * Dolibarr 18 and 19 the core function only accepts ($object, $module) and knows neither $forobject
- * nor $mode, hence the backported body kept below as a fallback.
- *
- * The version guard is placed here, and not at the four call sites, so that they keep a single entry
- * point and there is exactly one place to move (or drop) when the supported version floor rises.
+ * Core getMultidirOutput() takes the four arguments this module needs only since Dolibarr 20.0.0; on
+ * 18 and 19 it accepts ($object, $module) alone, hence the backported fallback body below.
  *
  * @param 	CommonObject|BlockedLog|null	$object 	Dolibarr common object.
  * @param 	string 							$module 	Override object element, for example to use 'mycompany' instead of 'societe'
@@ -642,16 +627,9 @@ if (!method_exists('Societe', 'findNearest')) {
 /**
  * Tell whether the seller reports the VAT on debits ("TVA d'apres les debits").
  *
- * That option makes the VAT of a service fall due when the invoice is issued instead of when it is
- * collected, and the seller who took it must carry the corresponding legal mention on its invoices.
- * The scheme itself is not a setting of this module: Dolibarr already holds it in the setup of the
- * Tax/VAT module (Home - Setup - Modules - Tax/VAT, "VAT mode"), where "TVA d'apres les debits" is
- * TAX_MODE 1, the one that puts both sell modes on 'invoice'. Conf::setValues() always populates the
- * two constants, defaulting to the French standard scheme.
- *
- * There is no option of this module to override it, deliberately: the same two constants are what the
- * VAT report of Dolibarr declares on (compta/tva/, through tax.lib.php), so an override would make the
- * document tell the buyer one regime while the seller declares its VAT under another.
+ * The scheme is not a setting of this module: Dolibarr holds it in the Tax/VAT module setup, where
+ * "TVA d'apres les debits" is TAX_MODE 1, the one that puts both sell modes on 'invoice'. Those same
+ * two constants are what the VAT report of Dolibarr declares on, hence no override here.
  *
  * @return bool		True when the invoices must carry the "VAT on debits" mention
  */
@@ -663,44 +641,10 @@ function einvoicingVatOnDebits()
 /**
  * VAT point date code (BT-8) the generated document has to declare.
  *
- * BT-8 tells the buyer when the VAT falls due, hence from when it may be deducted. BR-CL-06 restricts
- * it to a subset of UNTDID 2475 - 5 (invoice date), 29 (delivery date) and 72 (payment date) - and
- * BR-CO-03 makes it mutually exclusive with BT-7, the VAT point date itself. In CII the code lives in
- * the VAT breakdown (BG-23), which repeats per rate, but only one distinct value may appear in the
- * whole document (CII-SR-462): it is a document-level decision.
- *
- * What the French socle asks of it is narrower than the semantics of the codes, and it is what this
- * function follows. XP Z12-012 annexe A introduces BT-8 as the "champ permettant de specifier l'option
- * pour le paiement de la taxe d'apres les debits", reads its three values as "5 : date de la facture
- * (TVA sur DEBITS)", "29 : date de livraison (TVA sur DEBITS)" and "72 : date de paiement (TVA sur
- * ENCAISSEMENTS)", and carries two rules on it:
- *
- * @phpcs:ignore
- *   G1.43        "Le BT-8 ne sera obligatoire que si l'entreprise a opte pour la TVA sur les debits
- *                 et le specifie au moyen du code 5 (CII)"
- * @phpcs:ignore
- *   BR-FR-MAP-03 "BT-8 est obligatoire pour les factures de service des lors que l'assujetti Vendeur
- *                 a opte pour les debits"
- *
- * So 5 is not "this invoice is payable now", it is "I took the debits option", and a seller who did
- * not take it must not send it. That is why a goods invoice of a seller under the standard scheme
- * declares nothing: it has no option to signal, and its VAT falls due on a delivery the document
- * already dates. 72 is not mandatory anywhere, but it is true of an operation taxed on collection and
- * the annexe B examples carry it on every services invoice, so it is sent.
- *
- *   TAX_MODE 0, the French default   products on invoice, services on payment  -> 72 on a service line
- *   TAX_MODE 1, "d'apres les debits" everything on invoice                     -> 5
- *   TAX_MODE 2                       everything on payment                     -> 72
- *
- * 29 is never sent. It says the same thing as 5, BR-FR-MAP-29 states that "le PPF attend uniquement 5"
- * - a 29 having to be reported as 5 to the public portal - and Dolibarr has nothing to derive it from
- * anyway: its own setup reads the goods delivery as "OnDelivery (SupposedToBeInvoiceDate)".
- *
- * None of this is a setting of this module. Dolibarr holds the scheme once, in admin/taxes.php, and
- * that same setting decides how its VAT report is built, so a second place to state it would be a
- * second place to state it differently: a document declaring the debits option to the buyer while the
- * seller declares its VAT on collection, or the reverse. This is the same reason there is no option
- * for the VAT regime of the seller (BT-31 / BT-32) - see einvoicingSellerVatRegime().
+ * BR-CL-06 restricts BT-8 to 5, 29 or 72, BR-CO-03 makes it exclusive with BT-7, and CII-SR-462 allows
+ * one distinct value for the whole document. Under the French socle 5 does not mean "payable now" but
+ * "the seller took the debits option" (G1.43, BR-FR-MAP-03), so a seller under the standard scheme
+ * sends nothing on goods and 72 on services. 29 is never sent: BR-FR-MAP-29 says the PPF expects only 5.
  *
  * @param  bool		$hasProductLine		The document carries at least one goods line
  * @param  bool		$hasServiceLine		The document carries at least one service line
@@ -745,11 +689,9 @@ function einvoicingVatPointDateCode($hasProductLine, $hasServiceLine, $isDeposit
  * Tell whether the VAT of this document falls due on collection, i.e. whether a cash-in on it has to
  * be reported to the platform with the status 212.
  *
- * Close to the question BT-8 answers, but not the same one: BT-8 is what the French socle makes of it,
- * the declaration of the debits option, while this is the plain fact of when the VAT falls due. They
- * part company on the down payment of a seller who took the option, whose document declares 5 because
- * the option is general (G1.43), while the down payment itself is still taxed on collection - the
- * option "ne peut avoir pour effet de retarder l'exigibilite".
+ * Not the same question as BT-8: they part company on the down payment of a seller who took the debits
+ * option, whose document declares 5 because the option is general (G1.43) while the down payment
+ * itself stays taxed on collection.
  *
  * @param  bool		$hasProductLine		The document carries at least one goods line
  * @param  bool		$hasServiceLine		The document carries at least one service line
@@ -773,26 +715,10 @@ function einvoicingVatDueOnCollection($hasProductLine, $hasServiceLine)
 /**
  * VAT regime of the seller, as far as the identifier it declares on its invoices is concerned.
  *
- * EN 16931 lets a seller identify itself for tax purposes in two ways, and a document carries the one
- * that matches its regime:
- *
- *   BT-31  Seller VAT identifier            ram:SpecifiedTaxRegistration/ram:ID[@schemeID='VA']
- *   BT-32  Seller tax registration identif. ram:SpecifiedTaxRegistration/ram:ID[@schemeID='FC']
- *
- * A seller that charges VAT declares BT-31. A seller that does not - franchise en base de TVA of the
- * micro-entrepreneur, and more generally the "Non assujetti a la TVA" setup of Dolibarr - has no VAT
- * identifier to declare, and BT-32 is what the standard leaves it: in France, its SIREN. Without one
- * or the other, every exempt line of the document trips BR-E-02 and the platform refuses it, which is
- * the whole of issue #560.
- *
- * This is deliberately not a setting of this module, and there is no option to override it: Dolibarr
- * already holds the regime in the setup of the company (Home - Setup - Company/Organization, the "VAT
- * is used / is not used" radio, which admin/company.php writes into FACTURE_TVAOPTION as 1 or 0), and a
- * second place to state the same thing is a second place for it to be stated differently. Nothing is
- * re-derived from that constant here either: Societe::setMysoc() already turns it into ->tva_assuj, and
- * getCategoryRate() already decides from that same ->tva_assuj whether a line is exempt. Reading the
- * property the core computed is what keeps the two from ever disagreeing - a document declaring an
- * exempt line while claiming a VAT registration, or the reverse.
+ * A seller that charges VAT declares BT-31, one that does not (franchise en base, "Non assujetti a la
+ * TVA" in Dolibarr) declares BT-32 - in France its SIREN. Without either, every exempt line trips
+ * BR-E-02 and the platform refuses the document (issue #560). The regime is read from the property the
+ * core computed (Societe::setMysoc() into ->tva_assuj), never re-derived, so the two cannot disagree.
  *
  * @param	Societe		$seller		Selling company, normally $mysoc
  * @return	string					'standard' (the seller charges VAT, BT-31) or 'franchise' (it does not, BT-32)
@@ -845,12 +771,9 @@ function einvoicingShipToFromContact($shipContact, $buyer, $outputlangs, $db)
 		$name = ($shipSoc !== null && !empty($shipSoc->name)) ? $shipSoc->name : $buyer->name;
 	}
 
-	// The contact wins when it carries an address of its own - that is a delivery site the user
-	// entered deliberately. With none, the address of its company is the one that means something;
-	// the contact's own empty fields would emit a deliver-to party with no address at all. This is
-	// again what pdf_build_address() does, and a contact of the invoiced company with no address of
-	// its own falls back on that same company, so the deliver-to party then equals the buyer and no
-	// distinct BG-15 is emitted at all.
+	// The contact wins when it carries an address of its own - a delivery site the user entered
+	// deliberately; with none, its company address is used, as pdf_build_address() does. A contact of
+	// the invoiced company with no address then equals the buyer, so no distinct BG-15 is emitted.
 	$source = !empty($shipContact->address) ? $shipContact : ($shipSoc !== null ? $shipSoc : $shipContact);
 
 	return array(
@@ -865,11 +788,9 @@ function einvoicingShipToFromContact($shipContact, $buyer, $outputlangs, $db)
 /**
  * Tax registrations (BT-31 / BT-32) the seller declares, in the shape the two writers consume.
  *
- * One entry, because the two identifiers answer the same question and a document that carried both
- * would be claiming a VAT registration it does not use. Which one is decided by the regime rather
- * than by "is a VAT number recorded": a seller subject to VAT that simply left the field empty must
- * keep getting the explicit BADVATNUMBER message that names what to fill in, not a silent fallback on
- * its SIREN (issue #560).
+ * One entry only: the two identifiers answer the same question. Which one is decided by the regime,
+ * not by "is a VAT number recorded", so a seller subject to VAT that left the field empty still gets
+ * the explicit BADVATNUMBER message instead of a silent fallback on its SIREN (issue #560).
  *
  * @param	Societe		$seller		Selling company, normally $mysoc
  * @return	array<array{type:string,value:string}>	Registrations to write, possibly empty
@@ -892,21 +813,10 @@ function einvoicingSellerTaxRegistrations($seller)
 /**
  * Invoicing period of the document (BG-14 / BT-73 / BT-74), derived from the periods of its lines.
  *
- * Dolibarr has no invoicing period at invoice level: the period lives on the line, as the date_start
- * and date_end a service line carries. EN 16931 has both - BT-134/BT-135 on the line, BT-73/BT-74 on
- * the header - and says nothing about deriving one from the other, so the derivation is a decision:
- * the document covers everything its lines cover, hence the earliest start and the latest end (issue
- * #572, option 1, chosen by the maintainer because most receiving software only reads the header).
- *
- * A period that would be its own contradiction is not emitted. One line billed from March with another
- * billed until January derives a start after its end, which BR-29 refuses ("The Invoicing period end
- * date shall be later or equal to the Invoicing period start date") - and a document refused whole for
- * a header the operator never filled in would be worse than not deriving anything. The lines keep
- * their own periods in that case, which is what happened before this existed.
- *
- * The argument is the accumulator buildinvoicelines.inc.php fills as it walks the lines:
- * ['start' => [<numligne> => <timestamp>, ...], 'end' => [...]], either key absent when no line has
- * that side.
+ * Dolibarr has no period at invoice level, only BT-134/BT-135 on the line, so the header takes the
+ * earliest start and the latest end (issue #572). A start later than its end is not emitted at all:
+ * BR-29 refuses it and the whole document would be rejected. $billingPeriod is the accumulator
+ * buildinvoicelines.inc.php fills, ['start' => [<numligne> => <timestamp>], 'end' => [...]].
  *
  * @param	array<string,array<int,int>>	$billingPeriod	Line periods collected from the invoice
  * @return	array{start: ?int, end: ?int}					BT-73 and BT-74, null when there is none
@@ -932,14 +842,9 @@ function einvoicingInvoicingPeriodFromLines($billingPeriod)
 /**
  * Version of the module, followed by the commit it was built from when that one is known.
  *
- * The version alone does not name sources: between two releases the VERSION file does not move,
- * so every build of a branch answers the same string and a bug report quoting it says nothing
- * about what actually runs. einvoicingModuleCommit() is what names the sources, and this is the
- * single place deciding how the two read together, so that the stamp is the same wherever it is
- * printed - the comment opening a generated XML, the title of a page.
- *
- * An installation whose commit cannot be known gets the version alone, with no parentheses,
- * which is what every caller printed before the commit existed.
+ * The VERSION file does not move between two releases, so the version alone does not name sources.
+ * Single place deciding how version and commit read together, so the stamp is the same wherever it is
+ * printed. An installation whose commit cannot be known gets the version alone, with no parentheses.
  *
  * @return	string	Something like "1.4.2 (a6f4d2b)", or "1.4.2" when the commit is unknown
  */
@@ -959,25 +864,10 @@ function einvoicingModuleStamp()
 /**
  * Commit the module sources were built from, empty string when it cannot be known.
  *
- * An installed module has no repository to ask: the zip is unpacked into custom/ and that is
- * all there is. So the packager writes the commit it built from into a COMMIT file at the root
- * of the module (dev/build/makepack-modules.php), and reading that file back is the whole
- * mechanism - nothing is executed here, only one file is read.
- *
- * The commit is deliberately NOT part of the version: einvoicing/VERSION is compared with
- * version_compare() by the core (DolibarrModules::checkForUpdate()) against the VERSION file
- * published on GitHub, and it names both the package and the release tag in the packager. A
- * build suffix there would turn the "update available" flag into a lexicographic comparison of
- * hexadecimal, and every build into a new tag. A file of its own costs none of that.
- *
- * Whichever source answers, the commit is named on seven characters. `git rev-parse --short`
- * returns the shortest unambiguous prefix, which is a property of the repository on the machine
- * that built the package and grows with it, so the stamp is not a stable length on its own.
- *
- * A deployment made from a clone of the repository rather than from a package has no stamp and
- * never will, so the repository metadata is read as a second source. An installation answering
- * to neither - sources predating the stamp, an unpacked zip built before it - gets no commit,
- * and the caller falls back to the version alone, exactly as before.
+ * An installed module has no repository to ask, so the packager writes the commit into a COMMIT file
+ * at the root of the module (dev/build/makepack-modules.php); a deployment made from a clone has none,
+ * hence the repository metadata read as a second source. Deliberately not part of VERSION, which the
+ * core compares with version_compare() to flag an available update. Always shortened to 7 characters.
  *
  * @return	string	Short commit hash, or '' when neither source answers
  */
@@ -1008,13 +898,9 @@ function einvoicingModuleCommit()
 /**
  * Commit at the tip of a repository checkout, read from its metadata files.
  *
- * git is not run: a module has no business executing commands, and exec() is forbidden on a
- * good many hostings anyway. What is read is what `git rev-parse HEAD` would resolve - HEAD,
- * then the ref it names, as a file of its own or as a line of packed-refs - through the two
- * indirections a checkout may add: a .git that is a file naming the real directory (a linked
- * worktree, a submodule), and refs kept in the repository the worktree came from.
- *
- * Anything unexpected returns an empty string. This names sources, it never decides anything.
+ * git is never run: exec() is forbidden on a good many hostings. What is read is what
+ * `git rev-parse HEAD` would resolve, through the two indirections a checkout may add - a .git file
+ * naming the real directory (linked worktree, submodule), and refs kept in the repository it came from.
  *
  * @param	string	$repodir	Directory expected to hold the .git of a checkout
  * @return	string				Short commit hash, or '' when it is not a readable checkout
@@ -1068,13 +954,9 @@ function einvoicingCheckoutCommit($repodir)
 /**
  * Key identifying the VAT breakdown group (BG-23) a line belongs to.
  *
- * EN 16931 identifies a breakdown group by its VAT category code (BT-118), its rate (BT-119) and its
- * exemption reason (BT-120/BT-121), and by nothing else - in particular not by the Dolibarr
- * vat_src_code, which used to split otherwise identical groups in two and had the platform reject the
- * document (BR-S-08: the taxable base does not reconcile).
- *
- * It exists as a function because the same key is built in more than one place: a breakdown filled
- * under one shape and read back under another silently loses what was filed under it.
+ * A group is identified by BT-118, BT-119 and BT-120/BT-121 and by nothing else - in particular not by
+ * the Dolibarr vat_src_code, which split otherwise identical groups in two and had the platform reject
+ * the document (BR-S-08). A function because the same key is built in more than one place.
  *
  * @param	string		$categoryVAT			VAT category code of the line (BT-118)
  * @param	float|string	$rate				VAT rate of the line (BT-119)
@@ -1090,24 +972,10 @@ function einvoicingVatBreakdownKey($categoryVAT, $rate, $exemptionReasonCode = '
 /**
  * Tell whether an URL may be used as the target of a redirect made by the OAuth proxy.
  *
- * public/proxy_oauthcallback.php is reachable without authentication (NOLOGIN) and hands the caller
- * back to an address the caller itself supplied in redirect_uri. On the callback branch that address
- * receives the freshly issued access_token and refresh_token in its query string, so whoever controls
- * it controls the tokens: the destination is a trust decision, not a formatting detail, and it must be
- * taken in one single place for every redirect of that page.
- *
- * The allowed destinations are the domains listed in EINVOICING_SUPERPDPVIAPARTNER_ONLY_DOMAIN, comma
- * separated. A proxy deployment that serves partner domains has to name them explicitly; an empty
- * list is what the security report is about, since it lets any third party drive the flow and collect
- * the tokens on a host of its choice. It is nevertheless accepted for one transition step, because
- * nothing ever set that option and refusing at once would stop every existing proxy: see the TODO
- * below, and the warning pdpShowWarning() prints on the setup pages meanwhile.
- *
- * Two shapes are refused whatever the allowlist says, empty or not:
- *  - anything that is not an absolute http(s) URL, so that "javascript:" payloads and the scheme
- *    relative "//evil.tld" (which a browser resolves to the attacker host) never reach a Location header;
- *  - a host that merely ends with an allowed domain. Matching on the suffix alone accepts
- *    "notpartner.tld" for "partner.tld", so the comparison is on the host itself or on a dot boundary.
+ * public/proxy_oauthcallback.php is reachable without authentication and hands the freshly issued
+ * tokens to the redirect_uri the caller supplied: a trust decision. Only an absolute http(s) URL whose
+ * host matches, on a dot boundary, a comma separated EINVOICING_SUPERPDPVIAPARTNER_ONLY_DOMAIN entry
+ * is allowed. An empty list is accepted for one transition step.
  *
  * @param	string	$url	Candidate destination, as received from the caller
  * @return	bool			True when the URL may be passed to header('Location: ...')
@@ -1130,11 +998,8 @@ function einvoicingIsAllowedRedirectUrl($url)
 
 	$alloweddomains = getDolGlobalString('EINVOICING_SUPERPDPVIAPARTNER_ONLY_DOMAIN');
 	if ($alloweddomains === '') {
-		// TRANSITION. No proxy deployment has this option today - no code, no setup page and no
-		// upgrade ever set it - so refusing here would cut every customer instance off its proxy on
-		// the day of the update. It stays open for one step, and both setup pages print a warning
-		// for as long as it is: while the list is empty the proxy hands the access token and the
-		// refresh token to whatever destination the caller names.
+		// TRANSITION. Nothing ever set this option, so refusing here would cut every customer instance off
+		// its proxy on the day of the update. Both setup pages warn for as long as the list is empty.
 		// TODO Remove this and return false instead, once deployments have had time to declare the
 		// domains of their customer instances.
 		return true;

--- a/einvoicing/test/conformance/damage-vat-rate.php
+++ b/einvoicing/test/conformance/damage-vat-rate.php
@@ -20,14 +20,9 @@
  * \ingroup einvoicing
  * \brief   Builds the negative control of a conformance run: the same CII documents, with the rate
  *          of every taxing VAT breakdown set to 0.00.
- * \remarks This is the exact shape #709 shipped - BT-119 at 0.00 against a non-zero BT-117 - and the
- *          rules have to refuse it on BR-CO-17. A validation that comes back green says nothing
- *          until the validators are shown to bite, and this is what they are shown to bite on. The
- *          documents stay well formed and keep passing the XSD, so what a refusal demonstrates is
- *          that the semantic stage ran, not that a broken file was rejected.
- *
- *          Breakdowns that tax nothing are left alone: a 0.00 rate on a 0.00 tax amount is what an
- *          exempt document legitimately carries, and damaging one would prove nothing.
+ * \remarks This is the shape #709 shipped - BT-119 at 0.00 against a non-zero BT-117 - which the
+ *          rules must refuse on BR-CO-17. Breakdowns that tax nothing are left alone: a 0.00 rate
+ *          on a 0.00 tax amount is what an exempt document legitimately carries.
  *
  *          Usage: php damage-vat-rate.php <output directory> <document> [<document> ...]
  */

--- a/einvoicing/test/phpunit/BillingProcessIdTest.php
+++ b/einvoicing/test/phpunit/BillingProcessIdTest.php
@@ -20,12 +20,10 @@
  *      \file       test/phpunit/BillingProcessIdTest.php
  *      \ingroup    test
  *      \brief      PHPUnit test for the billing frame (BT-23).
- *                  BT-23 describes the billing case of the document, not a payment status: in the
- *                  AFNOR nominal use case (XP Z12-012 annexe B, UC1_F202500003) the invoice is
- *                  issued in frame S1 and stays S1 while the CDAR lifecycle reports 211 then 212.
- *                  The "already paid" frames B2/S2/M2 are therefore reserved to an invoice whose
- *                  amount was already received when it was issued, which BR-FR-CO-09 makes
- *                  concrete: BT-113 must equal BT-112 and BT-115 must be 0, both fatal.
+ *                  BT-23 is the billing case, not a payment status: an invoice issued in S1 stays S1
+ *                  whatever the lifecycle reports. The "already paid" frames B2/S2/M2 are reserved to
+ *                  an invoice already paid when issued, which BR-FR-CO-09 makes fatal: BT-113 must
+ *                  equal BT-112 and BT-115 must be 0.
  *      \remarks    To run this script as CLI: phpunit filename.php
  */
 

--- a/einvoicing/test/phpunit/CIIProfileShapeTest.php
+++ b/einvoicing/test/phpunit/CIIProfileShapeTest.php
@@ -20,11 +20,9 @@
  *      \file       test/phpunit/CIIProfileShapeTest.php
  *      \ingroup    test
  *      \brief      PHPUnit test for the groups a profile is allowed to carry.
- *                  MINIMUM and BASIC WL are header-only Factur-X profiles: neither
- *                  ram:IncludedSupplyChainTradeLineItem (BG-25) nor ram:DefinedTradeContact
- *                  (BG-6 / BG-9) is declared in their XSD, so emitting either makes every
- *                  generated document fail the profile schema. Every profile from BASIC upwards
- *                  expects both.
+ *                  MINIMUM and BASIC WL are header-only Factur-X profiles: their XSD declares
+ *                  neither ram:IncludedSupplyChainTradeLineItem (BG-25) nor ram:DefinedTradeContact
+ *                  (BG-6 / BG-9), while every profile from BASIC upwards expects both.
  *      \remarks    To run this script as CLI: phpunit filename.php
  */
 
@@ -464,11 +462,9 @@ class CIIProfileShapeTest extends CommonClassTest
 	 * The buyer routing code travels as a second ram:GlobalID of the buyer party, and only the
 	 * EXTENDED profiles may carry it.
 	 *
-	 * Scheme 0224 is where BR-FR-CPRO-11 and BR-FR-CPRO-13 read the Chorus Pro service code, but it
-	 * is a second identifier for the party, and the Factur-X EN16931 Schematron caps that element at
-	 * one occurrence (FX-SCH-A-000164): a document below EXTENDED that carries both is refused. The
-	 * Annexe B examples of XP Z12-012 agree - the routing code is in the EXTENDED and EXTENDED-CTC-FR
-	 * files of an invoice, absent from its EN16931 twin (issue #678).
+	 * Scheme 0224 is where BR-FR-CPRO-11 and BR-FR-CPRO-13 read the Chorus Pro service code, and the
+	 * Factur-X EN16931 Schematron caps ram:GlobalID at one occurrence (FX-SCH-A-000164): a document
+	 * below EXTENDED carrying both is refused (issue #678).
 	 *
 	 * @return void
 	 */

--- a/einvoicing/test/phpunit/CIIProtocolTest.php
+++ b/einvoicing/test/phpunit/CIIProtocolTest.php
@@ -21,14 +21,9 @@
  *      \ingroup    test
  *      \brief      PHPUnit test for the line billing period (EN 16931 BG-26 / BT-134 / BT-135), in
  *                  both directions.
- *                  Export (issue #435): CIIProtocol::buildLineItem() must map the line
- *                  date_start/date_end (already parsed upstream into linePeriodStart/linePeriodEnd)
- *                  to the BillingSpecifiedPeriod block, placed between ApplicableTradeTax and
- *                  SpecifiedTradeAllowanceCharge/SpecifiedTradeSettlementLineMonetarySummation as
- *                  required by the CII D22B schema sequence.
- *                  Import (issue #576): CIIProtocol::resolveLinePeriod() must turn what the parser
- *                  read back into the timestamps a supplier invoice line stores, keeping one side
- *                  alone and refusing a period that ends before it starts.
+ *                  Export (issue #435): buildLineItem() must place BillingSpecifiedPeriod where the
+ *                  CII D22B schema sequence requires it. Import (issue #576): resolveLinePeriod()
+ *                  must keep one side alone and refuse a period that ends before it starts.
  *      \remarks    To run this script as CLI: phpunit filename.php
  */
 

--- a/einvoicing/test/phpunit/CommonClassTestCompat.inc.php
+++ b/einvoicing/test/phpunit/CommonClassTestCompat.inc.php
@@ -20,15 +20,10 @@
  *      \file       test/phpunit/CommonClassTestCompat.inc.php
  *      \ingroup    test
  *      \brief      Make CommonClassTest available whatever the Dolibarr version.
- *      \remarks    The module supports Dolibarr >= 17 (see modEInvoicing::$need_dolibarr_version) but
- *                  test/phpunit/CommonClassTest.class.php only appeared later: on Dolibarr 18 the
- *                  require_once fatals and the whole suite is unrunnable. When the core class is
- *                  there we use it, so the tests behave exactly like the core ones; otherwise we
- *                  declare the small subset the module tests actually rely on ($savconf, $savuser,
- *                  $savlangs, $savdb and the surrounding transaction).
- *
- *                  Include this instead of requiring CommonClassTest.class.php directly. Requires
- *                  master.inc.php to have been included first (DOL_DOCUMENT_ROOT must be defined).
+ *      \remarks    test/phpunit/CommonClassTest.class.php does not exist on Dolibarr 18: requiring it
+ *                  fatals and the whole suite is unrunnable. Use the core class when it is there,
+ *                  otherwise declare the subset the module tests rely on. Include this file instead of
+ *                  CommonClassTest.class.php directly, and after master.inc.php.
  */
 
 if (!defined('DOL_DOCUMENT_ROOT')) {

--- a/einvoicing/test/phpunit/CompatShimReloadTest.php
+++ b/einvoicing/test/phpunit/CompatShimReloadTest.php
@@ -21,17 +21,10 @@
  *      \ingroup    test
  *      \brief      PHPUnit test for the polyfills of compat/: they must be inert when the symbol
  *                  they backport is already there.
- *      \remarks    The module runs from Dolibarr 17 and carries copies of core symbols that only
- *                  appeared later. It is not the only module in that situation: any other module of
- *                  the instance that also has to run on both sides of the line carries the same
- *                  copies, and on a name that is already taken PHP does not warn, it fatals. That is
- *                  how activating the module on the second entity of a multicompany setup died on
- *                  "Cannot declare class CommonHookActions, because the name is already in use"
- *                  (issue #630) - the hook of the module could no longer be loaded at all.
- *
- *                  Each shim is therefore checked in a subprocess, since a redeclaration cannot be
- *                  caught in the running one: first with the symbol already declared (the shim must
- *                  do nothing), then on its own (the shim must still deliver what it backports).
+ *      \remarks    Another module backporting the same core symbol makes PHP fatal on redeclaration,
+ *                  not warn (issue #630). A redeclaration cannot be caught in the running process, so
+ *                  each shim is checked in a subprocess: first with the symbol already declared (the
+ *                  shim must do nothing), then on its own (it must still deliver what it backports).
  *      \remarks    To run this script as CLI: phpunit filename.php
  */
 

--- a/einvoicing/test/phpunit/ExportImportRoundTripTest.php
+++ b/einvoicing/test/phpunit/ExportImportRoundTripTest.php
@@ -20,21 +20,11 @@
  *      \file       test/phpunit/ExportImportRoundTripTest.php
  *      \ingroup    test
  *      \brief      What the module writes, the module reads back the same.
- *      \remarks    The two halves of the module are tested apart: the generation against reference
- *                  documents, the import against documents written by hand. Nothing checks that they
- *                  agree, and that gap is where a whole family of defects lived - a quantity dropped
- *                  by updateline() on the way in (#726), a document level charge skipped (#731), a
- *                  received EXTENDED-CTC-FR document that could not be read at all (#742). Each of
- *                  them is a term the exporter writes and the importer does not read back.
- *
- *                  This generates an invoice, imports the document it produced as a supplier invoice
- *                  and requires the two to state the same thing: the same lines, the same
- *                  quantities, unit prices and rates, the same totals. Everything happens in the
- *                  transaction the test class rolls back.
- *
- *                  The seller of a generated document is the company of the instance, so the third
- *                  party the import resolves to is that same company seen from the other side: it is
- *                  created here as a supplier carrying the identifiers pinned on $mysoc.
+ *      \remarks    Generation and import are tested apart, and the gap between them is where a whole
+ *                  family of defects lived (#726, #731, #742). This generates an invoice, imports the
+ *                  document it produced as a supplier invoice and requires the two to state the same
+ *                  lines, quantities, prices, rates and totals. The seller of a generated document is
+ *                  $mysoc, so the supplier created here carries the identifiers pinned on it.
  */
 
 
@@ -154,12 +144,8 @@ class ExportImportRoundTripTest extends CommonClassTest
 
 		$savPdp = getDolGlobalString('EINVOICING_PDP');
 		$conf->global->EINVOICING_PDP = 'SPECIMEN';
-		// A line at 0 % has to say why it is exempt (BT-121), and the reason is a setting of the
-		// instance: without it the generation stops, which says nothing about the round trip. Pinned
-		// here to the French article an instance would name, and restored below.
-		// The lines sent here are free text, as most lines of a real invoice are. An instance either
-		// matches them to a product, creates the product, or takes the line as it comes: the last one
-		// is what this compares, and it is a setting, so it is pinned rather than assumed.
+		// The lines sent here are free text, as most lines of a real invoice are: the import is pinned
+		// to take them as they come rather than matching or creating a product. Restored below.
 		$savFreeLines = getDolGlobalString('EINVOICING_IMPORT_AS_FREE_LINES');
 		$conf->global->EINVOICING_IMPORT_AS_FREE_LINES = 1;
 

--- a/einvoicing/test/phpunit/FacturxPdfaContainerTest.php
+++ b/einvoicing/test/phpunit/FacturxPdfaContainerTest.php
@@ -19,24 +19,12 @@
 /**
  *      \file       test/phpunit/FacturxPdfaContainerTest.php
  *      \ingroup    test
- *      \brief      PHPUnit test for the PDF/A-3 container of the Factur-X files (issue #591).
- *                  A Factur-X file is a PDF/A-3 file carrying the XML, and everything else this
- *                  project validates looks at the XML only: the container had no guard, and two
- *                  defects that made the files invalid PDF/A shipped unnoticed. Both mergers of the
- *                  module are exercised here, on the carrier PDF and the XML fixtures the repository
- *                  already ships, and what they wrote into the container is read back.
- *
- *                  What is asserted is what a PDF/A validator would reject and what PHP can see
- *                  without one: a single parsable XMP packet identifying the file as PDF/A-3B, one
- *                  extension schema bag declaring Factur-X, a metadata stream whose /Length matches
- *                  what it holds, the XML embedded as an associated file with the right relationship,
- *                  and the PDF/A output intent. Run veraPDF over the same documents for the clauses
- *                  only a validator can settle - FACTURX_PDFA_OUTDIR is there for that.
- *
+ *      \brief      PHPUnit test for the PDF/A-3 container of the Factur-X files (issue #591). Both
+ *                  mergers are read back on the fixtures the repository ships: XMP packet identifying
+ *                  PDF/A-3B, extension schema declaring Factur-X, metadata stream /Length, embedded XML
+ *                  and output intent. FACTURX_PDFA_OUTDIR keeps the documents for a veraPDF run.
  *      \remarks    To run this script as CLI: phpunit filename.php
- *                  Needs no database. It uses the Dolibarr instance when there is one - as the other
- *                  tests of this directory do, through DOLIBARR_HTDOCS or the htdocs/custom symlink -
- *                  and stands on its own when there is none, which is how the CI runs it.
+ *                  Needs no database, which is how the CI runs it.
  */
 
 // Both mergers need a logger and nothing else of the core, so the Dolibarr instance is used when it
@@ -173,11 +161,9 @@ class FacturxPdfaContainerTest extends PHPUnit\Framework\TestCase
 	/**
 	 * Read back everything a Factur-X container is made of.
 	 *
-	 * The two defects this guards against both lived here: an XMP packet carrying two descriptions
-	 * that repeat pdfaExtension:schemas on the same subject - which the XMP specification forbids,
-	 * and which stops a reader before it ever sees the PDF/A identification, while staying perfectly
-	 * well-formed XML - and, once the entry is grafted into the bag the writer produces instead, a
-	 * metadata stream whose declared length no longer matches what it holds.
+	 * The two defects this guards against: an XMP packet repeating pdfaExtension:schemas on the same
+	 * subject, which the specification forbids and which stops a reader before the PDF/A identification
+	 * while staying well-formed XML; and a metadata stream whose declared length no longer matches.
 	 *
 	 * @param	string	$file	Full path of the generated document
 	 * @return	void

--- a/einvoicing/test/phpunit/IdentifierSpaceStrippingTest.php
+++ b/einvoicing/test/phpunit/IdentifierSpaceStrippingTest.php
@@ -20,12 +20,10 @@
  *      \file       test/phpunit/IdentifierSpaceStrippingTest.php
  *      \ingroup    test
  *      \brief      PHPUnit test proving the module strips the spaces of an identifier the same way everywhere.
- *                  The module used to carry two strippers: removeAllSpaces(), which knows every kind of
- *                  space, and EInvoicing::removeSpaces(), a '/\s+/' without the /u modifier that sees
- *                  none of the non-breaking, thin or zero-width ones. idprof() built the routing id with
- *                  the first one while getSellerCommunicationURI() checked it back with the second, so a
- *                  non-breaking space pasted into idprof1 - what a SIRET copied from a web page or a PDF
- *                  carries - made the two sides disagree and, in EINVOICING_LIVE, emptied the seller URI.
+ *                  EInvoicing::removeSpaces() used a '/\s+/' without the /u modifier, so it missed the
+ *                  non-breaking and zero-width spaces removeAllSpaces() removes: a SIRET pasted with
+ *                  one made idprof() and getSellerCommunicationURI() disagree and, under EINVOICING_LIVE,
+ *                  emptied the seller URI.
  *      \remarks    To run this script as CLI: phpunit filename.php
  */
 

--- a/einvoicing/test/phpunit/ImportVatCalculationModeTest.php
+++ b/einvoicing/test/phpunit/ImportVatCalculationModeTest.php
@@ -20,17 +20,9 @@
  *      \file       test/phpunit/ImportVatCalculationModeTest.php
  *      \ingroup    test
  *      \brief      PHPUnit test for the VAT calculation mode of a received invoice (issue #781).
- *
- *                  Dolibarr computes the VAT of an invoice either by rounding it on every line and
- *                  adding the results up ("total of round", mode 1, the default), or by adding the
- *                  line amounts up and rounding the VAT once ("round of total", mode 2). A received
- *                  document does not leave that open: BT-110 and BT-112 are the ones its issuer
- *                  computed, so the imported invoice has to carry them whatever the instance is set
- *                  to.
- *
- *                  The three line amounts used below are taken from the reported 46 line document:
- *                  1.09, 7.79 and 1.59 at 20 %, which round to 0.22 + 1.56 + 0.32 = 2.10 line by
- *                  line, where the document announces 10.47 x 20 % = 2.09.
+ *                  BT-110 and BT-112 are the ones the issuer computed, so the imported invoice has to
+ *                  carry them whatever the instance is set to - "total of round" (mode 1, the default,
+ *                  rounding line by line) or "round of total" (mode 2).
  *      \remarks    To run this script as CLI: phpunit filename.php
  */
 

--- a/einvoicing/test/phpunit/MandatoryThirdpartyExtrafieldTest.php
+++ b/einvoicing/test/phpunit/MandatoryThirdpartyExtrafieldTest.php
@@ -21,13 +21,10 @@
  *      \ingroup    test
  *      \brief      PHPUnit test for the synchronization of the seller of a received document when the
  *                  base carries a mandatory extrafield on thirdparties.
- *                  The module never sets an extrafield on a thirdparty, but from Dolibarr 20 on
- *                  Societe::fetch() pre-fills array_options with a null entry for every declared
- *                  extrafield, and update() hands that array to insertExtraFields(), which refuses the
- *                  whole record as soon as one of those fields is mandatory and empty. A thirdparty
- *                  created programmatically holds no extrafield row at all - which is exactly what the
- *                  automatic creation of this same function produces - so every received document was
- *                  then rejected on the seller.
+ *                  From Dolibarr 20 on, Societe::fetch() pre-fills array_options with a null entry for
+ *                  every declared extrafield, and update() hands it to insertExtraFields(), which
+ *                  refuses the whole record when one of those fields is mandatory and empty - so every
+ *                  received document was rejected on the seller.
  *      \remarks    To run this script as CLI: phpunit filename.php
  */
 

--- a/einvoicing/test/phpunit/MultidirOutputCompatTest.php
+++ b/einvoicing/test/phpunit/MultidirOutputCompatTest.php
@@ -20,18 +20,11 @@
  *      \file       test/phpunit/MultidirOutputCompatTest.php
  *      \ingroup    test
  *      \brief      PHPUnit test for getMultidirOutputCompat(): it must hand the call over to the core
- *                  getMultidirOutput() as soon as the core knows the four arguments, and only fall
- *                  back on its backported body on the versions where it does not.
- *      \remarks    getMultidirOutputCompat() used to be an unconditional copy of the core function,
- *                  so every fix made in the core (the /sending subdirectory of a shipment, the
- *                  dol_sanitizePathName() added in Dolibarr 24, ...) was silently ignored by the
- *                  module. The core function takes ($object, $module) only up to Dolibarr 19 and
- *                  ($object, $module, $forobject, $mode) from Dolibarr 20 on, hence the guard.
- *
- *                  The backported body is unreachable once the guard delegates, so it is re-declared
- *                  here under another name, from the very source of lib/einvoicing.lib.php with the
- *                  delegation stripped, to be compared against the core function of the instance the
- *                  tests run on.
+ *                  getMultidirOutput() as soon as the core knows the four arguments.
+ *      \remarks    The core function takes ($object, $module) only up to Dolibarr 19 and
+ *                  ($object, $module, $forobject, $mode) from Dolibarr 20 on, hence the guard. The
+ *                  backported body is unreachable once the guard delegates, so it is re-declared here
+ *                  under another name to be compared against the core function of the instance.
  *      \remarks    To run this script as CLI: phpunit filename.php
  */
 

--- a/einvoicing/test/phpunit/SituationInvoiceTotalsTest.php
+++ b/einvoicing/test/phpunit/SituationInvoiceTotalsTest.php
@@ -20,22 +20,11 @@
  *      \file       test/phpunit/SituationInvoiceTotalsTest.php
  *      \ingroup    test
  *      \brief      A generated document states the amount Dolibarr bills, not one of its own.
- *      \remarks    No validator can catch this. A document that overstates its amounts is
- *                  arithmetically consistent with itself - the lines, the breakdown and the totals
- *                  all agree - so the CEN, Factur-X and CTC-FR schematrons answer VALID on it. The
- *                  only thing it contradicts is the invoice it came from, and that is outside every
- *                  one of them.
- *
- *                  #709 did exactly that: it filed the deduction of the previous situations (#674)
- *                  under one key shape and read it back under another, so the document level
- *                  allowance (BT-107) was silently dropped. A second situation of 70 % on a 1000.00
- *                  line announced 840.00 where Dolibarr bills 480.00 - 360.00 too much, on a
- *                  document that goes to the platform and to the customer, and every validator said
- *                  the document was fine.
- *
- *                  This builds that very cycle - two situations, in the database, in the transaction
- *                  the test class rolls back - and requires the totals of the document to be the
- *                  totals of the invoice.
+ *      \remarks    No validator can catch this: a document that overstates its amounts is consistent
+ *                  with itself, so every schematron answers VALID; the only thing it contradicts is the
+ *                  invoice it came from. #709 dropped the document level allowance (BT-107) that carries
+ *                  the deduction of the previous situations (#674). Two situations are built here, in
+ *                  the database, and the totals of the document must be the totals of the invoice.
  */
 
 

--- a/einvoicing/test/phpunit/SkipB2CPrecheckTest.php
+++ b/einvoicing/test/phpunit/SkipB2CPrecheckTest.php
@@ -20,11 +20,9 @@
  *      \file       test/phpunit/SkipB2CPrecheckTest.php
  *      \ingroup    test
  *      \brief      PHPUnit test for the third party pre-check when EINVOICING_SKIP_B2C is on, issue #600.
- *                  A private individual has no professional id, and with that option on the invoice is
- *                  already out of the e-invoicing scope (needEInvoiceManagement() answers STATUS_IGNORE):
- *                  the pre-check must not report the missing SIREN as a blocking configuration error.
- *                  The detection of a private individual is Societe::isACompany(), the same one the
- *                  decision uses, so both ends of the chain agree on who is B2C.
+ *                  With that option on, a private individual is already out of the e-invoicing scope
+ *                  (needEInvoiceManagement() answers STATUS_IGNORE), so the pre-check must not report
+ *                  the missing professional id as a blocking configuration error.
  *      \remarks    To run this script as CLI: phpunit filename.php
  */
 

--- a/einvoicing/test/phpunit/SupplierInvoiceHelperTest.php
+++ b/einvoicing/test/phpunit/SupplierInvoiceHelperTest.php
@@ -23,8 +23,7 @@
  *                  business rule (issue #286): SupplierInvoiceHelper::abandonRefusedSupplierInvoice(),
  *                  SupplierInvoiceHelper::onOutboundStatusMessageValidated() and their dispatch from
  *                  EInvoicing::updateStatusMessageValidation().
- *                  Also covers SupplierInvoiceHelper::findIdByRef() and the delimiter rule of its
- *                  opt-in tolerant fallback (SupplierInvoiceHelper::refEmbedsReference()).
+ *                  Also covers SupplierInvoiceHelper::findIdByRef() and refEmbedsReference().
  *      \remarks    To run this script as CLI: phpunit filename.php
  */
 

--- a/einvoicing/test/phpunit/SupportExportTest.php
+++ b/einvoicing/test/phpunit/SupportExportTest.php
@@ -19,12 +19,9 @@
 /**
  *      \file       test/phpunit/SupportExportTest.php
  *      \ingroup    test
- *      \brief      PHPUnit test for the "Export for support" mass action of the flow list and of the
- *                  API call log. What has to hold whatever else changes: an archive built to be sent
- *                  to a maintainer carries no credential, and its manifest alone says which core,
- *                  which module build, which platform and which entity it was taken from - debug
- *                  mode included, without which an empty response cannot be told from a response
- *                  that was never stored.
+ *      \brief      PHPUnit test for the "Export for support" mass action of the flow list and of the API
+ *                  call log. What has to hold: the archive carries no credential, and its manifest alone
+ *                  says which core, module build, platform, entity and debug mode it was taken from.
  *      \remarks    To run this script as CLI: phpunit filename.php
  */
 

--- a/einvoicing/test/phpunit/TransmittedLockTest.php
+++ b/einvoicing/test/phpunit/TransmittedLockTest.php
@@ -20,11 +20,9 @@
  *      \file       test/phpunit/TransmittedLockTest.php
  *      \ingroup    test
  *      \brief      PHPUnit test for the already-transmitted guard: EInvoicing::isTransmittedLockActive()
- *                  and the two flags fetchLastknownInvoiceStatus() derives from an extlink record,
- *                  'transmitted' (from the resettable syncstatus) and 'everTransmitted' (from the
- *                  flow_id the platform assigned, which nothing clears). Re-sending an invoice the
- *                  platform already holds is refused as a duplicate, so only the second flag may gate
- *                  a transmission.
+ *                  and the two flags fetchLastknownInvoiceStatus() derives, 'transmitted' (from the
+ *                  resettable syncstatus) and 'everTransmitted' (from the flow_id, which nothing clears).
+ *                  Re-sending is refused as a duplicate, so only the second may gate a transmission.
  *      \remarks    To run this script as CLI: phpunit filename.php
  */
 

--- a/einvoicing/test/phpunit/VatNumberFromProfessionalIdTest.php
+++ b/einvoicing/test/phpunit/VatNumberFromProfessionalIdTest.php
@@ -22,24 +22,9 @@
  *      \brief      PHPUnit test for the VAT number the module builds for a French thirdparty that has
  *                  none, BT-31 for the seller and BT-48 for the buyer.
  *
- *                  A French VAT number is FR, a two digit key, and the nine digits of the SIREN: it is
- *                  thirteen characters, always. The module used to carry its own copy of the core
- *                  computation and the copy was wrong twice:
- *
- *                  - the key was concatenated raw. It is [12 + 3 * (SIREN modulo 97)] modulo 97, so it
- *                    falls between 00 and 09 for about one SIREN in ten - 3 being invertible modulo 97,
- *                    every key from 0 to 96 is reached by exactly one residue - and those numbers went
- *                    out on twelve characters;
- *                  - the SIRET to SIREN fallback cast to int, which eats the leading zero of a SIREN
- *                    that starts with one, and the number went out on twelve characters again, with the
- *                    wrong digits.
- *
- *                  Both defects reached the XML, where a malformed BT-31 or BT-48 is a document the
- *                  platform refuses. The computation is now the core one - Societe::calculateVAT-
- *                  NumberFromProperties(), there since Dolibarr 24 - or the faithful backport of
- *                  compat/societe.lib.php on 18 to 23, which do not have it. Both paths are checked
- *                  here: the entry point of the module, and the backport on its own, so that the
- *                  fallback is covered whatever core the test runs against.
+ *                  A French VAT number is FR, a two digit key, then the SIREN: the key is
+ *                  [12 + 3 * (SIREN modulo 97)] modulo 97, padded below 10. The computation is
+ *                  Societe::calculateVATNumberFromProperties() from v24, the compat backport on 18-23.
  *      \remarks    To run this script as CLI: phpunit filename.php
  */
 

--- a/einvoicing/vendorref_list.php
+++ b/einvoicing/vendorref_list.php
@@ -20,12 +20,8 @@
  *		\ingroup    einvoicing
  *		\brief      List of the vendor product references, i.e. the mappings used to import an e-invoice.
  *
- *		The mapping between a product of the vendor and a product of Dolibarr is stored as a vendor
- *		reference (llx_product_fournisseur_price), because it is the first criteria used by the matching
- *		when a supplier invoice is imported. Once saved, that link was only visible product by product,
- *		in the "Supplier prices" tab of each product. This page lists them all, and lets the user
- *		correct one without leaving the list: reassign a vendor reference to another Dolibarr product,
- *		or drop the mapping.
+ *		The mapping is stored as a vendor reference (llx_product_fournisseur_price), because it is the
+ *		first criteria used by the matching when a supplier invoice is imported.
  */
 
 // Load Dolibarr environment


### PR DESCRIPTION
## Why

The `Comments` section of `.agents/AGENTS.md` asks for comments of five lines at most, never more
than the code they describe. The reason given in review on #809 - *"having too much comment at each
PR fix accumulate too much comment and make the code very difficult to read"* - is exactly what the
files of this module look like today: 195 of my comment blocks are above five lines of prose, the
longest one 33 lines in front of a few lines of code.

## What changes

Comments only, in 61 files: **869 lines of comment prose removed**, no block of mine above five
lines left.

Each block keeps what the code cannot say - the rule id (BR, BR-CO, BR-FR, CII-SR), the core version
that forces a workaround, the trap, the issue number. What goes: the reasoning, the recette
measurements, the long quotations of the norm, the tables of examples, the design justifications.
All of it is already in the pull requests that introduced it.

Comments written by other contributors are untouched, including in the blocks I only shorten my own
lines of. That is why blocks above five lines remain in these files: commented-out code, `@var`
shape tables, and prose that is not mine.

## The code is unchanged, and this is proven rather than asserted

For each of the 61 files, the PHP token stream - `token_get_all()` stripped of `T_COMMENT`,
`T_DOC_COMMENT` and `T_WHITESPACE` - is **identical to the one of the parent commit**. That is
stronger than `php -l`, which says nothing of a line of code changed by mistake.

`php -l`, the phpcs ruleset of the repository and phan (run as the CI runs it, without `--quick`)
are clean.

On the bench: the 39 PHPUnit files on the seven cores 18 to 24, and the same result as `main`
measured in the same bench state, file by file and core by core; one full sandbox cycle - invoice
emitted, routed by the platform, received on the other instance with its line periods, statuses 200
and 201 back; and the generation matrix, seven invoice types in CII and in Factur-X, fourteen
documents with no error.

## Merging

Six of my open pull requests touch files this one also touches (#696, #706, #717, #785, #809, #817).
Every pair merges with no conflict, and the seven branches merged in three different orders give the
**same tree, byte for byte**. In that fully merged tree, the token stream of the 1258 PHP files is
identical with and without this branch: it adds no code there either.

No ChangeLog entry, per `.agents/AGENTS.md`.
