### PR TITLE
QUAL: [einvoicing] Shorten the comment blocks written by the other contributors

### DIFF
--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -1261,9 +1261,7 @@ class EInvoicing
 	 * Check the thirdparty existence and active status via the French National Business Registry API (data.gouv.fr).
 	 * Search is performed by company name; the returned SIREN is then cross-checked against idprof1.
 	 * No authentication required. API rate limit: 7 req/s.
-	 *
-	 * This check is optional and non-blocking: an API timeout or unavailability is
-	 * silently ignored (warning logged, no error raised to the user).
+	 * Optional and non-blocking: an API timeout or unavailability is silently ignored (warning logged).
 	 * Only runs when EINVOICING_ENABLE_API_VALIDATION constant is set to 1.
 	 *
 	 * @param Societe $thirdparty   Thirdparty object to check
@@ -2941,13 +2939,8 @@ class EInvoicing
 	 * Create or replace the default routing for a thirdparty.
 	 *
 	 * This method enforces a 1 → 1 relationship between a thirdparty and its active default routing:
-	 * - Only one active default routing can exist per thirdparty at any given time
 	 * - Any existing routing(s) for this thirdparty are automatically deleted before insertion
 	 * - The new routing is marked as active (active = 1) and default (is_default = 1)
-	 *
-	 * Note: Future versions may support true 1 → N routing management with:
-	 * - Multiple concurrent routings per thirdparty
-	 * - Switching default routing without deletion
 	 *
 	 * @param 	int    $fk_soc   		Thirdparty ID
 	 * @param 	string $routing_id		Routing ID
@@ -3422,11 +3415,10 @@ class EInvoicing
 	/**
 	 * Update validation information of an existing lifecycle status message.
 	 *
-	 * If the message being validated is an outbound "Refused" status message for a supplier
-	 * invoice, confirmed as accepted ('Ok') by the platform, this also triggers the abandon of
-	 * the related Dolibarr supplier invoice (see SupplierInvoiceHelper::onOutboundStatusMessageValidated()).
-	 * This side effect is best-effort: any failure in it is logged but never changes the return
-	 * value of this method, whose only responsibility is to persist the validation information.
+	 * An outbound "Refused" status message for a supplier invoice, confirmed as accepted ('Ok') by the
+	 * platform, also triggers the abandon of the related Dolibarr supplier invoice
+	 * (see SupplierInvoiceHelper::onOutboundStatusMessageValidated()). This side effect is best-effort:
+	 * any failure in it is logged but never changes the return value of this method.
 	 *
 	 * @param int    $rowid					ID
 	 * @param string $statusMessage         Optional detailed status message or comment
@@ -3884,9 +3876,8 @@ class EInvoicing
 	/**
 	 * Generates the deposit, standard and credit note CII sample-invoice chain and returns the normalized XML of each.
 	 *
-	 * Generates three sample invoices (deposit, standard, and credit note) using fixed specimen
-	 * third parties to ensure consistent, deterministic output across test runs. The XML output
-	 * is normalized to exclude non-deterministic parts like timestamps and dates.
+	 * Uses fixed specimen third parties to ensure consistent, deterministic output across test runs.
+	 * The XML output is normalized to exclude non-deterministic parts like timestamps and dates.
 	 *
 	 * @used-by	regenerate_einvoicing_fixtures.php For fixture generation
 	 * @used-by	EInvoicingSamplesTest.php For comparison and regression testing

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -1278,23 +1278,10 @@ class CIIProtocol extends AbstractProtocol
 					$resFetchLinkedObject = $linkedObject->fetch($linkedObjectId);
 					if ($resFetchLinkedObject > 0) {
 						/*
-						 * --------------------------------------------------
-						 * Deposit handling
-						 * --------------------------------------------------
-						 * Deposits may be referenced:
-						 *  - at document level
-						 *  - at line level
-						 *
-						 * If the deposit is referenced at line level:
-						 *   → we create the discount before creating the invoice line,
-						 *     so it can be linked later.
-						 *
-						 * If the same deposit appears both at line and document level:
-						 *    line-level handling takes priority to avoid duplicates.
-						 *
-						 * If the deposit exists only at document level:
-						 *   → a discount line will be created later after all invoice
-						 *     lines are generated.
+						 * Deposit handling: deposits may be referenced at document level or at line level.
+						 * At line level, we create the discount before creating the invoice line, so it can be linked later.
+						 * If the same deposit appears both at line and document level, line-level handling takes priority to
+						 * avoid duplicates. If it exists only at document level, the discount line is created after all lines.
 						 */
 						if ($linkedObject->type == FactureFournisseur::TYPE_DEPOSIT) {
 							$is_deposit_line = 1;
@@ -2384,10 +2371,9 @@ class CIIProtocol extends AbstractProtocol
 			$contractRef->appendChild($doc->createElement('ram:IssuerAssignedID', htmlspecialchars($invoiceData['contractReference'])));
 		}
 
-		// Additional order references: when an invoice covers several purchase orders, the first is
-		// emitted as BT-13 (BuyerOrderReferencedDocument above) and the others are listed here as
-		// AdditionalReferencedDocument/TypeCode=130 — the same approach Factur-X uses. Restricted to
-		// profiles that carry AdditionalReferencedDocument in the agreement section (not MINIMUM), and
+		// Additional order references: when an invoice covers several purchase orders, the first is emitted as BT-13
+		// (BuyerOrderReferencedDocument above) and the others are listed here as AdditionalReferencedDocument/TypeCode=130.
+		// Restricted to profiles that carry AdditionalReferencedDocument in the agreement section (not MINIMUM), and
 		// skipped for Chorus (which does not accept these extra nodes). Sequence position: after
 		// ContractReferencedDocument, before SpecifiedProcuringProject (CII schema order).
 		if (!$invoiceData['_chorus'] && $profile !== 'MINIMUM' && !empty($invoiceData['_customerOrderReferenceList'])) {

--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -1686,15 +1686,10 @@ trait CommonProtocol
 		}
 
 		// The VAT code the line carries (vat_src_code, the code column of the VAT dictionary) states the
-		// regime the line is invoiced under, and that regime is what BT-151 asks for. It is read here rather
-		// than deduced from the rate, because a rate of zero covers Z, E, AE, G and K alike: a generator that
-		// guesses from the rate builds a document that is valid and wrong, and BR-AE-05 and its siblings only
-		// catch the guesses that get the rate wrong as well.
-		//
+		// regime the line is invoiced under, which is what BT-151 asks for. It is read here rather than
+		// deduced from the rate, because a rate of zero covers Z, E, AE, G and K alike.
 		// The category is the segment of the code before its first dash, so 'AE' and 'AE-IC' are both reverse
-		// charge and a dictionary can tell apart two regimes that share one category. A code that does not
-		// open on a category the module supports - a code holding a VATEX identifier, or any code an existing
-		// installation already uses - is left to the rules below, unchanged.
+		// charge. A code that does not open on a category the module supports is left to the rules below.
 		$declaredCategoryVAT = $this->_getVatCategoryFromVatCode($vat_src_code);
 
 		if ($declaredCategoryVAT !== '' && $declaredCategoryVAT !== 'S') {
@@ -1830,11 +1825,9 @@ trait CommonProtocol
 					if ((float) DOL_VERSION < 24.0) {
 						// We must use the reason found in the constant MAIN_VAT_EXEMPTION_CODE_FOR_0.00_XXXX
 						// List of VATEX: https://docs.peppol.eu/poacc/billing/3.0/codelist/vatex/
-						// TVA non applicable article 261-4 CGI (nature non soumis à TVA, comme médecin): VATEX-FR-CGI261-4
-						// TVA non applicable - Vente objet art :       VATEX-FR-I
-						// TVA non applicable - Vente objet antiquité : VATEX-FR-J
-						// TVA non applicable - Vente agence voyage:    VATEX-EU-D
-						// TVA non applicable - Debours (VAT paid by customer):  VATEX-EU-79-C
+						// TVA non applicable: article 261-4 CGI (comme médecin) VATEX-FR-CGI261-4, vente objet art
+						// VATEX-FR-I, vente objet antiquité VATEX-FR-J, vente agence voyage VATEX-EU-D,
+						// debours (VAT paid by customer) VATEX-EU-79-C
 						$vatex = '';
 
 						// We try to find code in the vat code definition in the dictionary table (code only because einvoice_vatex does not exists).

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -45,13 +45,10 @@ dol_include_once('einvoicing/class/utils/CtcFrPdfMerger.class.php');
 /**
  * FacturX Protocol Class
  *
- * This class handles the FacturX protocol implementation for generating
- * and managing electronic invoices according to the FacturX standard.
- * This also throw an error if data is not correct.
- *
- * This implementation is based on FacturX plugin developed by CAP REL.
- * It has been adapted and integrated into the EInvoicing module to provide
- * electronic invoicing capabilities compliant with the French Factur-X standard.
+ * This class handles the FacturX protocol implementation for generating and managing electronic
+ * invoices according to the FacturX standard. This also throw an error if data is not correct.
+ * Based on the FacturX plugin developed by CAP REL, adapted and integrated into the EInvoicing
+ * module to provide electronic invoicing capabilities compliant with the French Factur-X standard.
  *
  * @author  Eric Seigne <eric.seigne@cap-rel.fr>
  * 			Modified by mdaoud
@@ -135,12 +132,10 @@ class FacturXProtocol extends CIIProtocol
 		$filename = dol_sanitizeFileName($invoice->ref);
 		$filedir = getMultidirOutputCompat($invoice, '', 1);		// Example '/mydolibarr/documents/facture/FAYYMM-XXXX'
 
-		// Resolve the source PDF into which the Factur-X XML will be embedded.
-		// Priority:
-		//   1. $sourceFilePath provided by the generation hook (afterPDFCreation / afterODTCreation).
-		//      ODT/ODS models hand over the .odt path; the PDF rendition (MAIN_ODT_AS_PDF) shares the basename.
+		// Resolve the source PDF into which the Factur-X XML will be embedded, by priority:
+		//   1. $sourceFilePath from the generation hook (ODT/ODS: the MAIN_ODT_AS_PDF rendition shares the basename);
 		//   2. the most recent <ref>*.pdf already present in the output dir (manual generation, ODT output
-		//      like <ref>_Template.pdf for which last_main_doc is not maintained), excluding our own output.
+		//      like <ref>_Template.pdf for which last_main_doc is not maintained), excluding our own output;
 		//   3. legacy <ref>.pdf, regenerated with the default PDF model if missing.
 		$orig_pdf = '';
 		$fromodt = false;

--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -869,14 +869,10 @@ abstract class AbstractPDPProvider
 
 		$LastSyncDate = null;
 
-		// Retrieve the last synchronization timestamp from the database
-		// Note: The PDP API does not support per-document synchronization yet.
-		// We perform a global sync for all flows and track the last modification
-		// timestamp (tms) from the einvoicing_document table to determine
+		// Retrieve the last synchronization timestamp from the database.
+		// The PDP API does not support per-document synchronization yet: we perform a global sync for all
+		// flows and track the last modification timestamp (tms) of the einvoicing_document table to know
 		// which flows need to be synchronized since the last successful sync.
-		//
-		// Future enhancement: Individual document sync may be possible when
-		// the PDP provider API supports it.
 
 		$provider = (string) $this->providerName;
 		$providershort = '';
@@ -979,10 +975,9 @@ abstract class AbstractPDPProvider
 	 * Make an API payload safe to store in the utf8mb4 TEXT debug columns
 	 * (llx_einvoicing_call.response, llx_einvoicing_document.response_for_debug).
 	 *
-	 * Some PDP responses carry non-UTF-8 bytes (signed or compressed payloads): stored as-is
-	 * they raise a SQL error 1366 (Incorrect string value) and abort the flow. Valid UTF-8 is
-	 * kept unchanged; anything else is base64-encoded behind a marker so the trace stays both
-	 * storable and recoverable.
+	 * Some PDP responses carry non-UTF-8 bytes (signed or compressed payloads): stored as-is they raise a
+	 * SQL error 1366 (Incorrect string value) and abort the flow. Valid UTF-8 is kept unchanged; anything
+	 * else is base64-encoded behind a marker.
 	 *
 	 * @param   string|null $payload    Raw payload, possibly binary
 	 * @return  string                  UTF-8-safe representation

--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -509,14 +509,10 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 			$callRef = $response['call_id'];
 
 			/**
-			 * We make an additional call to retrieve the acknowledgment information and update the status.
-			 * However, document validation on the PDP side may take some time.
-			 * Therefore, we initially set the status to "Sent".
-			 *
-			 * We then try to fetch the PDP validation result:
+			 * Document validation on the PDP side may take some time, so we initially set the status to
+			 * "Sent", then make an additional call to retrieve the acknowledgment information:
 			 * - If the validation is successful, we update the status to "Sent (awaiting acknowledgment)".
 			 * - If the PDP validation fails, we set the status to "Error".
-			 *
 			 * If no response is available yet, we wait for the next synchronization.
 			 **/
 
@@ -1872,14 +1868,10 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 
 			if ($response['status_code'] == 200 || $response['status_code'] == 202) {
 				/**
-				 * We make an additional call to retrieve the acknowledgment information and update the status.
-				 * However, document validation on the PDP side may take some time.
-				 * Therefore, we initially set the status to "Sent".
-				 *
-				 * We then try to fetch the PDP validation result:
+				 * Document validation on the PDP side may take some time, so we initially set the status to
+				 * "Sent", then make an additional call to retrieve the acknowledgment information:
 				 * - If the validation is successful, we update the status of the electronic invoice accordingly.
 				 * - If the PDP validation fails, we set the status to "Error" and log the reason.
-				 *
 				 * If no response is available yet, we wait for the next synchronization.
 				 **/
 

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -1176,14 +1176,9 @@ class SuperPDPProvider extends AbstractPDPProvider
 			$callRef = $response['call_id'];
 
 			/**
-			 * We make an additional call to retrieve the acknowledgment information and update the status.
-			 * However, document validation on the PDP side may take some time.
-			 * Therefore, we initially set the status to "Sent".
-			 *
-			 * We then try to fetch the PDP validation result:
-			 * - If the validation is successful, we update the status to "Sent (awaiting acknowledgment)".
-			 * - If the PDP validation fails, we set the status to "Error".
-			 *
+			 * PDP validation may take some time, so we initially set the status to "Sent", then make an additional call
+			 * to retrieve the acknowledgment information: if the validation is successful we update the status to
+			 * "Sent (awaiting acknowledgment)", if it fails we set the status to "Error".
 			 * If no response is available yet, we wait for the next synchronization.
 			 **/
 
@@ -3061,14 +3056,9 @@ class SuperPDPProvider extends AbstractPDPProvider
 
 			if ($response['status_code'] == 200 || $response['status_code'] == 202) {
 				/**
-				 * We make an additional call to retrieve the acknowledgment information and update the status.
-				 * However, document validation on the PDP side may take some time.
-				 * Therefore, we initially set the status to "Sent".
-				 *
-				 * We then try to fetch the PDP validation result:
-				 * - If the validation is successful, we update the status of the electronic invoice accordingly.
-				 * - If the PDP validation fails, we set the status to "Error" and log the reason.
-				 *
+				 * PDP validation may take some time, so we initially set the status to "Sent", then make an additional
+				 * call to retrieve the acknowledgment information: if the validation is successful we update the status of
+				 * the electronic invoice accordingly, if it fails we set the status to "Error" and log the reason.
 				 * If no response is available yet, we wait for the next synchronization.
 				 **/
 

--- a/einvoicing/class/utils/CdarHandler.class.php
+++ b/einvoicing/class/utils/CdarHandler.class.php
@@ -273,18 +273,11 @@ class CdarHandler
 		global $conf, $mysoc;
 
 		/**
-		* Perhaps in future PDP updates, endpoints will appear to simplify sending lifecycle messages without going through CDARs.
-		* Currently, CDARs must be generated manually.
-		* The CDAR can/must contain several blocks; for some statuses, informational blocks must be added.
-		* We should try to create them with the minimum number of mandatory blocks.
-		* Blocks will be added based on PDP feedback.
-		* Perhaps we need to import the UN/CEFACT XSD files to validate the generated files.
-		* We start by processing the following cases:
-		* - Acceptance (204) - optional => Implemented
+		* CDARs must be generated manually, with the minimum number of mandatory blocks; more blocks
+		* will be added based on PDP feedback. We start by processing the following cases:
 		* - Rejection (210) - mandatory in the case of a rejection (The only mandatory status for now)
+		* - Acceptance (204) - optional => Implemented ; Acceptance (205) - optional
 		* - Payment transmitted (212) - optional but recommended
-		* - Acceptance (205) - optional
-		* Others can be added as needed.
 		*/
 
 		// Id format: {SupplierRef}_{StatusCode}_{CreationDate}#{DocType}_{CreationDate} as defined in documentation
@@ -306,12 +299,10 @@ class CdarHandler
 		$mysocGlobalID = idprof($mysoc);
 
 		// Issuer SIREN (0002) of the invoice the status is about: us when we sell, the vendor otherwise.
-		// For a received supplier invoice, the platform indexed the incoming flow under the identifier
-		// the vendor's PDP placed in SellerTradeParty.GlobalID — which may differ from the Dolibarr
-		// third-party SIREN (e.g. test environments where the PDP assigns synthetic identifiers, or a
-		// vendor whose card has not been kept up to date). Reading it from the stored XML is the only
-		// reliable way to reference the same invoice the platform knows. The same parse also yields the
-		// vendor's electronic address (BT-34), used further down for MDT-73 when no routing is recorded.
+		// For a received supplier invoice, the platform indexed the flow under the identifier the vendor's
+		// PDP placed in SellerTradeParty.GlobalID, which may differ from the Dolibarr third-party SIREN.
+		// Reading it from the stored XML is the only reliable way to reference the same invoice. The same
+		// parse also yields the vendor's address (BT-34), used below for MDT-73 when no routing is recorded.
 		$vendorIdentity = array('globalid' => '', 'uriid' => '');
 		if ($isOurOwnInvoice) {
 			$InvoiceIssuerGlobalID = $mysocGlobalID;

--- a/einvoicing/class/utils/En16931Validator.class.php
+++ b/einvoicing/class/utils/En16931Validator.class.php
@@ -20,15 +20,11 @@
  * \ingroup     einvoicing
  * \brief       Lightweight EN 16931 business-rules validator for generated CII invoices.
  *
- * Checks a focused subset of the EN 16931 business rules (BR, BR-CO) plus a few
- * CTC-FR ones (BR-FR) directly on the generated CrossIndustryInvoice XML, before
- * the file is stored/sent. This is NOT a replacement for the official Schematron
- * (still applied by the Approved Platform): it is a fast local safety net that
- * catches arithmetic inconsistencies (the most common generation bugs) with a
- * clear message, without a network call and for any PDP provider.
- *
- * Messages are technical by design (they quote the official rule id and the
- * amounts involved), like a validator report.
+ * Checks a focused subset of the EN 16931 business rules (BR, BR-CO) plus a few CTC-FR ones
+ * (BR-FR) directly on the generated CrossIndustryInvoice XML, before the file is stored/sent.
+ * This is NOT a replacement for the official Schematron (still applied by the Approved Platform):
+ * it is a fast local safety net that catches arithmetic inconsistencies, without a network call
+ * and for any PDP provider. Messages are technical (they quote the rule id and the amounts).
  */
 class En16931Validator
 {

--- a/einvoicing/class/utils/PriceHelper.class.php
+++ b/einvoicing/class/utils/PriceHelper.class.php
@@ -28,11 +28,9 @@ class PriceHelper
 {
 	/**
 	 * Modified version of core function calculate_price_total() from core/lib/price.lib.php :
-	 * - add a new parameter $forceRoundingTotalsPrecision to allow rounding totals with a more accurate precision using 'MU' instead of 'MT'
-	 * - native Dolibarr version is rounding totals using 'MT', but in some cases, like calculating totals in 2 different VAT modes (totalofround, roundoftotal),
-	 * it is required to not round returned totals using 'MT' but 'MU' to keep precision on results
-	 *
-	 * PR to do to modify native Dolibarr function calcul_price_total(), then this function could be deleted
+	 * - adds $forceRoundingTotalsPrecision to round totals with 'MU' instead of the native 'MT', required to
+	 * keep precision when totals are calculated in 2 different VAT modes (totalofround, roundoftotal)
+	 * - PR to do on the native function, then this function could be deleted
 	 *
 	 *		Calculate totals (net, vat, ...) of a line.
 	 *		Value for localtaxX_type are	'0' : local tax not applied

--- a/einvoicing/class/utils/SupplierInvoiceHelper.class.php
+++ b/einvoicing/class/utils/SupplierInvoiceHelper.class.php
@@ -56,12 +56,8 @@ class SupplierInvoiceHelper
 
 	/**
 	 * Compare a Dolibarr supplier invoice to its related e-invoice and check they are identical
-	 * using following criteria :
-	 * - Currency
-	 * - VAT excl. total
-	 * - VAT incl. total
-	 * - VAT total
-	 * - Basis amount & VAT amount of each VAT rate
+	 * using following criteria : currency, VAT excl. total, VAT incl. total, VAT total, basis
+	 * amount & VAT amount of each VAT rate
 	 *
 	 * @param FactureFournisseur $dolSupplierInvoice   The Dolibarr object to compare to e-invoice
 	 *
@@ -443,20 +439,11 @@ class SupplierInvoiceHelper
 	}
 
 	/**
-	 * Abandon a Dolibarr supplier invoice because its refusal has been confirmed by the
-	 * e-invoicing platform (PDP/PA). Validates the invoice first if it is still a draft, then
-	 * cancels it with a dedicated close code so it can be excluded from the accountancy
-	 * transfer screen (see ActionsEinvoicing::printFieldListWhere()).
-	 *
-	 * Idempotent: calling this again on an invoice already abandoned by this same rule is a
-	 * no-op. A paid invoice is never touched. This idempotence check reads $object->status and
-	 * $object->close_code from the in-memory object: $object must reflect the current database
-	 * state (i.e. freshly fetched) for it to be reliable.
-	 *
-	 * The validation step runs BILL_SUPPLIER_VALIDATE normally, including the e-invoice/Dolibarr
-	 * consistency check when EINVOICING_SUPPLIER_INVOICE_CHECK_CONSISTENCY_ON_VALIDATION is
-	 * enabled: if that check rejects the invoice, this method fails too (returns -1) rather than
-	 * abandoning it.
+	 * Abandon a Dolibarr supplier invoice because its refusal has been confirmed by the PDP/PA:
+	 * validates it if still a draft, then cancels it with a dedicated close code, excluded from the
+	 * accountancy transfer screen (see ActionsEinvoicing::printFieldListWhere()). A paid invoice is
+	 * never touched; the idempotence check needs a freshly fetched $object (status/close_code).
+	 * Validation runs BILL_SUPPLIER_VALIDATE: if its consistency check rejects, this method fails.
 	 *
 	 * @param	FactureFournisseur	$object			Supplier invoice to abandon
 	 * @param	User				$user			User (or system user, when called from a cron) triggering the change
@@ -662,13 +649,11 @@ class SupplierInvoiceHelper
 	}
 
 	/**
-	 * Callback to invoke once an outbound lifecycle status message has been validated (confirmed
-	 * or rejected by the e-invoicing platform). This is a no-op unless the message is a
-	 * confirmed ('Ok') refusal (EInvoicing::STATUS_REFUSED) of a supplier invoice, in which case
-	 * it abandons the corresponding Dolibarr supplier invoice (see abandonRefusedSupplierInvoice()).
-	 *
-	 * Errors are logged but never thrown: this callback must never break the caller that is
-	 * persisting the platform confirmation (see EInvoicing::updateStatusMessageValidation()).
+	 * Callback to invoke once an outbound lifecycle status message has been validated by the
+	 * e-invoicing platform. No-op unless the message is a confirmed ('Ok') refusal
+	 * (EInvoicing::STATUS_REFUSED) of a supplier invoice, then it abandons the Dolibarr supplier
+	 * invoice (see abandonRefusedSupplierInvoice()). Errors are logged but never thrown, to never
+	 * break the caller persisting the confirmation (see EInvoicing::updateStatusMessageValidation()).
 	 *
 	 * @param	DoliDB	$db					Database handler
 	 * @param	User	$user				User (or system user, when called from a cron) triggering the change

--- a/einvoicing/test/phpunit/BillingProcessIdTest.php
+++ b/einvoicing/test/phpunit/BillingProcessIdTest.php
@@ -31,12 +31,11 @@
 
 global $conf, $user, $langs, $db;
 
-// This module is deployed by symlinking this repository into htdocs/custom/einvoicing of one or
-// several Dolibarr instances. Some test runners resolve the real (non-symlinked) path of this
-// file before including it, which breaks a fixed "../../htdocs/master.inc.php" relative path.
-// DOLIBARR_HTDOCS let's the developer/CI point explicitly at the Dolibarr instance to test
-// against; otherwise we fall back to the standard relative path (valid when this file is reached
-// through the htdocs/custom/einvoicing/test/phpunit symlink without realpath resolution).
+// This module is deployed by symlinking this repository into htdocs/custom/einvoicing. Some test
+// runners resolve the real (non-symlinked) path of this file before including it, which breaks a
+// fixed "../../htdocs/master.inc.php" relative path. DOLIBARR_HTDOCS let's the developer/CI point
+// explicitly at the Dolibarr instance to test against; otherwise we fall back to the relative path
+// (valid when this file is reached through the symlink without realpath resolution).
 $dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
 if (!$dolibarrHtdocs) {
 	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';

--- a/einvoicing/test/phpunit/CIIProfileShapeTest.php
+++ b/einvoicing/test/phpunit/CIIProfileShapeTest.php
@@ -30,12 +30,11 @@
 
 global $conf, $user, $langs, $db;
 
-// This module is deployed by symlinking this repository into htdocs/custom/einvoicing of one or
-// several Dolibarr instances. Some test runners resolve the real (non-symlinked) path of this
-// file before including it, which breaks a fixed "../../htdocs/master.inc.php" relative path.
-// DOLIBARR_HTDOCS let's the developer/CI point explicitly at the Dolibarr instance to test
-// against; otherwise we fall back to the standard relative path (valid when this file is reached
-// through the htdocs/custom/einvoicing/test/phpunit symlink without realpath resolution).
+// This module is deployed by symlinking this repository into htdocs/custom/einvoicing. Some test
+// runners resolve the real (non-symlinked) path of this file before including it, which breaks a
+// fixed "../../htdocs/master.inc.php" relative path. DOLIBARR_HTDOCS let's the developer/CI point
+// explicitly at the Dolibarr instance to test against; otherwise we fall back to the relative path
+// (valid when this file is reached through the symlink without realpath resolution).
 $dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
 if (!$dolibarrHtdocs) {
 	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';

--- a/einvoicing/test/phpunit/CIIProtocolTest.php
+++ b/einvoicing/test/phpunit/CIIProtocolTest.php
@@ -34,12 +34,10 @@
 
 global $conf, $user, $langs, $db;
 
-// This module is deployed by symlinking this repository into htdocs/custom/einvoicing of one or
-// several Dolibarr instances. Some test runners resolve the real (non-symlinked) path of this
-// file before including it, which breaks a fixed "../../htdocs/master.inc.php" relative path.
-// DOLIBARR_HTDOCS let's the developer/CI point explicitly at the Dolibarr instance to test
-// against; otherwise we fall back to the standard relative path (valid when this file is reached
-// through the htdocs/custom/einvoicing/test/phpunit symlink without realpath resolution).
+// This module is deployed by symlinking this repository into htdocs/custom/einvoicing of one or several
+// Dolibarr instances. Some test runners resolve the real (non-symlinked) path of this file before including
+// it, which breaks a fixed "../../htdocs/master.inc.php" relative path. DOLIBARR_HTDOCS let's the developer/CI
+// point explicitly at the Dolibarr instance to test against; otherwise we fall back to the relative path.
 $dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
 if (!$dolibarrHtdocs) {
 	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
@@ -241,9 +239,8 @@ class CIIProtocolTest extends CommonClassTest
 
 	/**
 	 * When a line has both a period and a discount, BillingSpecifiedPeriod must still be
-	 * inserted before SpecifiedTradeAllowanceCharge (the discount block) - this is the exact
-	 * case that a naive "insert before MonetarySummation" implementation would get wrong,
-	 * since the CII D22B schema requires ApplicableTradeTax, then BillingSpecifiedPeriod, then
+	 * inserted before SpecifiedTradeAllowanceCharge (the discount block), since the CII D22B
+	 * schema requires ApplicableTradeTax, then BillingSpecifiedPeriod, then
 	 * SpecifiedTradeAllowanceCharge, then SpecifiedTradeSettlementLineMonetarySummation, in
 	 * that exact order.
 	 *

--- a/einvoicing/test/phpunit/CompatShimReloadTest.php
+++ b/einvoicing/test/phpunit/CompatShimReloadTest.php
@@ -37,12 +37,11 @@
 
 global $conf, $user, $langs, $db;
 
-// This module is deployed by symlinking this repository into htdocs/custom/einvoicing of one or
-// several Dolibarr instances. Some test runners resolve the real (non-symlinked) path of this
-// file before including it, which breaks a fixed "../../htdocs/master.inc.php" relative path.
-// DOLIBARR_HTDOCS let's the developer/CI point explicitly at the Dolibarr instance to test
-// against; otherwise we fall back to the standard relative path (valid when this file is reached
-// through the htdocs/custom/einvoicing/test/phpunit symlink without realpath resolution).
+// This module is deployed by symlinking this repository into htdocs/custom/einvoicing. Some test
+// runners resolve the real (non-symlinked) path of this file before including it, which breaks a
+// fixed "../../htdocs/master.inc.php" relative path. DOLIBARR_HTDOCS let's the developer/CI point
+// explicitly at the Dolibarr instance to test against; otherwise we fall back to the standard
+// relative path (valid when this file is reached through the symlink without realpath resolution).
 $dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
 if (!$dolibarrHtdocs) {
 	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';

--- a/einvoicing/test/phpunit/RecipientDirectoryTest.php
+++ b/einvoicing/test/phpunit/RecipientDirectoryTest.php
@@ -29,12 +29,11 @@
 
 global $conf, $user, $langs, $db;
 
-// This module is deployed by symlinking this repository into htdocs/custom/einvoicing of one or
-// several Dolibarr instances. Some test runners resolve the real (non-symlinked) path of this
-// file before including it, which breaks a fixed "../../htdocs/master.inc.php" relative path.
-// DOLIBARR_HTDOCS let's the developer/CI point explicitly at the Dolibarr instance to test
-// against; otherwise we fall back to the standard relative path (valid when this file is reached
-// through the htdocs/custom/einvoicing/test/phpunit symlink without realpath resolution).
+// This module is deployed by symlinking this repository into htdocs/custom/einvoicing. Some test
+// runners resolve the real (non-symlinked) path of this file before including it, which breaks a
+// fixed "../../htdocs/master.inc.php" relative path. DOLIBARR_HTDOCS let's the developer/CI point
+// explicitly at the Dolibarr instance to test against; otherwise we fall back to the relative path
+// (valid when this file is reached through the symlink without realpath resolution).
 $dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
 if (!$dolibarrHtdocs) {
 	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';

--- a/einvoicing/test/phpunit/SupplierInvoiceHelperTest.php
+++ b/einvoicing/test/phpunit/SupplierInvoiceHelperTest.php
@@ -30,12 +30,10 @@
 
 global $conf, $user, $langs, $db;
 
-// This module is deployed by symlinking this repository into htdocs/custom/einvoicing of one or
-// several Dolibarr instances. Some test runners resolve the real (non-symlinked) path of this
-// file before including it, which breaks a fixed "../../htdocs/master.inc.php" relative path.
-// DOLIBARR_HTDOCS let's the developer/CI point explicitly at the Dolibarr instance to test
-// against; otherwise we fall back to the standard relative path (valid when this file is reached
-// through the htdocs/custom/einvoicing/test/phpunit symlink without realpath resolution).
+// This module is deployed by symlinking this repository into htdocs/custom/einvoicing. Some test runners
+// resolve the real (non-symlinked) path of this file before including it, which breaks a fixed
+// "../../htdocs/master.inc.php" relative path. DOLIBARR_HTDOCS let's the developer/CI point explicitly at
+// the Dolibarr instance to test against; otherwise we fall back to the standard relative path.
 $dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
 if (!$dolibarrHtdocs) {
 	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';


### PR DESCRIPTION
## Why

Same rule as #819, applied to what that one deliberately left alone. The `Comments` section of
`.agents/AGENTS.md` asks for comments of five lines at most; #819 only shortened the blocks I had
written myself, and said so. This one takes the blocks written by the other contributors.

## What changes

Comments only, in 19 files: **217 comment lines removed, 111 rewritten**, zero non-comment line
touched. 31 blocks, the largest going from 17 lines to 4.

The bar was set high on purpose, because these are not my sentences:

- a block is shortened only when it is **prose**. Commented-out code and the modulebuilder skeleton
  (`'type' field format:`, `uncomment lines below if you want to ...`, the `//define('NOREQUIREDB')`
  stack, the example menus) are left untouched: shortening them would make our files diverge from
  the upstream template for nothing. That is 51 of the 101 blocks measured;
- `PriceHelper` carries the docblock of the core `price.lib.php` verbatim - left as it is, so the
  port keeps matching its source;
- what carries a rule, a status label, a constant name or a step order is kept **word for word**,
  including the language mistakes of the original. Only the repetitions, the long examples and the
  design justifications go;
- a block whose meaning was not certain was left alone rather than guessed at.

## The code is unchanged, and this is proven rather than asserted

For each of the 19 files, the PHP token stream - `token_get_all()` stripped of `T_COMMENT`,
`T_DOC_COMMENT` and `T_WHITESPACE` - is **identical to the one of the parent commit**.

`php -l`, the phpcs ruleset of the repository and phan (run as the CI runs it) are clean. On the
bench: 39 PHPUnit files green on the seven cores 18 to 24, one full sandbox cycle (invoice emitted,
routed by the platform, received on the other instance with its line periods, statuses 200 and 201
back), and the generation matrix - seven invoice types in CII and in Factur-X, fourteen documents,
no error.

## Merging

This PR stands alone on `main`. With #819 and my five other open pull requests (#696, #706, #717,
#785, #809), every pair merges with no conflict, and the eight branches merged in three different
orders give the **same tree, byte for byte**. They can be merged in any order.

No ChangeLog entry, per `.agents/AGENTS.md`.
