### PR TITLE
Fix XSS: escape received e-invoice fields shown in the sync results panel

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -887,7 +887,7 @@ class CIIProtocol extends AbstractProtocol
 		}
 
 		if ($supplierInvoiceId > 0) {
-			$return_messages[] = 'Supplier Invoice with reference ' . $parsedHeader['documentno'] . ' already exists';
+			$return_messages[] = 'Supplier Invoice with reference ' . dol_escape_htmltag((string) ($parsedHeader['documentno'] ?? '')) . ' already exists';
 
 			$supplierInvoice = new FactureFournisseur($db);
 			$supplierInvoice->fetch($supplierInvoiceId);
@@ -948,7 +948,7 @@ class CIIProtocol extends AbstractProtocol
 					return [
 						'res' => -1,
 						'postponeflow' => 1,
-						'message' => 'Document ' . $refDoc . ', required by received document ' . $parsedHeader['documentno'] . ', was not found in Dolibarr',
+						'message' => 'Document ' . dol_escape_htmltag((string) $refDoc) . ', required by received document ' . dol_escape_htmltag((string) ($parsedHeader['documentno'] ?? '')) . ', was not found in Dolibarr',
 						'actioncode' => 'LINKED_INVOICE_NOT_FOUND',
 						'actionurl' => 'none',
 						'actiondata' => array('supplierref' => $refDoc, 'linkedref' => ($parsedHeader['documentno'] ?? ''), 'socid' => (int) $socId),
@@ -966,7 +966,7 @@ class CIIProtocol extends AbstractProtocol
 		// Set basic invoice information (type, date)
 		$supplierInvoice->type = $this->getDolibarrInvoiceType($parsedHeader['documenttypecode'] ?? null);
 		if ($supplierInvoice->type === '-1') {
-			return ['res' => -1, 'message' => 'Unfounded dolibarr corresponding Invoice code for document type code: ' . ($parsedHeader['documenttypecode'] ?? 'NA')];
+			return ['res' => -1, 'message' => 'Unfounded dolibarr corresponding Invoice code for document type code: ' . dol_escape_htmltag((string) ($parsedHeader['documenttypecode'] ?? 'NA'))];
 		}
 		// documentdate is already formatted into 'Y-m-d' by the parser ZugFerd and CII
 		$supplierInvoice->date = !empty($parsedHeader['documentdate']) ? dol_stringtotime($parsedHeader['documentdate']) : null;
@@ -1071,7 +1071,7 @@ class CIIProtocol extends AbstractProtocol
 						return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($linkedObjectId, $refDoc, 'required by received document ' . ($parsedHeader['documentno'] ?? ''))];
 					}
 					if ($linkedObjectId == 0) {
-						return ['res' => -1, 'message' => 'Document ' . $refDoc . ', required by received document ' . $parsedHeader['documentno'] . ', was not found in Dolibarr'];
+						return ['res' => -1, 'message' => 'Document ' . dol_escape_htmltag((string) $refDoc) . ', required by received document ' . dol_escape_htmltag((string) ($parsedHeader['documentno'] ?? '')) . ', was not found in Dolibarr'];
 					}
 
 					// Fetch Object
@@ -1110,7 +1110,7 @@ class CIIProtocol extends AbstractProtocol
 						// Reached only when fetch() failed on an id findIdByRef() did return, so the reference
 						// was matched and it is the loading that went wrong: saying "not found" here sent the
 						// reader looking for a missing invoice that is in fact there.
-						return ['res' => -1, 'message' => 'Document ' . $refDoc . ', required by received document ' . $parsedHeader['documentno'] . ', matches supplier invoice id ' . ((int) $linkedObjectId) . ' but that invoice could not be loaded'];
+						return ['res' => -1, 'message' => 'Document ' . dol_escape_htmltag((string) $refDoc) . ', required by received document ' . dol_escape_htmltag((string) ($parsedHeader['documentno'] ?? '')) . ', matches supplier invoice id ' . ((int) $linkedObjectId) . ' but that invoice could not be loaded'];
 					}
 				}
 			}
@@ -1260,7 +1260,7 @@ class CIIProtocol extends AbstractProtocol
 					if ($linkedObjectId == 0) {
 						return [
 							'res' => -1,
-							'message' => 'Document "' . $lineRefDocId . '" linked to line ' . $parsedLine['lineid'] . ' was not found in Dolibarr. Please verify why this document is missing (deleted, not imported, or not provided by the supplier). To resolve this issue, you must manually create the invoice using the supplier invoice reference "' . $lineRefDocId . '".'
+							'message' => 'Document "' . dol_escape_htmltag((string) $lineRefDocId) . '" linked to line ' . dol_escape_htmltag((string) $parsedLine['lineid']) . ' was not found in Dolibarr. Please verify why this document is missing (deleted, not imported, or not provided by the supplier). To resolve this issue, you must manually create the invoice using the supplier invoice reference "' . dol_escape_htmltag((string) $lineRefDocId) . '".'
 						];
 						// TODO: Add a check before sending a final invoice after deposit to ensure that the deposit invoice has been properly sent to the PDP and successfully received.
 					}
@@ -1293,7 +1293,7 @@ class CIIProtocol extends AbstractProtocol
 						 * document types such as credit notes, etc.
 						 */
 					} else {
-						return ['res' => -1, 'message' => 'Document : ' . $lineRefDocId . ' linked to line ' . $parsedLine['lineid'] . ' not found in Dolibarr'];
+						return ['res' => -1, 'message' => 'Document : ' . dol_escape_htmltag((string) $lineRefDocId) . ' linked to line ' . dol_escape_htmltag((string) $parsedLine['lineid']) . ' not found in Dolibarr'];
 					}
 				}
 			}

--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -788,7 +788,7 @@ trait CommonProtocol
 				dol_syslog(get_class($this) . '::_syncOrCreateThirdpartyFromEInvoiceSeller Error updating thirdparty: ' . implode(',', array_merge(array($thirdparty->error), $thirdparty->errors)), LOG_ERR);
 				return array(
 					'res' => -1,
-					'message' => 'Thirdparty update error: ' . implode(',', array_merge(array($thirdparty->error), $thirdparty->errors)).'.'
+					'message' => 'Thirdparty update error: ' . dol_escape_htmltag(implode(',', array_merge(array($thirdparty->error), $thirdparty->errors))).'.'
 				);
 			} else {
 				dol_syslog(get_class($this) . '::_syncOrCreateThirdpartyFromEInvoiceSeller Updated thirdparty: ' . $thirdpartyId);
@@ -852,7 +852,7 @@ trait CommonProtocol
 				return array('res' => $thirdpartyId, 'message' => 'Thirdparty ' . $thirdparty->name . ' created successfully');
 			} else {
 				dol_syslog(get_class($this) . '::_syncOrCreateThirdpartyFromEInvoiceSeller Error creating thirdparty: ' . $thirdparty->error, LOG_ERR);
-				return array('res' => -1, 'message' => 'Thirdparty creation error: ' . implode("\n", $thirdparty->errors));
+				return array('res' => -1, 'message' => 'Thirdparty creation error: ' . dol_escape_htmltag(implode("\n", $thirdparty->errors)));
 			}
 		} else {
 			dol_syslog(get_class($this) . '::_syncOrCreateThirdpartyFromEInvoiceSeller Auto-creation of thirdparties is disabled', LOG_ERR);
@@ -1147,7 +1147,7 @@ trait CommonProtocol
 			$resCheck = $product->check();
 			if ($resCheck < 0) {
 				dol_syslog(__METHOD__ . ' Product check failed: ' . $product->error, LOG_ERR);
-				return array('res' => -1, 'message' => 'Product check failed: ' . implode("\n", $product->errors));
+				return array('res' => -1, 'message' => 'Product check failed: ' . dol_escape_htmltag(implode("\n", $product->errors)));
 			}
 
 			// Create product
@@ -1174,7 +1174,7 @@ trait CommonProtocol
 			dol_syslog(__METHOD__ . ' Product creation error: ' . $product->error, LOG_ERR);
 			return [
 				'res' => -1,
-				'message' => 'Product creation error: ' . $product->error,
+				'message' => 'Product creation error: ' . dol_escape_htmltag($product->error),
 			];
 		} else {
 			// Suggest manual creation of product

--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -1033,7 +1033,7 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 						);
 
 						dol_syslog(__METHOD__ . " Flow " . $flow['flowId'] . " postponed: " . $res['message'], LOG_WARNING, 0, "_einvoicing");
-						$results_messages[] = "Flow " . $flow['flowId'] . " postponed, it will be retried on the next synchronization: " . $res['message'];
+						$results_messages[] = "Flow " . dol_escape_htmltag((string) $flow['flowId']) . " postponed, it will be retried on the next synchronization: " . $res['message'];
 
 						$postponedFlows++;
 						continue;
@@ -1102,14 +1102,14 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 						}
 					}
 					dol_syslog(__METHOD__ . " Failed to synchronize flow " . $flow['flowId'] . ": " . $res['message'], LOG_DEBUG, 0, "_einvoicing");
-					$results_messages[] = "ERROR_SYNCFLOW - Failed to synchronize flow " . $flow['flowId'] . ": " . $res['message'];
+					$results_messages[] = "ERROR_SYNCFLOW - Failed to synchronize flow " . dol_escape_htmltag((string) $flow['flowId']) . ": " . $res['message'];
 
 					$error++;
 				}
 
 				// If res == 0, commit but count it as already existed
 				if ($res['res'] == 0) {
-					$results_messages[] = "<span class=\"opacitylow\">Flow " . $flow['flowId'] . " skipped: " . $res['message'] . "</span>";
+					$results_messages[] = "<span class=\"opacitylow\">Flow " . dol_escape_htmltag((string) $flow['flowId']) . " skipped: " . $res['message'] . "</span>";
 					$alreadyExist++;
 					//$lastsuccessfullSyncronizedFlow = $flow['flowId'];
 				}
@@ -1120,7 +1120,7 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 					//$lastsuccessfullSyncronizedFlow = $flow['flowId'];
 				}
 			} catch (Exception $e) {
-				$results_messages[] = "Exception occurred while synchronizing flow " . $flow['flowId'] . ": " . $e->getMessage();
+				$results_messages[] = "Exception occurred while synchronizing flow " . dol_escape_htmltag((string) $flow['flowId']) . ": " . dol_escape_htmltag($e->getMessage());
 				$error++;
 			}
 

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -1975,7 +1975,7 @@ class SuperPDPProvider extends AbstractPDPProvider
 							);
 
 							dol_syslog(__METHOD__ . " Flow " . $flow['flowId'] . " postponed: " . $res['message'], LOG_WARNING, 0, "_einvoicing");
-							$results_messages[] = "Flow " . $flow['flowId'] . " postponed, it will be retried on the next synchronization: " . $res['message'];
+							$results_messages[] = "Flow " . dol_escape_htmltag((string) $flow['flowId']) . " postponed, it will be retried on the next synchronization: " . $res['message'];
 
 							$postponedFlows++;
 							continue;
@@ -2044,14 +2044,14 @@ class SuperPDPProvider extends AbstractPDPProvider
 							}
 						}
 						dol_syslog(__METHOD__ . " Failed to synchronize flow " . $flow['flowId'] . ": " . $res['message'], LOG_DEBUG, 0, "_einvoicing");
-						$results_messages[] = "ERROR_SYNCFLOW - Failed to synchronize flow " . $flow['flowId'] . ": " . $res['message'];
+						$results_messages[] = "ERROR_SYNCFLOW - Failed to synchronize flow " . dol_escape_htmltag((string) $flow['flowId']) . ": " . $res['message'];
 
 						$error++;
 					}
 
 					// If res == 0, commit but count it as already existed
 					if ($res['res'] == 0) {
-						$results_messages[] = "<span class=\"opacitylow\">Flow " . $flow['flowId'] . " skipped: " . $res['message'] . "</span>";
+						$results_messages[] = "<span class=\"opacitylow\">Flow " . dol_escape_htmltag((string) $flow['flowId']) . " skipped: " . $res['message'] . "</span>";
 						$alreadyExist++;
 						//$lastsuccessfullSyncronizedFlow = $flow['flowId'];
 					}
@@ -2062,7 +2062,7 @@ class SuperPDPProvider extends AbstractPDPProvider
 						//$lastsuccessfullSyncronizedFlow = $flow['flowId'];
 					}
 				} catch (Exception $e) {
-					$results_messages[] = "Exception occurred while synchronizing flow " . $flow['flowId'] . ": " . $e->getMessage();
+					$results_messages[] = "Exception occurred while synchronizing flow " . dol_escape_htmltag((string) $flow['flowId']) . ": " . dol_escape_htmltag($e->getMessage());
 					$error++;
 				}
 

--- a/einvoicing/class/utils/SupplierInvoiceHelper.class.php
+++ b/einvoicing/class/utils/SupplierInvoiceHelper.class.php
@@ -776,6 +776,11 @@ class SupplierInvoiceHelper
 	{
 		global $db;
 
+		// $ref and $context carry values read from the received e-invoice (document number, line id).
+		// The caller prints this message as HTML in the synchronization panel, so neutralize any markup.
+		$ref = dol_escape_htmltag((string) $ref);
+		$context = dol_escape_htmltag($context);
+
 		if ($code == -2) {
 			return 'Several supplier invoices match reference "' . $ref . '" ' . $context . ', cannot determine which one to use';
 		}
@@ -783,7 +788,7 @@ class SupplierInvoiceHelper
 			return 'Found a supplier invoice matching "' . $ref . '" for the thirdparty (but with non matching expected amount) ' . $context . ', cannot determine which one to use';
 		}
 
-		return 'Database error while looking for a supplier invoice with reference "' . $ref . '" ' . $context . ': ' . $db->lasterror();
+		return 'Database error while looking for a supplier invoice with reference "' . $ref . '" ' . $context . ': ' . dol_escape_htmltag($db->lasterror());
 	}
 
 	/**


### PR DESCRIPTION
### Problem

The synchronization results panel (`document_list.php`) prints a run's technical messages and details as raw HTML. Several of those messages are built by concatenating fields read verbatim from a **received** e-invoice: document number (BT-1), referenced document ids (BT-25), line id, document type code (BT-3), and the product/thirdparty errors that echo them.

`getXPathValue()` returns the decoded node text, so a value delivered XML-escaped inside a perfectly valid document (`&lt;img src=x onerror=...&gt;`) turns back into live markup when the panel renders it. Under the e-invoicing mandate the sender of an incoming invoice cannot be chosen, so a counterparty could store markup that runs in the operator's browser session when a reception fails and the run is displayed.

It is a hard-to-reach stored XSS (it needs a reception that fails on one of these fields, and a strict access point may reject the payload at intake), but the module should not depend on the platform to sanitize its own output.

### Fix

Escape the untrusted values with `dol_escape_htmltag()` **at the point where they are interpolated** into the message, so the intended panel layout (line breaks, the "skipped" span, the action buttons) is preserved while the data is neutralized:

- `CIIProtocol`: document number, referenced document ids, line id and document type code in the reception error messages.
- `SupplierInvoiceHelper::refLookupErrorMessage()`: escapes its `ref` and `context` once, covering every caller.
- `CommonProtocol`: the thirdparty and product creation/update error messages.
- `SuperPDPProvider` / `EsalinkPDPProvider`: the flow id and exception text pushed into the per-run details.

Clean references (letters, digits, dashes) pass through unchanged, so the panel and the existing `refLookupErrorMessage` unit test are unaffected. `dolics` clean, `php -l` clean on all five files.
