### PR TITLE
QUAL: the reviewer assignment no longer runs on a push to main

### DIFF
--- a/.github/workflows/ci-pr-autoassign.yml
+++ b/.github/workflows/ci-pr-autoassign.yml
@@ -15,7 +15,6 @@
 #     - Assign the reviewers listed below, excluding the PR author
 #       -> attempt per reviewer (if a reviewer fails, log and continue)
 #       -> the step fails only if no reviewer could be added
-# - On push: workflow runs but PR-specific actions are skipped
 #
 name: Set reviewers and label according to module MAINTENERS
 
@@ -27,9 +26,6 @@ permissions:
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
-    branches:
-      - "main"
-  push:
     branches:
       - "main"
 
@@ -280,9 +276,3 @@ jobs:
           else
             echo "Reviewers added: ${SUCCESS}. Failed to add: ${FAILED[*]:-none}"
           fi
-
-      # 6) Push event notice (no PR-specific actions performed)
-      - name: Push event notice
-        if: ${{ github.event_name == 'push' }}
-        run: |
-          echo "Triggered by push on branch. No PR-specific actions performed."


### PR DESCRIPTION
Every step of this job is guarded by `github.event_name == 'pull_request_target'`. On a push to
`main` the job therefore generates a GitHub App token, checks out the repository, prints
"Triggered by push on branch. No PR-specific actions performed." and stops.

That is about twenty runs a day doing nothing. The `push` trigger is removed, along with the step
that printed that message.

Nothing changes on a pull request: the `opened`, `synchronize` and `reopened` types are kept -
`synchronize` earns its place, it replays the "a PR must impact one module at once" check when the
pull request changes.

Split out of #828 so it can be judged on its own, since it touches a file that is not mine.
