### PR TITLE
FIX [einvoicing] The CDAR date test errors on Dolibarr 19 since it landed on main

### DIFF
--- a/einvoicing/test/phpunit/CdarDateFormatTest.php
+++ b/einvoicing/test/phpunit/CdarDateFormatTest.php
@@ -143,7 +143,10 @@ class CdarDateFormatTest extends CommonClassTest
 		$conf->tzuserinputkey = $this->savtzuserinputkey;
 		if ($this->savsessiontzset) {
 			$_SESSION['dol_tz_string'] = $this->savsessiontz;
-		} else {
+		} elseif (isset($_SESSION)) {
+			// A CLI run starts no session, so $_SESSION does not exist until a test writes into it.
+			// unset() of a key of a variable that does not exist warns on PHP 8.0, the version the
+			// suite runs Dolibarr 19 on, and PHPUnit turns that warning into a failure.
 			unset($_SESSION['dol_tz_string']);
 		}
 


### PR DESCRIPTION
`einvoicing_phpunit` is red on `main` since the merge of #817: `CdarDateFormatTest` errors twice on Dolibarr 19, and only there.

```
Cdar Date Format
 ✘ Date time stamp is unchanged
   │ Undefined variable $_SESSION
   │ einvoicing/test/phpunit/CdarDateFormatTest.php:147
 ✘ Date stamp is unchanged
   │ Undefined variable $_SESSION
```
(<https://github.com/Dolibarr/dolibarr-community-modules/actions/runs/34084388491> — the six other cores are green.)

## What happens

`tearDown()` puts back what the tests moved. When `setUp()` found no `$_SESSION['dol_tz_string']`, it unsets it:

```php
unset($_SESSION['dol_tz_string']);
```

A CLI run starts no session, so `$_SESSION` does not exist at all, and `unset()` of a key of a variable that does not exist warns on PHP 8.0. PHPUnit turns that warning into a failure.

That PHP is exactly the one the suite gives Dolibarr 19 since each core walks the range its `install/check.php` accepts. Checked on the three PHP the matrix uses at the ends and in the middle:

| PHP | `unset($_SESSION['x'])` with no session |
| --- | --- |
| 7.4 | `Notice: Undefined variable: _SESSION` — filtered out by the `error_reporting` of the core, so the run stays green |
| 8.0 | `Warning: Undefined variable $_SESSION` — PHPUnit fails the test |
| 8.1 to 8.5 | nothing |

So the two cores a pull request runs on (18 on PHP 7.4, 24 on PHP 8.5) could not see it: the file only meets PHP 8.0 on `main`, where the whole matrix runs.

## The fix

The unset is guarded by `isset($_SESSION)`, which never warns. Nothing else changes, and the test still restores the session key when there was one.

## Test

Full seven core matrix run on the branch, green: Dolibarr 18.0.0 to 24.0.0 on PHP 7.4 to 8.5, including the 19.0.0 / PHP 8.0 pair that is red on `main`.

<https://github.com/daGrumpf-bxp/dolibarr-community-modules/actions/runs/34097656543>

`workflow_dispatch` was used on purpose: it takes the same branch of the `cores` job as a push on `main`, so it runs the seven cores instead of the two a pull request gets. The checks of this pull request itself only cover 18 and 24, which is exactly why the defect got through.
