### PR TITLE
QUAL einvoicing: one test file per source file under test, checked by the CI

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -166,6 +166,7 @@ Before any modification, verify:
 
 If adding a unit test was explicitely requested:
 - If making or modifying external module, add PHPUnit test files in `yourmoduledir/test/phpunit/`.
+- **One test file per source file under test**: a new case goes into the test file of the class or library file it exercises, as a new method. Create a file only when that source file has no test file yet, and split by direction (export / import) rather than by issue when a file grows past about a thousand lines. The CI reads what a test file loads with `dol_include_once()` and refuses a new file whose source already has one.
 - If you need to validate code change or if it is explicitely requested, you can check code and dev syntax rules by running the following command on modified files (it takes a long time):
 	`phan -k .phan/config.php -B dev/tools/phan/baseline.txt --analyze-twice --minimum-target-php-version 7.2 --exclude-directory-list=dev/tools,mymodule/test/,mymodule/vendor/ --output-mode=checkstyle filemodified1.php filemodified2.php ...`
 

--- a/.github/scripts/check-test-file-placement.php
+++ b/.github/scripts/check-test-file-placement.php
@@ -1,0 +1,123 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    .github/scripts/check-test-file-placement.php
+ * \brief   Refuses a new PHPUnit file when the module source it tests already has one.
+ * \remarks A test file costs a class, a bootstrap, a header and one more place to look; a method in
+ *          an existing file costs a method. The rule is one test file per source file under test,
+ *          and what a file tests is read from its own dol_include_once() lines. Only files ADDED by
+ *          the pull request are checked, so the existing suite is never a reason to fail.
+ *
+ *          Usage: php .github/scripts/check-test-file-placement.php <base ref>
+ */
+
+if (PHP_SAPI !== 'cli') {
+	echo "Error: this script must be run from the command line.\n";
+	exit(1);
+}
+
+$base = (string) ($argv[1] ?? '');
+if ($base === '') {
+	fwrite(STDERR, "usage: check-test-file-placement.php <base ref>\n");
+	exit(2);
+}
+
+/**
+ * Sources of a module a test file loads, which is what it is a test of.
+ *
+ * @param	string	$content	Content of a test file
+ * @return	string[]			Sorted module source paths, without duplicates
+ */
+function tested_sources($content)
+{
+	preg_match_all("/dol_include_once\('([^']+)'\)/", (string) $content, $matches);
+	$sources = array_values(array_unique($matches[1]));
+	sort($sources);
+
+	return $sources;
+}
+
+/**
+ * Content of a file as the base branch holds it.
+ *
+ * @param	string	$base	Base ref
+ * @param	string	$path	Path of the file
+ * @return	string			Content, empty when the ref does not carry it
+ */
+function content_at_base($base, $path)
+{
+	$out = array();
+	$rc = 0;
+	exec('git show ' . escapeshellarg($base . ':' . $path) . ' 2>/dev/null', $out, $rc);
+
+	return ($rc === 0) ? implode("\n", $out) : '';
+}
+
+exec('git diff --name-only --diff-filter=A ' . escapeshellarg($base) . '...HEAD 2>&1', $added, $rc);
+if ($rc !== 0) {
+	// No usable history (a shallow clone, a branch that left no merge base): say so and let the
+	// pull request through rather than failing on the checkout.
+	echo "::notice::test file placement not checked, no diff against " . $base . "\n";
+	exit(0);
+}
+
+// A pull request that regroups files adds one and removes several: what it removes tested the same
+// sources, so such a file is a consolidation and not one more place to look.
+$removed = array();
+exec('git diff --name-only --diff-filter=D ' . escapeshellarg($base) . '...HEAD 2>/dev/null', $deleted);
+foreach ($deleted as $file) {
+	$file = trim($file);
+	if (preg_match('#^[^/]+/test/phpunit/\w+Test\.php$#', $file)) {
+		$removed[] = tested_sources(content_at_base($base, $file));
+	}
+}
+
+$errors = array();
+foreach ($added as $file) {
+	$file = trim($file);
+	if (!preg_match('#^([^/]+)/test/phpunit/\w+Test\.php$#', $file, $m)) {
+		continue;
+	}
+	$module = $m[1];
+	$sources = tested_sources((string) @file_get_contents($file));
+	if (!$sources || in_array($sources, $removed, true)) {
+		continue;
+	}
+
+	foreach ((array) glob($module . '/test/phpunit/*Test.php') as $existing) {
+		if (in_array($existing, array_map('trim', $added), true)) {
+			continue;
+		}
+		if (tested_sources((string) @file_get_contents($existing)) === $sources) {
+			$errors[] = $file . ' tests ' . implode(', ', $sources) . ', and so does ' . $existing
+				. ': add a test method to ' . basename($existing) . ' instead of a new file.';
+			break;
+		}
+	}
+}
+
+if ($errors) {
+	foreach ($errors as $error) {
+		echo '::error::' . $error . "\n";
+	}
+	echo "\nOne test file per source file under test: a new case belongs in the file of the class or\n";
+	echo "library file it exercises. Create a file only when that source has no test file yet.\n";
+	exit(1);
+}
+
+echo "Test file placement: nothing to say.\n";

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -49,3 +49,9 @@ jobs:
         run: var-dump-check --extensions php --tracy --exclude */vendor/* .
       - name: Run Parallel Lint
         run: parallel-lint --exclude einvoicing/vendor/ --exclude dev/tools/phan/stubs/ .
+      - name: One test file per source file under test
+        # Only files this pull request ADDS are looked at, so the existing suite never fails the job.
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --quiet origin "${{ github.base_ref }}"
+          php .github/scripts/check-test-file-placement.php FETCH_HEAD


### PR DESCRIPTION
Test files grow one per pull request. A file costs a class, a bootstrap, a header and one more place to look; a method in an existing file costs a method — so the suite grows in the expensive direction by default.
This adds the rule to `.agents/AGENTS.md` and has the CI apply it, so it does not depend on anyone remembering: **one test file per source file under test**.
The check reads what a test file loads with `dol_include_once()` and refuses a new file when an existing one already tests exactly the same sources, naming the file to extend instead.
Only files the pull request **adds** are looked at: the existing suite is never a reason to fail, and nothing has to be cleaned up first.
A pull request that regroups files is let through: when it also deletes a test file that loaded the same sources, the new file consolidates rather than adds.
It runs as one step of the phpcs job — no new workflow, no new checkout, a few milliseconds.
Verified all three ways on this branch: a new file loading `einvoicing.lib.php` is refused and pointed at `InvoicingPeriodTest.php`, a file loading a combination nothing else loads passes, and a regrouping that removes six files to add one passes.


**#828 is built on top of this one** and carries its commit, so this pull request is merged first. There, the step below is gated on the `steps.scope` outputs that #828 introduces — skipped when no PHP file changed, since a translation or a workflow cannot add a test file.
