### PR TITLE
FIX #844 #850 [einvoicing] A received invoice line is imported at the amount it announces

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -1616,8 +1616,9 @@ class CIIProtocol extends AbstractProtocol
 	 * updateline() recomputes the totals from those three, so BT-131 is never stored as such. A line that is not a
 	 * DETAIL item (BT-X-8) carries no amount and becomes a text line. A regular item whose quantity times price
 	 * cannot express BT-131 - zero quantity, zero price, opposite sign - carries BT-131 as a single unit instead
-	 * (issues #726 and #772). A price whose six allowed decimals cannot state BT-131 over the quantity is refined
-	 * to the one that does (issue #844). Anything else is checked against BT-131 and reported when it differs.
+	 * (issues #726 and #772). Any other line whose quantity times price is not BT-131 is imported at BT-131, at
+	 * the unit price that totals it (issues #844 and #850), and what was rewritten is reported. The charges of
+	 * the line (BG-28) are out of all this: they leave on lines of their own.
 	 *
 	 * @param	array<string,mixed>		$parsedLine			One line as parseInvoiceLines() returns it
 	 * @param	float					$qty				Quantity read from the document (BT-129)
@@ -1628,7 +1629,12 @@ class CIIProtocol extends AbstractProtocol
 	protected function resolveLineAmounts(array $parsedLine, $qty, $subprice, $remisePercent)
 	{
 		$lineid = (string) ($parsedLine['lineid'] ?? '?');
-		$announced = round((float) ($parsedLine['lineTotalAmount'] ?? 0), 2);
+
+		// A line charge (BG-28) is part of BT-131 but rejoins the invoice as a line of its own (issue #735),
+		// so what this line has to total is BT-131 less those charges.
+		$charges = $this->lineChargeTotal($parsedLine);
+		$announced = round((float) ($parsedLine['lineTotalAmount'] ?? 0) - $charges, 2);
+		$announcedText = $announced . ($charges == 0.0 ? '' : ' (BT-131 less the charges that leave on their own line)');
 
 		if (!$this->isDetailLine($parsedLine)) {
 			return array('qty' => 0.0, 'subprice' => 0.0, 'remise_percent' => 0.0, 'warning' => '');
@@ -1650,32 +1656,40 @@ class CIIProtocol extends AbstractProtocol
 				$reason = 'its quantity (BT-129) and unit price (BT-146) rebuild ' . $rebuilt . ', of the opposite sign';
 			}
 
-			$warning = 'Line ' . $lineid . ' of the received document carries a net amount (BT-131) of ' . $announced
+			$warning = 'Line ' . $lineid . ' of the received document carries a net amount (BT-131) of ' . $announcedText
 				. ' while ' . $reason . '. It was imported as a single unit at that amount, so the total of the invoice matches the document.';
 
 			return array('qty' => 1.0, 'subprice' => $announced, 'remise_percent' => 0.0, 'warning' => $warning);
 		}
 
-		// A unit price is written with at most MAX_DECIMALS_UNIT_PRICE decimals while BT-131 is exact, and no rule
-		// ties one to the other: over a large quantity, the rounding of the price alone is worth euros (issue #844).
-		// When the whole difference fits in that rounding, the document is consistent and BT-131 says what the line
-		// is worth, so the price is refined to the one that totals it. Anything wider is reported, not rewritten.
+		// BT-131 is what the line is worth: the totals of the document are summed from it (BR-CO-10, BR-CO-13)
+		// and no rule ties it to quantity times price. So a line whose couple rebuilds another amount is imported
+		// at the one announced, with the unit price that totals it: the six decimals of a price cannot state it
+		// over a large quantity (issue #844), or the issuer simply prices the line elsewhere than it bills it
+		// (issue #850). Only a line announcing nothing keeps what its price rebuilds.
 		$difference = abs($rebuilt - $announced);
 		$divisor = $qty * (1 - ($remisePercent / 100));
 		$fromPriceRounding = (abs($divisor) * 0.5 / pow(10, self::MAX_DECIMALS_UNIT_PRICE)) + 0.01;
 
 		$warning = '';
 		$refined = false;
-		if ($difference > 0.01 && $difference <= $fromPriceRounding && $divisor != 0.0) {
+		if (!empty($announced) && $difference > 0.01 && $divisor != 0.0) {
 			$subprice = $announced / $divisor;
 			$refined = true;
 
-			$warning = 'Line ' . $lineid . ' of the received document announces a net amount (BT-131) of ' . $announced
-				. ', while its quantity and unit price (BT-146) rebuild ' . $rebuilt . '. That difference is within the '
-				. self::MAX_DECIMALS_UNIT_PRICE . ' decimals a unit price is written with (BR-FR-DEC-03), so the price was refined to '
-				. $this->spellOutUnitPrice($subprice) . ' and the line totals the amount announced.';
+			$warning = 'Line ' . $lineid . ' of the received document announces a net amount (BT-131) of ' . $announcedText
+				. ', while its quantity (BT-129) and unit price (BT-146) rebuild ' . $rebuilt . '. ';
+
+			if ($difference <= $fromPriceRounding) {
+				$warning .= 'That difference is within the ' . self::MAX_DECIMALS_UNIT_PRICE
+					. ' decimals a unit price is written with (BR-FR-DEC-03), so the price was refined to '
+					. $this->spellOutUnitPrice($subprice) . ' and the line totals the amount announced.';
+			} else {
+				$warning .= 'The document prices that line elsewhere than it bills it: the line was imported at the amount announced, at a unit price of '
+					. $this->spellOutUnitPrice($subprice) . ', so the invoice totals what the document bills.';
+			}
 		} elseif ($difference > 0.01) {
-			$warning = 'Line ' . $lineid . ' of the received document announces a net amount (BT-131) of ' . $announced
+			$warning = 'Line ' . $lineid . ' of the received document announces a net amount (BT-131) of ' . $announcedText
 				. ', but its quantity and unit price rebuild ' . $rebuilt . '. The invoice carries the rebuilt amount.';
 		}
 
@@ -1689,13 +1703,40 @@ class CIIProtocol extends AbstractProtocol
 			$warning = trim($warning . ' Line ' . $lineid . ' of the received document prices a single unit at '
 				. $this->spellOutUnitPrice($subprice)
 				. ', below the unit price precision of this Dolibarr (MAIN_MAX_DECIMALS_UNIT = '
-				. getDolGlobalInt('MAIN_MAX_DECIMALS_UNIT') . '). Its net amount (BT-131) of ' . $announced
+				. getDolGlobalInt('MAIN_MAX_DECIMALS_UNIT') . '). Its net amount (BT-131) of ' . $announcedText
 				. ' is imported as announced, but the unit price is stored as '
 				. number_format($stored, getDolGlobalInt('MAIN_MAX_DECIMALS_UNIT'), '.', '')
 				. ': editing that line would recompute it to ' . number_format($reopened, 2, '.', '') . '.');
 		}
 
 		return array('qty' => $qty, 'subprice' => $subprice, 'remise_percent' => $remisePercent, 'warning' => $warning);
+	}
+
+
+	/**
+	 * Total of the charges of a line (BG-28), the part of BT-131 that leaves on a line of its own.
+	 *
+	 * buildLineChargeLines() gives every charge of the line a Dolibarr line, so the line itself is worth
+	 * BT-131 less that total: comparing the whole of BT-131 to what quantity times price rebuilds would
+	 * count the charge twice (issue #735).
+	 *
+	 * @param	array<string,mixed>		$parsedLine		One line as parseInvoiceLines() returns it
+	 * @return	float									Sum of the charges of the line, zero when it has none
+	 */
+	protected function lineChargeTotal(array $parsedLine)
+	{
+		if (empty($parsedLine['lineAllowances']) || !is_array($parsedLine['lineAllowances'])) {
+			return 0.0;
+		}
+
+		$total = 0.0;
+		foreach ($parsedLine['lineAllowances'] as $allowanceCharge) {
+			if (($allowanceCharge['indicator'] ?? '') === 'true') {
+				$total += (float) ($allowanceCharge['actualAmount'] ?? 0);
+			}
+		}
+
+		return $total;
 	}
 
 

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -1616,7 +1616,8 @@ class CIIProtocol extends AbstractProtocol
 	 * updateline() recomputes the totals from those three, so BT-131 is never stored as such. A line that is not a
 	 * DETAIL item (BT-X-8) carries no amount and becomes a text line. A regular item whose quantity times price
 	 * cannot express BT-131 - zero quantity, zero price, opposite sign - carries BT-131 as a single unit instead
-	 * (issues #726 and #772). Anything else is checked against BT-131 and reported when it does not match.
+	 * (issues #726 and #772). A price whose six allowed decimals cannot state BT-131 over the quantity is refined
+	 * to the one that does (issue #844). Anything else is checked against BT-131 and reported when it differs.
 	 *
 	 * @param	array<string,mixed>		$parsedLine			One line as parseInvoiceLines() returns it
 	 * @param	float					$qty				Quantity read from the document (BT-129)
@@ -1655,24 +1656,60 @@ class CIIProtocol extends AbstractProtocol
 			return array('qty' => 1.0, 'subprice' => $announced, 'remise_percent' => 0.0, 'warning' => $warning);
 		}
 
+		// A unit price is written with at most MAX_DECIMALS_UNIT_PRICE decimals while BT-131 is exact, and no rule
+		// ties one to the other: over a large quantity, the rounding of the price alone is worth euros (issue #844).
+		// When the whole difference fits in that rounding, the document is consistent and BT-131 says what the line
+		// is worth, so the price is refined to the one that totals it. Anything wider is reported, not rewritten.
+		$difference = abs($rebuilt - $announced);
+		$divisor = $qty * (1 - ($remisePercent / 100));
+		$fromPriceRounding = (abs($divisor) * 0.5 / pow(10, self::MAX_DECIMALS_UNIT_PRICE)) + 0.01;
+
 		$warning = '';
-		if (abs($rebuilt - $announced) > 0.01) {
+		$refined = false;
+		if ($difference > 0.01 && $difference <= $fromPriceRounding && $divisor != 0.0) {
+			$subprice = $announced / $divisor;
+			$refined = true;
+
+			$warning = 'Line ' . $lineid . ' of the received document announces a net amount (BT-131) of ' . $announced
+				. ', while its quantity and unit price (BT-146) rebuild ' . $rebuilt . '. That difference is within the '
+				. self::MAX_DECIMALS_UNIT_PRICE . ' decimals a unit price is written with (BR-FR-DEC-03), so the price was refined to '
+				. $this->spellOutUnitPrice($subprice) . ' and the line totals the amount announced.';
+		} elseif ($difference > 0.01) {
 			$warning = 'Line ' . $lineid . ' of the received document announces a net amount (BT-131) of ' . $announced
 				. ', but its quantity and unit price rebuild ' . $rebuilt . '. The invoice carries the rebuilt amount.';
-		} elseif ($subprice != 0.0 && (float) price2num($subprice, 'MU') == 0.0) {
-			// calcul_price_total() rounds only the pu_ht copy it stores, to MAIN_MAX_DECIMALS_UNIT: a price stated
-			// per 100 000 (issue #777) totals what the document announces and still reaches the line as 0.00000.
-			// The import is right, but reopening and saving the line would recompute it to zero, so say so now.
-			// Spell the price out in full: PHP writes such a float as 1.34195E-6, which reads as a typo.
-			$spelled = rtrim(rtrim(number_format($subprice, 12, '.', ''), '0'), '.');
+		}
 
-			$warning = 'Line ' . $lineid . ' of the received document prices a single unit at ' . $spelled
+		// calcul_price_total() totals the line from the price it is handed, but stores a copy of that price rounded
+		// to MAIN_MAX_DECIMALS_UNIT: a price stated per 100 000 (issue #777) or refined above reaches the line as
+		// 0.00000. The amount imported is the one announced, but reopening and saving the line would recompute it
+		// from the stored price, so say so now rather than let it be found out.
+		$stored = (float) price2num($subprice, 'MU');
+		$reopened = round($qty * $stored * (1 - ($remisePercent / 100)), 2);
+		if (($warning === '' || $refined) && abs($reopened - $announced) > 0.001) {
+			$warning = trim($warning . ' Line ' . $lineid . ' of the received document prices a single unit at '
+				. $this->spellOutUnitPrice($subprice)
 				. ', below the unit price precision of this Dolibarr (MAIN_MAX_DECIMALS_UNIT = '
 				. getDolGlobalInt('MAIN_MAX_DECIMALS_UNIT') . '). Its net amount (BT-131) of ' . $announced
-				. ' is imported as announced, but the unit price is stored as zero: editing that line would recompute it to 0.00.';
+				. ' is imported as announced, but the unit price is stored as '
+				. number_format($stored, getDolGlobalInt('MAIN_MAX_DECIMALS_UNIT'), '.', '')
+				. ': editing that line would recompute it to ' . number_format($reopened, 2, '.', '') . '.');
 		}
 
 		return array('qty' => $qty, 'subprice' => $subprice, 'remise_percent' => $remisePercent, 'warning' => $warning);
+	}
+
+
+	/**
+	 * Write a unit price out in full, for a message a human reads.
+	 *
+	 * PHP writes a price of that size as 1.34195E-6, which reads as a typo, and price() would round it away.
+	 *
+	 * @param	float	$subprice	Unit price to spell out
+	 * @return	string				The same price, in plain digits
+	 */
+	private function spellOutUnitPrice($subprice)
+	{
+		return rtrim(rtrim(number_format($subprice, 12, '.', ''), '0'), '.');
 	}
 
 

--- a/einvoicing/test/phpunit/ReceivedInvoiceLinesTest.php
+++ b/einvoicing/test/phpunit/ReceivedInvoiceLinesTest.php
@@ -280,12 +280,12 @@ class ReceivedInvoiceLinesTest extends CommonClassTest
 	}
 
 	/**
-	 * A line whose quantity and price do not rebuild what the document announces keeps the amount the
-	 * core computes - it is the only one Dolibarr can store - but says so.
+	 * A line whose quantity and price do not rebuild what the document announces is imported at the
+	 * amount announced - BT-131 is the figure the totals of the document are summed from - and says so.
 	 *
 	 * @return	void
 	 */
-	public function testAnAmountThatDoesNotRebuildIsReported()
+	public function testAnAmountThatDoesNotRebuildIsImportedAtTheAnnouncedAmount()
 	{
 		global $db;
 
@@ -294,8 +294,8 @@ class ReceivedInvoiceLinesTest extends CommonClassTest
 		$parsedLine = array('lineid' => '004', 'lineTotalAmount' => 100.0, 'linestatusreasoncode' => 'DETAIL');
 		$amounts = $this->callResolveLineAmounts($protocol, $parsedLine, 2.0, 40.0);
 
-		$this->assertSame(2.0, $amounts['qty'], 'nothing is invented, the document is only reported');
-		$this->assertSame(40.0, $amounts['subprice']);
+		$this->assertSame(2.0, $amounts['qty'], 'the quantity of the document is kept');
+		$this->assertEquals(50.0, $amounts['subprice'], 'the price is the one that totals BT-131');
 		$this->assertStringContainsString('BT-131', $amounts['warning']);
 		$this->assertStringContainsString('80', $amounts['warning'], 'the warning names what was rebuilt');
 	}
@@ -680,26 +680,84 @@ class ReceivedInvoiceLinesTest extends CommonClassTest
 	}
 
 	/**
-	 * The refinement is bounded by what the six decimals of BT-146 can hide, so a document whose line
-	 * genuinely does not add up is still reported and never rewritten: over 1 951 593 units the price
-	 * rounding is worth 0.98 at most, and a difference of 5.24 is not that.
+	 * The reported case of issue #850: a bank fee whose line is priced elsewhere than it is billed. The
+	 * document states a quantity of 0.5999 - the rate the fee is computed at, printed as "0,5999 %" on
+	 * the PDF - against a price of 50 005.00, the credit it applies to, and announces the fee itself,
+	 * 300.00. The couple rebuilds 50 005.00, which is what the invoice used to carry.
 	 *
 	 * @return	void
 	 */
-	public function testADifferenceWiderThanThePriceRoundingIsOnlyReported()
+	public function testALinePricedElsewhereThanItIsBilledTotalsTheAnnouncedAmount()
 	{
-		$parsedLine = array('lineid' => '3', 'lineTotalAmount' => 15.00);
+		global $db;
 
-		$amounts = $this->amounts($parsedLine, 1951593.0, 0.000005);
+		$protocol = new CIIProtocol($db);
 
-		$this->assertSame(0.000005, $amounts['subprice'], 'the price the document states is left alone');
-		$this->assertStringContainsString('The invoice carries the rebuilt amount', $amounts['warning']);
+		$lines = $protocol->parseInvoiceLines($this->documentWithLine('
+      <ram:AssociatedDocumentLineDocument><ram:LineID>2608</ram:LineID></ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct><ram:Name>Frais dossier</ram:Name></ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>50005.000000</ram:ChargeAmount>
+          <ram:BasisQuantity unitCode="A9">0.5999</ram:BasisQuantity>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery><ram:BilledQuantity unitCode="A9">0.5999</ram:BilledQuantity></ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation><ram:LineTotalAmount>300.00</ram:LineTotalAmount></ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>'));
 
-		// The other end of the same rule: an ordinary line of two units at 40.00 announcing 100.00 is a
-		// document that contradicts itself, whatever its price precision, and stays reported.
-		$ordinary = $this->amounts(array('lineid' => '4', 'lineTotalAmount' => 100.0), 2.0, 40.0);
-		$this->assertSame(40.0, $ordinary['subprice'], 'nothing is invented on a plain quantity');
-		$this->assertStringContainsString('rebuild 80', $ordinary['warning']);
+		$this->assertCount(1, $lines);
+
+		$imported = $this->importedLine($lines[0]);
+
+		$this->assertSame(0.5999, $imported['qty'], 'the quantity the document bills is kept');
+		$this->assertEquals(300.00, $imported['rebuilt'], 'the line totals BT-131, not the 50005.00 its price rebuilds');
+		$this->assertStringContainsString('rebuild 50005', $imported['warning'], 'the import says what the document rebuilds');
+		$this->assertStringContainsString('imported at the amount announced', $imported['warning'], 'and what it did about it');
+	}
+
+	/**
+	 * A charge of the line (BG-28) is part of BT-131 but leaves on a line of its own (issue #735), so the
+	 * line itself is worth BT-131 less that charge: the couple the document states rebuilds exactly that,
+	 * and nothing is rewritten or reported. Five units at 100.05 less 10.001 percent, plus a charge of
+	 * 7.00, announcing 457.22.
+	 *
+	 * @return	void
+	 */
+	public function testAChargeOfTheLineIsOutOfTheComparison()
+	{
+		$parsedLine = array(
+			'lineid' => '6',
+			'lineTotalAmount' => 457.22,
+			'lineAllowances' => array(
+				array('indicator' => 'false', 'actualAmount' => 50.03, 'reason' => 'Commercial discount'),
+				array('indicator' => 'true', 'actualAmount' => 7.00, 'reasonCode' => 'FC', 'reason' => 'Handling'),
+			),
+		);
+
+		$amounts = $this->amounts($parsedLine, 5.0, 100.05, 10.001);
+
+		$this->assertSame(100.05, $amounts['subprice'], 'the price of the document is left alone');
+		$this->assertSame('', $amounts['warning'], 'and the charge is not read as a document that does not add up');
+
+		// Without the charge line the same figures do not add up, and there the price is refined.
+		unset($parsedLine['lineAllowances'][1]);
+		$this->assertNotSame('', $this->amounts($parsedLine, 5.0, 100.05, 10.001)['warning']);
+	}
+
+	/**
+	 * A line announcing nothing has no amount to be imported at: BT-131 is what a line is worth, and an
+	 * absent one is not a figure to rewrite a price against. It keeps what its own price rebuilds.
+	 *
+	 * @return	void
+	 */
+	public function testALineAnnouncingNothingKeepsWhatItsPriceRebuilds()
+	{
+		$amounts = $this->amounts(array('lineid' => '5', 'lineTotalAmount' => 0.0), 2.0, 40.0);
+
+		$this->assertSame(40.0, $amounts['subprice'], 'nothing is rewritten against an absent BT-131');
+		$this->assertStringContainsString('carries the rebuilt amount', $amounts['warning']);
 	}
 
 	/**

--- a/einvoicing/test/phpunit/ReceivedInvoiceLinesTest.php
+++ b/einvoicing/test/phpunit/ReceivedInvoiceLinesTest.php
@@ -644,6 +644,85 @@ class ReceivedInvoiceLinesTest extends CommonClassTest
 	}
 
 	/**
+	 * The reported case of issue #844, read from the document the way the import reads it: a metered
+	 * consumption of 1 951 593 units at 0.00000548, which the issuer can only write as 0.000005 (BT-146
+	 * takes six decimals, BR-FR-DEC-03). Quantity times that price rebuilds 9.76 where the document
+	 * announces 10.69, and the invoice used to carry the 9.76.
+	 *
+	 * @return	void
+	 */
+	public function testTheReportedRoundedUnitPriceStillTotalsTheAnnouncedAmount()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$lines = $protocol->parseInvoiceLines($this->documentWithLine('
+      <ram:AssociatedDocumentLineDocument><ram:LineID>478803531</ram:LineID></ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct><ram:Name>Stockage Standard Infrequent Access</ram:Name></ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:NetPriceProductTradePrice><ram:ChargeAmount>0.000005</ram:ChargeAmount></ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery><ram:BilledQuantity unitCode="C62">1951593.0000</ram:BilledQuantity></ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation><ram:LineTotalAmount>10.69</ram:LineTotalAmount></ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>'));
+
+		$this->assertCount(1, $lines);
+		$this->assertNull($lines[0]['netpricebasisquantity'], 'BT-149 is absent: the price is stated per unit, rounded');
+
+		$imported = $this->importedLine($lines[0]);
+
+		$this->assertSame(1951593.0, $imported['qty'], 'the quantity the document bills is kept');
+		$this->assertEquals(10.69, $imported['rebuilt'], 'the line totals BT-131, not 9.76');
+		$this->assertStringContainsString('BR-FR-DEC-03', $imported['warning'], 'the import says what it refined and why');
+		$this->assertStringContainsString('MAIN_MAX_DECIMALS_UNIT', $imported['warning'], 'and that such a price is stored as zero');
+	}
+
+	/**
+	 * The refinement is bounded by what the six decimals of BT-146 can hide, so a document whose line
+	 * genuinely does not add up is still reported and never rewritten: over 1 951 593 units the price
+	 * rounding is worth 0.98 at most, and a difference of 5.24 is not that.
+	 *
+	 * @return	void
+	 */
+	public function testADifferenceWiderThanThePriceRoundingIsOnlyReported()
+	{
+		$parsedLine = array('lineid' => '3', 'lineTotalAmount' => 15.00);
+
+		$amounts = $this->amounts($parsedLine, 1951593.0, 0.000005);
+
+		$this->assertSame(0.000005, $amounts['subprice'], 'the price the document states is left alone');
+		$this->assertStringContainsString('The invoice carries the rebuilt amount', $amounts['warning']);
+
+		// The other end of the same rule: an ordinary line of two units at 40.00 announcing 100.00 is a
+		// document that contradicts itself, whatever its price precision, and stays reported.
+		$ordinary = $this->amounts(array('lineid' => '4', 'lineTotalAmount' => 100.0), 2.0, 40.0);
+		$this->assertSame(40.0, $ordinary['subprice'], 'nothing is invented on a plain quantity');
+		$this->assertStringContainsString('rebuild 80', $ordinary['warning']);
+	}
+
+	/**
+	 * A discounted line is refined the same way, on the price the discount is applied to: the couple the
+	 * core stores is quantity, unit price and percent, and it is their product that has to total BT-131.
+	 *
+	 * @return	void
+	 */
+	public function testTheRefinedPriceAccountsForTheLineDiscount()
+	{
+		$parsedLine = array('lineid' => '5', 'lineTotalAmount' => 8.55);
+
+		$amounts = $this->amounts($parsedLine, 1951593.0, 0.000005, 20.0);
+
+		$this->assertSame(20.0, $amounts['remise_percent'], 'the discount of the document is kept');
+		$this->assertEquals(
+			8.55,
+			round($amounts['qty'] * $amounts['subprice'] * (1 - ($amounts['remise_percent'] / 100)), 2),
+			'the line still totals what BT-131 announces'
+		);
+	}
+
+	/**
 	 * Every other shape of BT-149 leaves the price alone. It is optional and means one when absent;
 	 * BR-64 requires it to be positive when it is there, so a zero or a negative one is a broken
 	 * document and the price it states is the best the import can do with it.


### PR DESCRIPTION
Fixes #844.
Fixes #850.

## The rule

**BT-131 is what a line is worth.** The totals of a document are summed from it (BR-CO-10, BR-CO-13) and **no rule of EN 16931 ties it to quantity × price** — the item net price (BT-146) only says how the issuer priced the line. The import rebuilt each line from that couple and kept the result, so a line the issuer prices otherwise than it bills it came in at the wrong amount, and so did the invoice.

Two documents, one cause:

- **#844** — metered consumption, 1 951 593 units really at 0.00000548. A unit price is written with at most **6 decimals** (`BR-FR-DEC-03`, fatal, French Schematron), so the issuer writes `0.000005` and the rebuild lands on **9.76** where the line announces **10.69**. The document is conformant; only the printed precision of the price is at fault.
- **#850** — a bank fee, printed on the PDF as *quantité 50 005,00 € / P.U. 0,5999 %* and written in the XML as a quantity of `0.5999` against a price of `50005.000000`, announcing the fee itself, **300.00**. Dolibarr created the invoice at **50 005.00**.

### What the rule set actually says

Checked against the executable schematrons, not from memory. In annex A of XP Z12-012 (the normative file, EUPL, shipped in the FNFE repository) **BT-131 carries three rules**: `BR-24` (present), `BR-FR-DEC-01` (2 decimals) and `BR-FR-MV-10` (the VAT-inclusive amount of a `GROUP` line). BT-146 carries `BR-26`, `BR-27`, `BR-FR-DEC-03`, and one stated relation only: *net price = gross price − item price discount*. The CEN schematron agrees: on `ram:LineTotalAmount` there is nothing but BR-24, BR-DEC-23, `BR-CO-10` and the VAT base rules `BR-*-08`. **No rule computes BT-131 from quantity and price** — while `BR-CO-10` (fatal) makes BT-131 the one line figure the totals of the document are summed from.

Run through the full FNFE chain (XSD + profile XSLT + BR-FR), the reported document of #850 rebuilt as EN 16931 comes out **VALID** (97 profile checks, 67 CTC-FR checks, no failure), and the reporter's own EXTENDED XML fails only on the identifiers they redacted. It is a conformant document, and it was imported at 167× what it bills.

The only place the calculation is enforced is `PEPPOL-EN16931-R120` (fatal, 0.02 slack), a Peppol CIUS rule — absent from every FNFE schematron, CII and UBL alike.

Both are now imported **at the amount announced**, at the unit price that totals it over the quantity the document bills. The message names what the couple rebuilt and what was stored, and says whether the difference is the rounding of the price (a consistent document) or wider (a document that prices a line elsewhere than it bills it). A line announcing nothing is left alone: there is no amount to import it at.

The **charges of a line (BG-28)** leave that comparison. They are part of BT-131 but rejoin the invoice as lines of their own (#735), so BT-131 was being compared to a line that never carried them: every charged line was reported for a difference that was its own charge, and refining its price would have counted it twice.

The precision note of #777 follows the same line: it fired only on a price rounding to exactly zero, and now on any price whose stored copy (`MAIN_MAX_DECIMALS_UNIT`) no longer rebuilds the amount imported, saying what reopening the line would recompute.

## Measured

Real imports through `createSupplierInvoiceFromSource()` on **Dolibarr 23.0.4**, read back from the database:

| document | announced | before | after |
|---|---|---|---|
| #844 — 1 951 593 × 0.000005 | 10.69 | 9.76 | **10.69** |
| #850 — 0.5999 × 50 005.00 | 300.00 | 50 005.00 | **300.00** |
| #735 — 5 × 100.05 −10 %, charge 7.00 | 457.22 | 457.22, reported | **457.22, silent** |

## Tests

Module suite **file by file on 18.0.10, 19, 20, 21, 22, 23.0.4, 24.0 and 25**, each core under the PHP version of the CI matrix: same verdict as `main`, the residual failures being present on `main` too (`CdarDateFormatTest` on 19, subject of #846, and `MandatoryThirdpartyExtrafieldTest`, bench state). QA generation matrix, 9 instances × 14 documents: 126/126. E2E, 16 cycles both ways: all complete (200, 201, 205, 211, 212).

Five cases added to `test/phpunit/ReceivedInvoiceLinesTest.php`, both reported lines read end to end from their XML.
