### PR TITLE
QUAL: [einvoicing] The module declares the PHP version its libraries need

### DIFF
--- a/einvoicing/core/modules/modEInvoicing.class.php
+++ b/einvoicing/core/modules/modEInvoicing.class.php
@@ -157,7 +157,7 @@ class modEInvoicing extends DolibarrModules
 		$this->langfiles = array("einvoicing@einvoicing");
 
 		// Prerequisites
-		$this->phpmin = array(7, 0); // Minimum version of PHP required by module
+		$this->phpmin = array(7, 3); // Minimum version of PHP required by module: the bundled horstoeko/zugferd needs 7.3
 		// $this->phpmax = array(8, 0); // Maximum version of PHP required by module
 		$this->need_dolibarr_version = array(18, -3); // Minimum version of Dolibarr required by module
 		// $this->max_dolibarr_version = array(19, -3); // Maximum version of Dolibarr required by module


### PR DESCRIPTION
The module declared `phpmin = array(7, 0)`, below what it can actually run on.

The bundled horstoeko/zugferd requires PHP >= 7.3 in its `composer.json`, as do its
`horstoeko/stringmanagement` and `horstoeko/mimedb` dependencies, and the vendor tree was resolved
with `platform.php = 7.3.0` (see `einvoicing/composer.disabled.json`). The generated
`einvoicing/vendor/composer/platform_check.php` therefore refuses anything below PHP 7.3.0, with a
fatal `E_USER_ERROR` rather than a message — and `FacturXProtocol.class.php` requires the autoloader
at file scope, so merely including it is enough.

**Choosing CII does not keep that file out of the way.** It governs what we *emit*. Reception picks
the protocol from what *arrived*: `detectProtocolFromContent()` answers `FACTURX` for anything
starting with `%PDF-`, and `getProtocol()` is then called by the flow picker of
`AbstractPDPProvider`, by `Document::cleanXmlData()`, by the consistency check of
`SupplierInvoiceHelper` and by `product_mapping.php`. None of them reads `EINVOICING_PROTOCOL`, and
incoming synchronisation is on unless it is turned off. A supplier that sends Factur-X — the format
most French senders use — loads the library on a site set to CII.

Measured on the bench for #764/#785 (04-05/09/2026), with a `horstoeko\zugferd` probe on
`get_declared_classes()`: with the Approved Platform account set to CII, not one class is loaded and
`FacturXProtocol.class.php` is never even included; with the account set to Factur-X, the document
handed back is a PDF and **three classes are loaded**, on `main` and on the branch alike. That
account setting lives at the platform, not in Dolibarr — hgy29 reported exactly such an account on
 #718. So "the library is never loaded with the recommended setup" holds only for one particular
platform-side configuration, not for the module.

Nothing reachable needs more than 7.3. The only PHP 8.x files under `vendor/` are the optional
`horstoeko\zugferd\codelistsenum` enums, autoloaded PSR-4 and referenced neither by the module nor by
zugferd itself, two Rector configs under `build/` that are not autoloaded, and
`symfony/polyfill-mbstring/bootstrap80.php`, required only when `PHP_VERSION_ID >= 80000`. The PHP
7.4+ and 8.x functions the reached libraries call (`str_contains`, `get_debug_type`, `mb_str_split`,
`array_is_list`) all come from the bundled symfony polyfills.

Measured, not assumed: `php -l` over the vendor tree under PHP 7.3.33 and 7.4.33 errors on exactly
those 18 unreachable files and on no other, and is clean on the 92 non-vendor PHP files of the
module — which, for the record, also parse under 7.0, 7.1 and 7.2. Parsing is not the point; the
`platform_check.php` fatal is.

So a site below 7.3 now gets the module's own prerequisite warning instead of a fatal from the
autoloader, the first time a supplier sends a Factur-X.
