### PR TITLE
Fix #826: einvoicing, mass delete of vendor reference mappings is broken as soon as the list is filtered

### DIFF
--- a/einvoicing/vendorref_list.php
+++ b/einvoicing/vendorref_list.php
@@ -195,7 +195,7 @@ if ($action == 'confirm_delete' && $confirm == 'yes' && $permissiontoadd && $row
 }
 
 // Delete the selected mappings
-if ($massaction == 'massdelete' && $confirm == 'yes' && $permissiontoadd && is_array($toselect) && count($toselect) > 0) {
+if ($action == 'massdelete' && $confirm == 'yes' && $permissiontoadd && is_array($toselect) && count($toselect) > 0) {
 	$nbdeleted = 0;
 	foreach ($toselect as $torowid) {
 		$pfp = new ProductFournisseur($db);
@@ -211,6 +211,7 @@ if ($massaction == 'massdelete' && $confirm == 'yes' && $permissiontoadd && is_a
 	if ($nbdeleted > 0) {
 		setEventMessages($langs->trans("NbOfVendorRefMappingsDeleted", $nbdeleted), null, 'mesgs');
 	}
+	$action = 'view';
 	$massaction = '';
 	$toselect = array();
 }
@@ -296,26 +297,9 @@ if (getDolGlobalString('EINVOICING_SHOW_MAPPING_TOOL_ON_VENDOR_PRICE_LIST')) {	/
 	$newcardbutton = dolGetButtonTitle($langs->trans("MapEInvoiceProducts"), '', 'fa fa-link', dol_buildpath('/einvoicing/product_mapping.php', 1), '', ($permissiontoadd ? 1 : 0));
 }
 
-// Confirmations are printed before the search form: a form cannot be nested into another one
+// Confirmation of a single deletion, printed before the search form: a form cannot be nested into another one
 if ($action == 'delete' && $permissiontoadd && $rowid > 0) {
 	print $form->formconfirm($_SERVER["PHP_SELF"].'?rowid='.((int) $rowid).$param, $langs->trans("DeleteVendorRefMapping"), $langs->trans("ConfirmDeleteVendorRefMapping"), 'confirm_delete', '', 0, 1);
-}
-if ($massaction == 'massdelete' && $permissiontoadd && count($toselect) > 0) {
-	// Same as formconfirm, but it has to carry the ids selected into the list
-	print '<form method="POST" action="'.$_SERVER["PHP_SELF"].$param.'">';
-	print '<input type="hidden" name="token" value="'.newToken().'">';
-	print '<input type="hidden" name="massaction" value="massdelete">';
-	print '<input type="hidden" name="confirm" value="yes">';
-	foreach ($toselect as $selected) {
-		print '<input type="hidden" name="toselect[]" value="'.((int) $selected).'">';
-	}
-	print '<div class="warning">';
-	print $langs->trans("ConfirmDeleteSelectedVendorRefMappings", count($toselect)).'<br>';
-	print '<input type="submit" class="button small" value="'.$langs->trans("Yes").'">';
-	print ' <a class="button button-cancel small" href="'.$_SERVER["PHP_SELF"].'?'.ltrim($param, '&').'">'.$langs->trans("No").'</a>';
-	print '</div>';
-	print '</form>';
-	print '<br>';
 }
 
 print '<form method="POST" id="searchFormList" action="'.$_SERVER["PHP_SELF"].'">';
@@ -325,6 +309,11 @@ print '<input type="hidden" name="sortfield" value="'.dol_escape_htmltag($sortfi
 print '<input type="hidden" name="sortorder" value="'.dol_escape_htmltag($sortorder).'">';
 
 print_barre_liste($title, $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, '', $num, $nbtotalofrecords, 'einvoicing.png@einvoicing', 0, $newcardbutton, '', $limit);
+
+// Confirmation of the mass deletion, inside the list form so the selected lines and the filters are posted again (same place as core/tpl/massactions_pre.tpl.php)
+if ($massaction == 'predelete' && $permissiontoadd && count($toselect) > 0) {
+	print $form->formconfirm($_SERVER["PHP_SELF"], $langs->trans("DeleteSelectedVendorRefMappings"), $langs->trans("ConfirmDeleteSelectedVendorRefMappings", count($toselect)), 'massdelete', null, '', 0, 200, 500, 1);
+}
 
 print '<div class="info"><span class="">'.$langs->trans("MappedVendorRefsDesc");
 print ' '.$langs->trans("MapEInvoiceProductsDesc2");
@@ -545,7 +534,7 @@ print '</div>';
 
 if ($permissiontoadd && $num > 0 && $action != 'editmapping') {
 	print '<div class="right paddingtop">';
-	print '<button type="submit" class="button small" name="massaction" value="massdelete">'.$langs->trans("DeleteSelectedVendorRefMappings").'</button>';
+	print '<button type="submit" class="button small" name="massaction" value="predelete">'.$langs->trans("DeleteSelectedVendorRefMappings").'</button>';
 	print '</div>';
 }
 


### PR DESCRIPTION
Fixes #826

### The bug

The confirmation of the mass deletion, on `einvoicing/vendorref_list.php`, was a hand made form
posting to `$_SERVER["PHP_SELF"].$param`. `$param` starts with `&`, so as soon as a filter was set
on the list the form action became:

```
/custom/einvoicing/vendorref_list.php&search_socid=126
```

On Apache that file does not exist, hence the 404 of the report. On nginx the same URL falls back
to `index.php` and the user silently lands on the home page. Either way nothing is deleted.

Without any filter `$param` is empty and the action is correct, which is why the mass deletion
looks fine when you do not filter the list first — hence the "works for me".

The same block also built its own buttons: an `<input type="submit">` for Yes and an `<a>` for No.
The two do not render with the same size, which is the second point of the report.

### The fix

Both come from not using the core here. The confirmation is now `$form->formconfirm()` printed
inside the list form, at the place where `core/tpl/massactions_pre.tpl.php` prints it in the core:

- the selected lines and the filters are posted again by that form, so there is no URL to build;
- the buttons are the standard ones of Dolibarr, and are the same as the ones already used by the
  single line deletion of that same page.

The bottom button now posts `massaction=predelete`, and the deletion runs on
`action=massdelete && confirm=yes`, like `core/actions_massactions.inc.php` does.

### Screenshot

The Yes/No pair is replaced by the core confirmation bar, so here is the new GUI next to the old one:

<img width="1547" height="276" alt="Confirmation bar, before and after" src="https://github.com/user-attachments/assets/82a8b35f-9e27-45d7-a937-9938931a6f59" />

And the whole page with the new confirmation, two lines selected and the supplier filter kept:

<img width="1568" height="784" alt="The vendor reference list with the new confirmation" src="https://github.com/user-attachments/assets/55f456ff-a918-4a00-b603-2c8b161fa015" />

### Test

Eight bench instances, one per core, Dolibarr 18.0.10, 19.0.4, 20.0.4, 21.0.4, 22.0.5, 23.0.4,
24.0.1 and 25.0.0, module served from this branch:

- the list is filtered on a supplier, two lines are selected, the delete button is pressed;
- the confirmation keeps the selected lines checked and keeps the supplier filter;
- the page holds a single form, whose action is `/custom/einvoicing/vendorref_list.php`;
- Yes deletes ("2 mapping(s) deleted") and comes back to the filtered list, No deletes nothing;
- no fatal error and no PHP warning on any of the eight.

The same scenario on `main` reproduces the report: the confirmation form carries
`action="/custom/einvoicing/vendorref_list.php&search_socid=1"`, and confirming leaves the count
unchanged.

The unit test suite is unchanged: 28 files × 8 cores, same result before and after this branch.
