### PR TITLE
FIX: [einvoicing] The module no longer shows a raw translation key

### DIFF
--- a/einvoicing/admin/setup.php
+++ b/einvoicing/admin/setup.php
@@ -78,7 +78,7 @@ require_once "../class/einvoicing.class.php";
 
 
 // Translations
-$langs->loadLangs(array("admin", "einvoicing@einvoicing"));
+$langs->loadLangs(array("admin", "agenda", "einvoicing@einvoicing"));
 
 // Initialize a technical object to manage hooks of page. Note that conf->hooks_modules contains an array of hook context
 /** @var HookManager $hookmanager */

--- a/einvoicing/admin/setup_devtools.php
+++ b/einvoicing/admin/setup_devtools.php
@@ -334,7 +334,7 @@ if (getDolGlobalString('EINVOICING_PDP')) {
 	print '<span class="width150 inline-block">'.$langs->trans("InvoiceType").'</span> ';
 	if ((float) DOL_VERSION >= 24.0) {
 		$typeofinvoice = array(
-			Facture::TYPE_STANDARD => array('label' => $langs->trans('Standard')),
+			Facture::TYPE_STANDARD => array('label' => $langs->trans('InvoiceStandard')),
 			Facture::TYPE_REPLACEMENT => array('label' => $langs->trans('ReplacementInvoice')),
 			Facture::TYPE_DEPOSIT => array('label' => $langs->trans('Deposit')),
 			Facture::TYPE_CREDIT_NOTE => array('label' => $langs->trans('CreditNote')),
@@ -342,7 +342,7 @@ if (getDolGlobalString('EINVOICING_PDP')) {
 		);
 		print $form->selectarray('invoicetype', $typeofinvoice, GETPOSTISSET('invoicetype') ? GETPOSTINT('invoicetype') : Facture::TYPE_STANDARD, 0, 0, 0, '', 0, 0, 0, '', 'minwidth300');
 	} else {
-		print $langs->trans("Standard");
+		print $langs->trans("InvoiceStandard");
 	}
 
 	// Referenced invoice

--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -197,7 +197,7 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 				$item->fieldOverride = htmlspecialchars('**************' . substr($tokenData['token'], -4));
 
 				if (!empty($tokenData['token_expires_at'])) {
-					$item->fieldOverride .= ' &nbsp; <span class="opacitymedium hideonsmartphone">(' . $langs->trans("until") . ' ' . dol_print_date($tokenData['token_expires_at'], 'dayhoursec', 'tzuserrel') . ')</span>';
+					$item->fieldOverride .= ' &nbsp; <span class="opacitymedium hideonsmartphone">(' . $langs->trans("Until") . ' ' . dol_print_date($tokenData['token_expires_at'], 'dayhoursec', 'tzuserrel') . ')</span>';
 				}
 				//var_dump($tokenData);
 			}
@@ -417,7 +417,7 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 			return array('res' => -1, 'message' => $langs->trans('NoAvailableValidatorforThisAccessPoint'));
 		}
 
-		return array('res' => 0, 'message' => $langs->trans('skipped'));
+		return array('res' => 0, 'message' => $langs->trans('Skipped'));
 	}
 
 	/**

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -421,7 +421,7 @@ class SuperPDPProvider extends AbstractPDPProvider
 						$item->fieldOverride = htmlspecialchars('**************' . substr($tokenData['token'], -4));
 
 						if (!empty($tokenData['token_expires_at'])) {
-							$item->fieldOverride .= ' &nbsp; <span class="opacitymedium hideonsmartphone">(' . $langs->trans("until") . ' ' . dol_print_date($tokenData['token_expires_at'], 'dayhoursec', 'tzuserrel') . ')</span>';
+							$item->fieldOverride .= ' &nbsp; <span class="opacitymedium hideonsmartphone">(' . $langs->trans("Until") . ' ' . dol_print_date($tokenData['token_expires_at'], 'dayhoursec', 'tzuserrel') . ')</span>';
 						}
 						//var_dump($tokenData);
 					}

--- a/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
+++ b/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
@@ -520,7 +520,7 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 		$result = $provider->sendStatusMessage($invoice, 212, '', array('amount' => $amount));
 
 		if ($result['res'] > 0) {
-			setEventMessage($langs->trans("ModuleEInvoicingName").' : '.$langs->trans('EInvStatus212Paid'), 'mesgs');
+			setEventMessage($langs->trans("ModuleEInvoicingName").' : '.$langs->trans('EInvStatus212PaymentReceived'), 'mesgs');
 		} else {
 			dol_syslog(__METHOD__ . ' Failed to send paid status (212) to platform for invoice id=' . $invoice->id . ' : ' . $result['message'], LOG_ERR);
 			setEventMessage($langs->trans("ModuleEInvoicingName").' : '.$result['message'], 'errors');

--- a/einvoicing/document_agenda.php
+++ b/einvoicing/document_agenda.php
@@ -94,7 +94,7 @@ dol_include_once('/einvoicing/class/document.class.php');
 dol_include_once('/einvoicing/lib/einvoicing_document.lib.php');
 
 // Load translation files required by the page
-$langs->loadLangs(array("einvoicing@einvoicing", "other"));
+$langs->loadLangs(array("einvoicing@einvoicing", "other", "agenda", "commercial"));
 
 // Get parameters
 $id = GETPOSTINT('id');

--- a/einvoicing/document_document.php
+++ b/einvoicing/document_document.php
@@ -235,7 +235,7 @@ print '<table class="border centpercent tableforfield">';
 print '<tr><td class="titlefield">'.$langs->trans("NbOfAttachedFiles").'</td><td colspan="3">'.count($filearray).'</td></tr>';
 
 // Total size
-print '<tr><td>'.$langs->trans("TotalSizeOfAttachedFiles").'</td><td colspan="3">'.$totalsize.' '.$langs->trans("bytes").'</td></tr>';
+print '<tr><td>'.$langs->trans("TotalSizeOfAttachedFiles").'</td><td colspan="3">'.$totalsize.' '.$langs->trans("Bytes").'</td></tr>';
 
 print '</table>';
 

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -7,6 +7,19 @@
 ModuleEInvoicingName = EInvoicing
 ModuleEInvoicingDesc = Support for E-invoice management. This module allows generating (automatically or manually) invoices in E-invoice format and send them to an E-invoice Access Point. It can also retrieve purchase invoices from this E-invoice Access Point. Only a few countries (France) and Access Points (also called PDP/PA) are supported.
 
+# Keys of the core that the supported cores do not all carry: absent from 18 (RefSupplierBill), 18-19
+# (AccessToken, Message), 18-21 (Automatic, Input, Output), 18-22 (InvoiceType) or 18-23 (the rest).
+AccessToken=Access Token
+Message=Message
+RefSupplierBill=Supplier invoice ref
+Automatic=Automatic
+ErrorThirdPartyNotFound=Error ThirdParty Not Found
+Input=Input
+InvoiceType=Invoice type
+Output=Output
+Success=Success
+VATExemptionCode=VAT exemption code
+
 #
 # Admin page
 #
@@ -178,6 +191,7 @@ DateSyncro=Sync date
 Status=Status
 call_id=Call ID
 flow_id=Flow ID
+FlowId=Flow ID
 tracking_idref=Tracking Ref
 flow_type=Flow type
 flow_direction=Direction
@@ -199,6 +213,18 @@ cdar_reason_detail=LC Reason details
 ack_status=Acknowledgement status
 ack_reason_code=Acknowledgement reason code
 ack_info=Acknowledgement details
+
+# Cards, lists and error paths of the two objects of the module (document_card.php, call_card.php)
+Document=Document
+ShowDocument=Show document
+DeleteDocument=Delete document
+ShowCall=Show call
+DeleteCall=Delete call
+Failed=Failed
+Skipped=Skipped
+ClassNotFound=Class not found
+ErrorNumberingModuleNotSetup=Numbering module not set up for %s
+ErrorLoadingInvoice=Failed to load the invoice
 PASettings=Access Point Settings (PA, PDP...)
 EInvoicingInfo=As part of the French electronic invoicing law, any invoicing software must allow the sending and receiving of invoices. This is achieved through communication with an approved private partner called a PA (formerly PDP). This module enables bi-directional synchronization between your Dolibarr and a PA. The module is free, but the PA you choose will most likely charge subscription fees (The contract is drawn up directly with the PA %s).
 EInvoicingInfoProxy= Or via %s
@@ -357,6 +383,11 @@ VATOnDebitsMention=Option for the payment of VAT on debits
 CurrentAP=Current access point: %s
 CreatedManually=Created manually
 DevTools=Dev tools
+
+# Generation page of the developer tools (admin/setup_devtools.php)
+MyCompany=My company
+Seller=Seller
+Buyer=Buyer
 YourSoftwareSeemsConnectedWith=Your software seems linked to the E-invoicing Access Point Platform %s
 YourSoftwareDoesNotSeemsConnectedWith=Your software does NOT appear to be linked to an E-invoicing Access Point Platform yet. Go into the e-invoicing module setup to connect it.
 ClickHereToRemoveConnection=Click here to remove this connection
@@ -434,6 +465,7 @@ EinvoicingCantUnvalidateATransmittedInvoice=You are trying to modify the status 
 EinvoicingCantModifyATransmittedInvoice=You are trying to modify a property that is locked once the invoice has been transmitted to the Access Point
 SendingStatus=Sending status
 CheckingStatus=Checking status
+CheckStatus=Check status
 
 EINVOICING_CLIENT_ID=Client ID
 EINVOICING_CLIENT_SECRET=Client secret

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -42,7 +42,7 @@ function einvoicingAdminPrepareHead()
 	// $extrafields = new ExtraFields($db);
 	// $extrafields->fetch_name_optionals_label('myobject');
 
-	$langs->load("einvoicing@einvoicing");
+	$langs->loadLangs(array("accountancy", "einvoicing@einvoicing"));
 
 	$h = 0;
 	$head = array();


### PR DESCRIPTION
Twenty-seven translation keys the module asks for with a literal argument are defined by no
`en_US` file the page loads — neither the module's nor the core's — on at least one supported
core. Dolibarr then prints the key itself: `Document` as the title of a document card,
`CheckStatus` in the agenda event written after a status check, `Failed` as the status of an API
call, `until` next to the expiry of the access token.

## What is in here

- **15 keys added to `en_US`**, none of which any supported core defines: `Document`,
  `ShowDocument`, `DeleteDocument`, `ShowCall`, `DeleteCall`, `Failed`, `Skipped`,
  `ClassNotFound`, `ErrorNumberingModuleNotSetup`, `ErrorLoadingInvoice`, `FlowId`,
  `CheckStatus`, `MyCompany`, `Seller`, `Buyer`.
- **10 keys the core added along the way**, so they are missing on the older cores the module
  supports: `RefSupplierBill` is absent from 18, `AccessToken` and `Message` from 18 to 19,
  `Automatic`, `Input` and `Output` from 18 to 21, `InvoiceType` up to 22, and
  `ErrorThirdPartyNotFound`, `Success` and `VATExemptionCode` up to 23. They are added with the
  wording of the core, so nothing changes on 24.
- **2 keys live in a core lang file the page does not load**, on every supported core: `Until`
  in `agenda.lang` and `Options` in `accountancy.lang`. The setup page and the admin tabs now load
  those files, and the module carries no copy of the key. On a French instance the token line of
  the setup page reads `(jusqu'à …)` where `main` shows `(until …)`, the raw key it asks for.
- **6 call sites named a key that already exists**: `EInvStatus212Paid` is
  `EInvStatus212PaymentReceived`, the status label of this module; `bytes` and `Standard` are
  `Bytes` and `InvoiceStandard` in the core. And the agenda tab of a document asks for three
  keys of `agenda.lang` and `commercial.lang` without loading them, so it now does.

Only `en_US` is touched, the other languages are left to Transifex.

## Measurement

A script loads each instance through `Translate` and asks the loader, for the literal keys the
module passes to `trans()`, whether it knows them at all. On the seven supported cores:

| | 18.0.10 | 19.0.4 | 20.0.4 | 21.0.4 | 22.0.5 | 23.0.4 | 24.0.1 |
|---|---|---|---|---|---|---|---|
| main | 33 | 32 | 30 | 30 | 27 | 26 | 23 |
| this branch | 0 | 0 | 0 | 0 | 0 | 0 | 0 |

Each key added to `en_US` was also checked by hand against every `en_US` file of the seven
cores: the 15 exist in none of them, the 10 only from the version stated above.

The PHPUnit suite of the module, 39 files, passes on those same seven cores.

The check itself is not added to the CI here: it wants a Dolibarr instance, so its place is a
step of the `einvoicing_phpunit` job, and that file is being changed elsewhere. Happy to add it
once that lands, if you want the guard.
