### PR TITLE
FIX einvoicing: give imported supplier invoice lines a rank

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -732,6 +732,10 @@ class CIIProtocol extends AbstractProtocol
 	 */
 	public function createSupplierInvoiceLinesIntoDatabase(FactureFournisseur $supplierInvoice): bool
 	{
+		// Start after the lines already written: this runs a second time for the document level charges
+		// (BG-21). line_max() is what addline() itself calls to resolve its $rang = -1.
+		$rang = (int) $supplierInvoice->line_max();
+
 		foreach ($supplierInvoice->lines as $i => $val) {
 			$sql = 'INSERT INTO '.MAIN_DB_PREFIX.'facture_fourn_det (fk_facture_fourn, special_code, fk_remise_except)';
 			/** @phan-suppress-next-line PhanUndeclaredProperty */
@@ -740,6 +744,7 @@ class CIIProtocol extends AbstractProtocol
 			$resql_insert = $this->db->query($sql);
 			if ($resql_insert) {
 				$idligne = $this->db->last_insert_id(MAIN_DB_PREFIX.'facture_fourn_det');
+				$rang++;
 
 				$res = $supplierInvoice->updateline(
 					$idligne,
@@ -764,7 +769,8 @@ class CIIProtocol extends AbstractProtocol
 					$supplierInvoice->lines[$i]->fk_unit,
 					$supplierInvoice->lines[$i]->multicurrency_subprice,
 					/** @phan-suppress-next-line PhanUndeclaredProperty */
-					$supplierInvoice->lines[$i]->ref_supplier
+					$supplierInvoice->lines[$i]->ref_supplier,
+					$rang
 				);
 
 				if ($res < 0) {


### PR DESCRIPTION
Every line of a supplier invoice created by importing a received e-invoice carries `rang = 0`.
`fetch_lines()` orders by `rang, rowid`, so the order of an imported invoice only holds by accident,
and the up/down arrows of the card have nothing to work with.

`FactureFournisseur::updateline()` already takes the rank as its 20th argument on all seven supported
cores — 18.0.10, 19.0.4, 20.0.4, 21.0.4, 22.0.5, 23 and 24 — and persists it:
`$line->rang = $rang` then `SupplierInvoiceLine::update()` writes the column. The call in
`CIIProtocol::createSupplierInvoiceLinesIntoDatabase()` simply never passed it.

The starting rank comes from `CommonObject::line_max()`, which is the very method `addline()` uses to
resolve `$rang = -1`, rather than a hand-written `SELECT max(rang)`. It matters here because that
writer is called **twice** on the same invoice: once for the lines of the document, then again by
`createHeaderChargeLines()` for a document level charge (BG-21), on a freshly fetched object. A
counter restarting at 1 would overwrite the order of the first pass; `line_max()` reads the database,
so the second pass continues where the first stopped.

Note that `SupplierInvoiceLine::update()` guards the column with `if (!empty($this->rang))`, so the
counter starts at 1 and never at 0.

Measured on a bench running the seven cores, importing three lines then a document level charge, and
reading `llx_facture_fourn_det` back:

| | ranks written |
|---|---|
| before | `0, 0, 0, 0` |
| after, on 18 and on 24 | `1, 2, 3, 4` |

PHPUnit: 39/39 on each of the seven cores, unchanged from `main`. `ExportImportRoundTripTest` is the
only existing test that walks this writer; its assertion that the lines come back in the order they
were sent used to hold by `rowid` alone, and now holds by rank.

No PHPUnit file is added, per the rule in `.agents/AGENTS.md`. What a test would add here, and what
nothing covers today, is exactly the second-pass case measured above: the round trip test uses a
document with no header charge, so it never reaches `createHeaderChargeLines()`. Say the word and I
will add it.

This change is deliberately orthogonal to #821: it does not move this path to `addline()`, and it
does not touch the pricing of an imported line.
