### PR TITLE
Fix line discount dropped when BasisAmount is zero

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -3430,9 +3430,9 @@ class CIIProtocol extends AbstractProtocol
 		// price of the Dolibarr line.
 		$priceWithoutDiscount = (float) $lineTotalAmount - $totalChargeAmount + $totalDiscountAmount;
 
-		// Base used for percent calculation — BT-137 when the document states it, the amount before
-		// discount otherwise (issue #783).
-		$base = $allowances[0]['basisAmount'] ?? $priceWithoutDiscount;
+		// Base for the percent — BT-137 if given, amount before discount otherwise (issue #783).
+		// A BasisAmount of 0 (some pivots emit it) counts as not given: ?? would keep the 0 and drop the discount.
+		$base = !empty($allowances[0]['basisAmount']) ? $allowances[0]['basisAmount'] : $priceWithoutDiscount;
 
 		if (!$base) {
 			return false;


### PR DESCRIPTION

## What

When an incoming line discount has `<BasisAmount>0.00</BasisAmount>` but a real `ActualAmount`, the discount was silently dropped and the line got imported at full price.

`?? ` only falls back on `null`, so a BasisAmount of `0` was kept as the base, failed the `if (!$base)` guard, and `resolveLineDiscountPercent()` returned `false`.

Some pivots (e.g. Esalink) emit `BasisAmount = 0` next to a valid discount amount, so we now treat `0` as "not stated" and fall back to the amount before discount.

## Example

Line with gross 4766, 50% discount, net 2383:

```xml
<ram:SpecifiedTradeAllowanceCharge>
    <ram:ChargeIndicator><udt:Indicator>false</udt:Indicator></ram:ChargeIndicator>
    <ram:CalculationPercent>50.00</ram:CalculationPercent>
    <ram:BasisAmount>0.00</ram:BasisAmount>
    <ram:ActualAmount>2383.00</ram:ActualAmount>
</ram:SpecifiedTradeAllowanceCharge>
<ram:LineTotalAmount>2383.00</ram:LineTotalAmount>
````

- Before: discount ignored, line imported at 4766.00
- After: discount applied, line imported at 2383.00