### PR TITLE
FIX: [einvoicing] Typos: sotorder in the list title hook, GETPOSt in the OAuth proxy callback

### DIFF
--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -1896,12 +1896,12 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 
 			// Einvoice generated or not
 			if (!empty($parameters['arrayfields']['einvoicegenerated']['checked'])) {
-				print_liste_field_titre($langs->transnoentitiesnoconv('EInvoiceFile'), '', '', '', $parameters['param'] ?? '', '', $parameters['sortfield'] ?? '', $parameters['sotorder'] ?? '', 'center ');
+				print_liste_field_titre($langs->transnoentitiesnoconv('EInvoiceFile'), '', '', '', $parameters['param'] ?? '', '', $parameters['sortfield'] ?? '', $parameters['sortorder'] ?? '', 'center ');
 			}
 
 			// syncstatus
 			if (empty($parameters['arrayfields']['pdp_syncstatus']) || !empty($parameters['arrayfields']['pdp_syncstatus']['checked'])) {
-				print_liste_field_titre($langs->transnoentitiesnoconv('PDPSyncStatus'), '', '', '', $parameters['param'] ?? '', '', $parameters['sortfield'] ?? '', $parameters['sotorder'] ?? '', 'center ');
+				print_liste_field_titre($langs->transnoentitiesnoconv('PDPSyncStatus'), '', '', '', $parameters['param'] ?? '', '', $parameters['sortfield'] ?? '', $parameters['sortorder'] ?? '', 'center ');
 			}
 		}
 

--- a/einvoicing/public/proxy_oauthcallback.php
+++ b/einvoicing/public/proxy_oauthcallback.php
@@ -122,7 +122,7 @@ if ($state) { // Used to store scope and anti-csrf value. The scope is stored in
 }
 
 $providertouse = getDolGlobalString('EINVOICING_PDP');
-if (GETPOSt('proxy') && getDolGlobalString('EINVOICING_SUPERPDP_VIAPARTNER') == 'proxy') {	// If using a proxy is requested and we are on a server proxy
+if (GETPOST('proxy') && getDolGlobalString('EINVOICING_SUPERPDP_VIAPARTNER') == 'proxy') {	// If using a proxy is requested and we are on a server proxy
 	$providertouse = strtoupper(GETPOST('proxy', 'aZ09'));
 }
 


### PR DESCRIPTION
Two typos, no behaviour change worth a screenshot:

- `printFieldListTitle` in `actions_einvoicing.class.php` read `$parameters['sotorder']` while
  every core list passes `sortorder` (`compta/facture/list.php`, `fourn/facture/list.php`, …), so
  the two module columns were always titled with an empty sort order.
- `public/proxy_oauthcallback.php` called `GETPOSt('proxy')`. PHP resolves function names case
  insensitively so it worked, but it reads as a mistake and trips linters.

## Tested

- PHPUnit, 28 files on Dolibarr 18.0.10 to develop (25.0.0-alpha), 8 cores: 224/224.
- Customer and supplier invoice lists over HTTP on 18.0.10 and develop, both module columns
  present, no PHP notice.
- phpcs and phan clean.
