### PR TITLE
FIX: [einvoicing] Realign the compat copies on the core they backport

### DIFF
--- a/einvoicing/compat/commonhookactions.class.php
+++ b/einvoicing/compat/commonhookactions.class.php
@@ -36,13 +36,53 @@ if (!class_exists('CommonHookActions', false)) {
 	abstract class CommonHookActions
 	{
 		/**
-		 * @var string	String of results.
+		 * @var ?string	String of results.
 		 */
 		public $resprints;
 
 		/**
-		 * @var array 	Array of results.
+		 * @var array<mixed|mixed[]> 	Array of results.
 		 */
 		public $results = array();
+
+		/**
+		 * @var string
+		 */
+		public $error;
+
+		/**
+		 * @var string[]
+		 */
+		public $errors = array();
+
+		/**
+		 * @var string[]
+		 */
+		public $warnings = array();
+
+
+		/**
+		 * Check context of hook
+		 *
+		 * @param 	array<string,mixed> $parameters 	Hook parameters.
+		 * @param 	string[]|string 	$allContexts 	Context to check
+		 * @return 	bool
+		 */
+		protected function isContext($parameters, $allContexts)
+		{
+			if (is_array($allContexts)) {
+				foreach ($allContexts as $context) {
+					if ($this->isContext($parameters, $context)) {
+						return true;
+					}
+				}
+				return false;
+			}
+			if ($parameters['currentcontext'] == $allContexts) {
+				return true;
+			}
+			$contexts = explode(':', $parameters['context']);
+			return in_array($allContexts, $contexts);
+		}
 	}
 }

--- a/einvoicing/compat/profid.lib.php
+++ b/einvoicing/compat/profid.lib.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2006-2011	Laurent Destailleur		<eldy@users.sourceforge.net>
- * Copyright (C) 2022		Frédéric France			<frederic.france@netlogic.fr>
- * Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2022-2026  Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,6 +24,9 @@
  */
 
 // @phan-file-suppress PhanRedefineFunction
+
+// Copy of the core file, function by function under a function_exists() guard: the module loads it
+// below Dolibarr 20, where the core has no profid.lib.php, and the core version wins everywhere else.
 
 if (!function_exists('isValidLuhn')) {
 	/**
@@ -51,16 +54,16 @@ if (!function_exists('isValidLuhn')) {
 	}
 }
 
-
 if (!function_exists('isValidSiren')) {
 	/**
 	 *  Check the syntax validity of a SIREN.
 	 *
-	 *  @param		string		$siren		SIREN to check
-	 *  @return		boolean					True if valid, False otherwise
+	 *  @param		string		$siren			SIREN to check
+	 *  @param  	int			$lengthonly		Make surface test only (length, ...)
+	 *  @return		boolean						True if valid, False otherwise
 	 *  @since		Dolibarr V20
 	 */
-	function isValidSiren($siren)
+	function isValidSiren($siren, $lengthonly = 0)
 	{
 		$siren = trim($siren);
 		$siren = preg_replace('/(\s)/', '', $siren);
@@ -69,20 +72,20 @@ if (!function_exists('isValidSiren')) {
 			return false;
 		}
 
-		return isValidLuhn($siren);
+		return ($lengthonly || isValidLuhn($siren));
 	}
 }
-
 
 if (!function_exists('isValidSiret')) {
 	/**
 	 *  Check the syntax validity of a SIRET.
 	 *
-	 *  @param		string		$siret		SIRET to check
-	 *  @return		boolean					True if valid, False otherwise
+	 *  @param		string		$siret			SIRET to check
+	 *  @param  	int			$lengthonly		Make surface test only (length, ...)
+	 *  @return		boolean						True if valid, False otherwise
 	 *  @since		Dolibarr V20
 	 */
-	function isValidSiret($siret)
+	function isValidSiret($siret, $lengthonly = 0)
 	{
 		$siret = trim($siret);
 		$siret = preg_replace('/(\s)/', '', $siret);
@@ -91,7 +94,7 @@ if (!function_exists('isValidSiret')) {
 			return false;
 		}
 
-		if (isValidLuhn($siret)) {
+		if ($lengthonly || isValidLuhn($siret)) {
 			return true;
 		} elseif ((substr($siret, 0, 9) == "356000000") && (array_sum(str_split($siret)) % 5 == 0)) {
 			/**
@@ -106,11 +109,10 @@ if (!function_exists('isValidSiret')) {
 	}
 }
 
-
 if (!function_exists('isValidTinForPT')) {
 	/**
 	 *  Check the syntax validity of a Portuguese (PT) Tax Identification Number (TIN).
-	 *  (NIF = Número de Identificação Fiscal)
+	 *  (NIF = Numero de Identificacao Fiscal)
 	 *
 	 *  @param		string		$str		NIF to check
 	 *  @return		boolean					True if valid, False otherwise
@@ -129,11 +131,10 @@ if (!function_exists('isValidTinForPT')) {
 	}
 }
 
-
 if (!function_exists('isValidTinForDZ')) {
 	/**
 	 *  Check the syntax validity of an Algerian (DZ) Tax Identification Number (TIN).
-	 *  (NIF = Numéro d'Identification Fiscale)
+	 *  (NIF = Tax Identification Number)
 	 *
 	 *  @param		string		$str		TIN to check
 	 *  @return		boolean					True if valid, False otherwise
@@ -152,11 +153,10 @@ if (!function_exists('isValidTinForDZ')) {
 	}
 }
 
-
 if (!function_exists('isValidTinForBE')) {
 	/**
 	 *  Check the syntax validity of a Belgium (BE) Tax Identification Number (TIN).
-	 *  (NN = Numéro National)
+	 *  (NN = National Number)
 	 *
 	 *  @param		string		$str		NN to check
 	 *  @return		boolean					True if valid, False otherwise
@@ -176,13 +176,12 @@ if (!function_exists('isValidTinForBE')) {
 	}
 }
 
-
 if (!function_exists('isValidTinForES')) {
 	/**
 	 *  Check the syntax validity of a Spanish (ES) Tax Identification Number (TIN), where:
-	 *  - NIF = Número de Identificación Fiscal (used for residents only before 2008. Used for both residents and companies since 2008.)
-	 *  - CIF = Código de Identificación Fiscal (used for companies only before 2008. Replaced by NIF since 2008.)
-	 *  - NIE = Número de Identidad de Extranjero
+	 *  - NIF = Numero de Identificacion Fiscal (used for residents only before 2008. Used for both residents and companies since 2008.)
+	 *  - CIF = Codigo de Identificacion Fiscal (used for companies only before 2008. Replaced by NIF since 2008.)
+	 *  - NIE = Numero de Identidad de Extranjero
 	 *
 	 *  @param		string		$str		TIN to check
 	 *  @return		int<-4,3>				1 if NIF ok, 2 if CIF ok, 3 if NIE ok, -1 if NIF bad, -2 if CIF bad, -3 if NIE bad, -4 if unexpected bad
@@ -241,7 +240,8 @@ if (!function_exists('isValidTinForES')) {
 
 		//Check NIE T
 		if (preg_match('/^[T]{1}/', $str)) {
-			if ($num[8] == preg_match('/^[T]{1}[A-Z0-9]{8}$/', $str)) {
+			// A NIE starting with T has no control key to check, so the syntax check is enough.
+			if (preg_match('/^[T]{1}[A-Z0-9]{8}$/', $str)) {
 				return 3;
 			} else {
 				return -3;
@@ -259,5 +259,58 @@ if (!function_exists('isValidTinForES')) {
 
 		//Can not be verified
 		return -4;
+	}
+}
+
+if (!function_exists('isValidProfIds')) {
+	/**
+	 *  Check the validity of a professional identifier according to the properties (country) of the company (siren, siret, ...)
+	 *
+	 *  @param	int			$idprof         1,2,3,4 (Example: 1=siren, 2=siret, 3=naf, 4=rcs/rm)
+	 *  @param  Societe		$thirdparty     Object societe
+	 *  @param  int			$lenghtonly		Make surface test only (length, ...)
+	 *  @return int             			Return integer <=0 if KO, >0 if OK
+	 */
+	function isValidProfIds($idprof, $thirdparty, $lenghtonly = 0)
+	{
+		$ok = 1;
+
+		if (getDolGlobalString('MAIN_DISABLEPROFIDRULES')) {
+			return 1;
+		}
+
+		// Check SIREN
+		if ($thirdparty->country_code == 'FR') {
+			if ($idprof == 1 && !isValidSiren($thirdparty->idprof1, $lenghtonly)) {
+				return -1;
+			}
+
+			// Check SIRET
+			if ($idprof == 2 && !isValidSiret($thirdparty->idprof2, $lenghtonly)) {
+				return -2;
+			}
+		}
+
+		// Verify CIF/NIF/NIE if pays ES
+		if ($idprof == 1 && $thirdparty->country_code == 'ES') {
+			return isValidTinForES($thirdparty->idprof1);
+		}
+
+		// Verify NIF if country is PT
+		if ($idprof == 1 && $thirdparty->country_code == 'PT' && !isValidTinForPT($thirdparty->idprof1)) {
+			return -1;
+		}
+
+		// Verify NIF if country is DZ
+		if ($idprof == 1 && $thirdparty->country_code == 'DZ' && !isValidTinForDZ($thirdparty->idprof1)) {
+			return -1;
+		}
+
+		// Verify ID Prof 1 if country is BE
+		if ($idprof == 1 && $thirdparty->country_code == 'BE' && !isValidTinForBE($thirdparty->idprof1)) {
+			return -1;
+		}
+
+		return $ok;
 	}
 }

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -339,11 +339,20 @@ function getMultidirOutputCompat($object, $module = '', $forobject = 0, $mode = 
 			$module = 'knowledgemanagement';
 			$subdirectory = '/knowledgerecord';
 			break;
+		case 'partnership':
+			$subdirectory = '/partnership';
+			break;
+		case 'stocktransfer':
+			$subdirectory = '/stocktransfer';
+			break;
 		case 'commande_fournisseur':
 			$module = 'fournisseur';
 			$subdirectory = '/commande';
 			break;
 		case 'expedition':
+		case 'shipment':
+		case 'shipping':
+			$module = 'expedition';
 			$subdirectory = '/sending';
 			break;
 		case 'company':
@@ -352,6 +361,24 @@ function getMultidirOutputCompat($object, $module = '', $forobject = 0, $mode = 
 		case 'service':
 		case 'produit':
 			$module = 'product';
+			break;
+		case 'project_task':
+			$module = 'projet';
+
+			// Fetch the project to build the correct path. The signature of this function accepts an object
+			// that is not a CommonObject, and even a null when a module is given, so we must not call a method
+			// that only a CommonObject owns without testing it exists.
+			if (is_object($object) && method_exists($object, 'fetchProject')) {
+				$object->fetchProject();
+			}
+
+			// The ref must be sanitized with dol_sanitizeFileName() and not only with dol_sanitizePathName()
+			// done at the end of this function, because a project ref is a user input that may contain a '/',
+			// a ':' or an accented char. dol_sanitizePathName() keeps them, so we would not return the
+			// directory used by projet/tasks/document.php, that sanitizes the ref with dol_sanitizeFileName().
+			if (!empty($object->project->ref)) {
+				$subdirectory = '/'.dol_sanitizeFileName($object->project->ref);
+			}
 			break;
 		case 'action':
 		case 'actioncomm':
@@ -367,12 +394,18 @@ function getMultidirOutputCompat($object, $module = '', $forobject = 0, $mode = 
 		if (isset($conf->$module) && property_exists($conf->$module, 'multidir_output')) {
 			$s = '';
 			if ($mode != 'outputrel') {
-				$s = $conf->$module->multidir_output[(empty($object->entity) ? $conf->entity : $object->entity)] . $subdirectory;
+				// An entity with no directory declared used to return an undefined index, so a relative path
+				// that made the caller read or write under the web root. Answer the error instead.
+				$entity = (int) (empty($object->entity) ? $conf->entity : $object->entity);
+				if (!isset($conf->$module->multidir_output[$entity])) {
+					return 'error-diroutput-not-defined-for-this-object='.$module;
+				}
+				$s = $conf->$module->multidir_output[$entity].$subdirectory;
 			}
 			if ($forobject && $object->id > 0) {
 				$s .= ($mode != 'outputrel' ? '/' : '') . get_exdir(0, 0, 0, 0, $object);
 			}
-			return $s;
+			return dol_sanitizePathName($s);
 		} elseif (isset($conf->$module) && property_exists($conf->$module, 'dir_output')) {
 			$s = '';
 			if ($mode != 'outputrel') {
@@ -381,15 +414,20 @@ function getMultidirOutputCompat($object, $module = '', $forobject = 0, $mode = 
 			if ($forobject && $object->id > 0) {
 				$s .= ($mode != 'outputrel' ? '/' : '') . get_exdir(0, 0, 0, 0, $object);
 			}
-			return $s;
+			return dol_sanitizePathName($s);
 		} else {
 			return 'error-diroutput-not-defined-for-this-object=' . $module;
 		}
 	} elseif ($mode == 'temp') {
 		if (isset($conf->$module) && property_exists($conf->$module, 'multidir_temp')) {
-			return $conf->$module->multidir_temp[(empty($object->entity) ? $conf->entity : $object->entity)];
+			// Same guard as the 'output' mode above, see the comment there
+			$entity = (int) (empty($object->entity) ? $conf->entity : $object->entity);
+			if (!isset($conf->$module->multidir_temp[$entity])) {
+				return 'error-dirtemp-not-defined-for-this-object='.$module;
+			}
+			return dol_sanitizePathName($conf->$module->multidir_temp[$entity]);
 		} elseif (isset($conf->$module) && property_exists($conf->$module, 'dir_temp')) {
-			return $conf->$module->dir_temp;
+			return dol_sanitizePathName($conf->$module->dir_temp);
 		} else {
 			return 'error-dirtemp-not-defined-for-this-object=' . $module;
 		}
@@ -457,9 +495,10 @@ if (!method_exists('Societe', 'findNearest')) {
 	 *    @param    string	$ref_alias 		Name_alias of third party (Warning, this can return several records)
 	 * 	  @param	int		$is_client		Only client third party
 	 *    @param	int		$is_supplier	Only supplier third party
+	 *    @param	string	$vatnumber		VAT number
 	 *    @return   int						ID of thirdparty found if OK, <0 if KO (-2 if two records found or other negative if error), 0 if not found.
 	 */
-	function findNearest($rowid = 0, $ref = '', $ref_ext = '', $barcode = '', $idprof1 = '', $idprof2 = '', $idprof3 = '', $idprof4 = '', $idprof5 = '', $idprof6 = '', $email = '', $ref_alias = '', $is_client = 0, $is_supplier = 0)
+	function findNearest($rowid = 0, $ref = '', $ref_ext = '', $barcode = '', $idprof1 = '', $idprof2 = '', $idprof3 = '', $idprof4 = '', $idprof5 = '', $idprof6 = '', $email = '', $ref_alias = '', $is_client = 0, $is_supplier = 0, $vatnumber = '')
 	{
 		global $db;
 
@@ -539,6 +578,12 @@ if (!method_exists('Societe', 'findNearest')) {
 				$sqlprof .= " OR";
 			}
 			$sqlprof .= " s.idprof6 = '".$db->escape($idprof6)."'";
+		}
+		if ($vatnumber) {
+			if ($sqlprof) {
+				$sqlprof .= " OR";
+			}
+			$sqlprof .= " s.tva_intra = '".$db->escape($vatnumber)."'";
 		}
 
 		if ($sqlprof) {


### PR DESCRIPTION
Four backports had drifted from the core code they stand in for. Each is now the develop (25.0)
text again, so a call that behaves one way on 20+ behaves the same on 18 and 19:

- **`compat/profid.lib.php`** is regenerated from `core/lib/profid.lib.php`, function by function
  under its `function_exists()` guard. It brings back the `$lengthonly` argument of
  `isValidSiren()` / `isValidSiret()`, the fixed T-NIE branch of `isValidTinForES()` (the copy
  compared the 9th character to the integer returned by `preg_match()`, so a valid T-NIE came out
  as -3) and `isValidProfIds()`. A diff of the file against the core one, guards and indentation
  aside, is empty.
- **`compat/commonhookactions.class.php`** gains `$error`, `$errors`, `$warnings` and
  `isContext()`, as the core class has them.
- **`findNearest()`** in `lib/einvoicing.lib.php` gains the `$vatnumber` argument and its
  `tva_intra` clause. The one deliberate difference stays, with its comment: `Societe::fetch()`
  answers 1 on the cores this copy runs on, so the copy returns the thirdparty id where the core
  returns the raw result (#739).
- **`getMultidirOutputCompat()`**: the fallback body used below 20 is the develop
  `getMultidirOutput()` body again (`partnership`, `stocktransfer`, `shipment` and `project_task`
  cases, the guard on an entity with no directory, `dol_sanitizePathName()` on the result).

## Tested

- PHPUnit, 28 files on Dolibarr 18.0.10 to develop (25.0.0-alpha), 8 cores: 224/224.
- A probe run on 18.0.10 (where the copies run) and 24.0.1 (core functions) with the same inputs:
  `isValidTinForES('T12345678')` gives 3 on both (main gave -3 on 18), `isValidSiren('…', 1)` and
  `isValidSiret('…', 1)` honour `$lengthonly`, `isValidProfIds()` answers the same, every
  `getMultidirOutputCompat()` case matches the core answer on 24 (and answers the error string on
  18 for an entity without directory), the hook class exposes `errors` and `isContext()`.
- An e-invoice received on 18.0.10 through the sandbox access point, where the thirdparty
  matching goes through the copy of `findNearest()`: imported, 205 and 211 sent, 212 back.
- phpcs and phan clean.
