### PR TITLE
FIX #847 [einvoicing] The commercial name of the customer is the trading name of the document

### DIFF
--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -134,6 +134,10 @@ $myGlobalIdProf    = idprof($mysoc);
 $mySchemeGlobalIdProf = $this->getIEC6523Code($mysoc->country_code, 1);
 $myUri             = $einvoicing->getSellerCommunicationURI(0);
 $mySchemeUri       = $this->getIEC6523Code($mysoc->country_code, 2);
+// BT-28, the trading name of the seller: "a name by which the seller is known, other than the
+// seller name". The company setup of the core has no such field, so there is nothing to declare
+// here and the term is left out of the document (issue #847).
+$sellerTradingName = trim((string) ($mysoc->name_alias ?? ''));
 
 // Buyer party resolution.
 // The external BILLING contact always fills the buyer contact group (BG-9). Whether it also *replaces*
@@ -192,6 +196,13 @@ if (!empty($billingContactIds) && $object->fetch_contact($billingContactIds[0]) 
 // Buyer identifiers (resolved buyer party: invoice thirdparty or billing-contact recipient)
 if (!($buyerParty instanceof Societe)) {
 	throw new \RuntimeException('einvoicing: invoice thirdparty is not a valid Societe (invoice id=' . $object->id . ')');
+}
+// BT-45, the trading name of the buyer: Dolibarr keeps it on the third party as name_alias,
+// labelled "Alias name (commercial, trademark, ...)". A term that only repeats the name of the
+// party says nothing, and the norm asks for it only when it differs (issue #847).
+$buyerTradingName  = trim((string) $buyerParty->name_alias);
+if ($buyerTradingName === trim((string) $buyerName)) {
+	$buyerTradingName = '';
 }
 $idprof            = idprof($buyerParty) ?? '';
 $schemeIdProf      = $this->getIEC6523Code($buyerParty->country_code);
@@ -972,7 +983,7 @@ $invoiceData = [
 
 	'sellerLegalOrgId'          => $myidprof,
 	'sellerLegalOrgScheme'      => $mySchemeIdProf,
-	'sellerTradingName'         => $mysoc->name ?? 'SPECIMEN',
+	'sellerTradingName'         => $sellerTradingName,
 
 	// Buyer part
 	'buyername'                 =>  $buyerName ?: 'CUSTOMER',
@@ -992,7 +1003,7 @@ $invoiceData = [
 
 	'buyerLegalOrgId'           => $idprof,
 	'buyerLegalOrgScheme'       => $schemeIdProf,
-	'buyerTradingName'          => $buyerName,
+	'buyerTradingName'          => $buyerTradingName,
 
 	'buyerReference'            => $buyerReference,
 

--- a/einvoicing/test/phpunit/TradingNameFromAliasTest.php
+++ b/einvoicing/test/phpunit/TradingNameFromAliasTest.php
@@ -1,0 +1,256 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/TradingNameFromAliasTest.php
+ *      \ingroup    test
+ *      \brief      The trading name of a party is its commercial name, or nothing at all.
+ *      \remarks    BT-45 carried the legal name of the customer, repeating BT-44, and the commercial
+ *                  name recorded on the third party card never reached the document (#847). The
+ *                  document is built here from a real invoice, because the value comes from the
+ *                  assembly of the invoice data, not from the writer that puts it in the XML.
+ */
+
+
+// This script must only be run from the command line.
+if (PHP_SAPI !== 'cli') {
+	echo "Error: this script must be run from the command line (CLI), not through a web server.\n";
+	exit(1);
+}
+
+global $conf, $user, $langs, $db;
+
+// Load Dolibarr environment. Same resolution as the other test files of the module.
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+require_once $dolibarrHtdocs . '/master.inc.php';
+require_once DOL_DOCUMENT_ROOT . '/user/class/user.class.php';
+require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
+require_once DOL_DOCUMENT_ROOT . '/compta/facture/class/facture.class.php';
+
+/**
+ * @var Conf $conf
+ * @var DoliDB $db
+ * @var Translate $langs
+ * @var User $user
+ */
+
+dol_include_once('einvoicing/class/protocols/CIIProtocol.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+
+/**
+ * Class TradingNameFromAliasTest
+ *
+ * Invoices three customers - one with a commercial name, one without, one whose commercial name
+ * merely repeats its legal name - and reads BT-28 and BT-45 back from the generated document.
+ */
+class TradingNameFromAliasTest extends CommonClassTest
+{
+	const RAM = 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100';
+
+	/** @var string	Legal name of the customer, the one BT-44 states */
+	const BUYER_NAME = 'EINVOICING TEST ALIAS BUYER';
+	/** @var string	Commercial name of the customer, the one BT-45 is for */
+	const BUYER_ALIAS = 'Alias & Commerce';
+
+	/**
+	 * Build one invoice for a customer of the given shape and generate its document.
+	 *
+	 * @param	string	$alias	Commercial name of the customer, empty for a customer without one
+	 * @return	string			The generated document
+	 */
+	private function documentForAlias($alias)
+	{
+		global $conf, $db, $langs, $mysoc;
+
+		$user = new User($db);
+		$this->assertGreaterThan(0, $user->fetch(1), 'the instance has a user to act as');
+
+		// The seller is the company of the instance, whose identifiers a demo database does not
+		// necessarily fill: the generation stops before the first name is written without them.
+		// $mysoc is a global object, so pinning it changes nothing in the database and is undone below.
+		$savSeller = array(
+			'idprof1' => $mysoc->idprof1,
+			'idprof2' => $mysoc->idprof2,
+			'tva_intra' => $mysoc->tva_intra,
+			'country_id' => $mysoc->country_id,
+			'country_code' => $mysoc->country_code,
+			'name_alias' => $mysoc->name_alias,
+		);
+		$mysoc->idprof1 = '000000001';
+		$mysoc->idprof2 = '00000000100010';
+		$mysoc->tva_intra = 'FR12000000001';
+		$mysoc->country_id = 1;
+		$mysoc->country_code = 'FR';
+
+		$savPdp = getDolGlobalString('EINVOICING_PDP');
+		$conf->global->EINVOICING_PDP = 'SPECIMEN';
+
+		try {
+			$buyer = new Societe($db);
+			$buyer->name = self::BUYER_NAME;
+			$buyer->name_alias = $alias;
+			$buyer->client = 1;
+			// Some instances - the demo database among them - number their customers with a module
+			// that refuses a third party without a code.
+			$buyer->code_client = 'EINVAL' . strtoupper(substr(md5(uniqid('', true)), 0, 6));
+			$buyer->address = '2 rue du Test';
+			$buyer->zip = '75000';
+			$buyer->town = 'Paris';
+			$buyer->country_id = 1;			// France
+			$buyer->country_code = 'FR';
+			$buyer->idprof1 = '000000002';
+			$buyer->idprof2 = '00000000200010';
+			$buyer->tva_intra = 'FR12000000002';
+			$this->assertGreaterThan(0, $buyer->create($user), 'the customer is created: ' . $buyer->error);
+
+			$invoice = new Facture($db);
+			$invoice->socid = $buyer->id;
+			$invoice->type = Facture::TYPE_STANDARD;
+			$invoice->date = dol_now();
+			$this->assertGreaterThan(0, $invoice->create($user), 'the invoice is created: ' . $invoice->error);
+
+			$lineId = $invoice->addline('Alias line', 100.0, 1, 20.0);
+			$this->assertGreaterThan(0, $lineId, 'the line of the invoice is added: ' . $invoice->error);
+
+			$reloaded = new Facture($db);
+			$this->assertGreaterThan(0, $reloaded->fetch($invoice->id), 'the invoice is read back');
+			$reloaded->fetch_lines();
+			$reloaded->fetch_thirdparty();
+
+			$protocol = new CIIProtocol($db);
+			$path = $protocol->generateXML($reloaded, $langs);
+			$this->assertNotEmpty($path, 'the document is generated: ' . $protocol->error . ' ' . implode(', ', (array) $protocol->errors));
+			$this->assertFileExists((string) $path, 'the generated document is written');
+
+			return (string) file_get_contents((string) $path);
+		} finally {
+			$conf->global->EINVOICING_PDP = $savPdp;
+			foreach ($savSeller as $property => $value) {
+				$mysoc->$property = $value;
+			}
+		}
+	}
+
+	/**
+	 * Read one term of a party out of the document.
+	 *
+	 * @param	string	$xml	The generated document
+	 * @param	string	$party	ram:SellerTradeParty or ram:BuyerTradeParty
+	 * @param	string	$term	Element to read, relative to the party
+	 * @return	?string			Its text, null when the element is absent
+	 */
+	private function partyTerm($xml, $party, $term)
+	{
+		$doc = new DOMDocument();
+		$this->assertTrue($doc->loadXML($xml), 'the generated document is well formed XML');
+		$xpath = new DOMXPath($doc);
+		$xpath->registerNamespace('ram', self::RAM);
+
+		$found = $xpath->query('//ram:' . $party . '/' . $term);
+
+		return ($found !== false && $found->length > 0) ? $found->item(0)->textContent : null;
+	}
+
+	/**
+	 * The commercial name recorded on the customer is the one the document states as BT-45.
+	 *
+	 * On the code of #847 this reads the legal name of the customer instead.
+	 *
+	 * @return void
+	 */
+	public function testTheCommercialNameOfTheCustomerIsItsTradingName()
+	{
+		$xml = $this->documentForAlias(self::BUYER_ALIAS);
+
+		$this->assertSame(
+			self::BUYER_NAME,
+			$this->partyTerm($xml, 'BuyerTradeParty', 'ram:Name'),
+			'BT-44 states the legal name of the customer'
+		);
+		$this->assertSame(
+			self::BUYER_ALIAS,
+			$this->partyTerm($xml, 'BuyerTradeParty', 'ram:SpecifiedLegalOrganization/ram:TradingBusinessName'),
+			'BT-45 states the commercial name of the customer'
+		);
+	}
+
+	/**
+	 * A customer without a commercial name has no BT-45, and an absent term is an absent element:
+	 * an empty one is refused by PEPPOL-EN16931-R008 (#695).
+	 *
+	 * @return void
+	 */
+	public function testACustomerWithoutACommercialNameHasNoTradingName()
+	{
+		$xml = $this->documentForAlias('');
+
+		$this->assertNull(
+			$this->partyTerm($xml, 'BuyerTradeParty', 'ram:SpecifiedLegalOrganization/ram:TradingBusinessName'),
+			'BT-45 is left out when the customer has no commercial name'
+		);
+		$this->assertStringNotContainsString(
+			'<ram:TradingBusinessName/>',
+			$xml,
+			'no empty element is written'
+		);
+	}
+
+	/**
+	 * A commercial name that merely repeats the legal name says nothing, and the norm asks for the
+	 * term only when it differs from the name of the party.
+	 *
+	 * @return void
+	 */
+	public function testACommercialNameThatRepeatsTheLegalNameIsNotStated()
+	{
+		$xml = $this->documentForAlias(self::BUYER_NAME);
+
+		$this->assertNull(
+			$this->partyTerm($xml, 'BuyerTradeParty', 'ram:SpecifiedLegalOrganization/ram:TradingBusinessName'),
+			'BT-45 is left out when it would repeat BT-44'
+		);
+	}
+
+	/**
+	 * The company setup of the core has no commercial name, so the seller has no BT-28 to declare.
+	 *
+	 * @return void
+	 */
+	public function testTheSellerStatesNoTradingNameItDoesNotHave()
+	{
+		$xml = $this->documentForAlias(self::BUYER_ALIAS);
+
+		// Whatever the instance is called, its name is stated: without that the absence below would
+		// only prove that the seller party was not built at all.
+		$this->assertNotEmpty(
+			(string) $this->partyTerm($xml, 'SellerTradeParty', 'ram:Name'),
+			'BT-27 states the name of the company of the instance'
+		);
+		$this->assertNull(
+			$this->partyTerm($xml, 'SellerTradeParty', 'ram:SpecifiedLegalOrganization/ram:TradingBusinessName'),
+			'BT-28 is left out: the core has no commercial name for the company of the instance'
+		);
+	}
+}

--- a/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_creditnote.xml
+++ b/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_creditnote.xml
@@ -77,7 +77,6 @@
         <ram:Name>EINVOICING TEST SELLER</ram:Name>
         <ram:SpecifiedLegalOrganization>
           <ram:ID schemeID="0002">000000001</ram:ID>
-          <ram:TradingBusinessName>EINVOICING TEST SELLER</ram:TradingBusinessName>
         </ram:SpecifiedLegalOrganization>
         <ram:DefinedTradeContact>
           <ram:PersonName>EINVOICING TEST SELLER</ram:PersonName>
@@ -107,7 +106,6 @@
         <ram:Name>EINVOICING TEST BUYER</ram:Name>
         <ram:SpecifiedLegalOrganization>
           <ram:ID schemeID="0002">000000002</ram:ID>
-          <ram:TradingBusinessName>EINVOICING TEST BUYER</ram:TradingBusinessName>
         </ram:SpecifiedLegalOrganization>
         <ram:PostalTradeAddress>
           <ram:PostcodeCode>75000</ram:PostcodeCode>

--- a/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_deposit.xml
+++ b/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_deposit.xml
@@ -77,7 +77,6 @@
         <ram:Name>EINVOICING TEST SELLER</ram:Name>
         <ram:SpecifiedLegalOrganization>
           <ram:ID schemeID="0002">000000001</ram:ID>
-          <ram:TradingBusinessName>EINVOICING TEST SELLER</ram:TradingBusinessName>
         </ram:SpecifiedLegalOrganization>
         <ram:DefinedTradeContact>
           <ram:PersonName>EINVOICING TEST SELLER</ram:PersonName>
@@ -107,7 +106,6 @@
         <ram:Name>EINVOICING TEST BUYER</ram:Name>
         <ram:SpecifiedLegalOrganization>
           <ram:ID schemeID="0002">000000002</ram:ID>
-          <ram:TradingBusinessName>EINVOICING TEST BUYER</ram:TradingBusinessName>
         </ram:SpecifiedLegalOrganization>
         <ram:PostalTradeAddress>
           <ram:PostcodeCode>75000</ram:PostcodeCode>

--- a/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_replacement.xml
+++ b/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_replacement.xml
@@ -77,7 +77,6 @@
         <ram:Name>EINVOICING TEST SELLER</ram:Name>
         <ram:SpecifiedLegalOrganization>
           <ram:ID schemeID="0002">000000001</ram:ID>
-          <ram:TradingBusinessName>EINVOICING TEST SELLER</ram:TradingBusinessName>
         </ram:SpecifiedLegalOrganization>
         <ram:DefinedTradeContact>
           <ram:PersonName>EINVOICING TEST SELLER</ram:PersonName>
@@ -107,7 +106,6 @@
         <ram:Name>EINVOICING TEST BUYER</ram:Name>
         <ram:SpecifiedLegalOrganization>
           <ram:ID schemeID="0002">000000002</ram:ID>
-          <ram:TradingBusinessName>EINVOICING TEST BUYER</ram:TradingBusinessName>
         </ram:SpecifiedLegalOrganization>
         <ram:PostalTradeAddress>
           <ram:PostcodeCode>75000</ram:PostcodeCode>

--- a/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_situation.xml
+++ b/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_situation.xml
@@ -77,7 +77,6 @@
         <ram:Name>EINVOICING TEST SELLER</ram:Name>
         <ram:SpecifiedLegalOrganization>
           <ram:ID schemeID="0002">000000001</ram:ID>
-          <ram:TradingBusinessName>EINVOICING TEST SELLER</ram:TradingBusinessName>
         </ram:SpecifiedLegalOrganization>
         <ram:DefinedTradeContact>
           <ram:PersonName>EINVOICING TEST SELLER</ram:PersonName>
@@ -107,7 +106,6 @@
         <ram:Name>EINVOICING TEST BUYER</ram:Name>
         <ram:SpecifiedLegalOrganization>
           <ram:ID schemeID="0002">000000002</ram:ID>
-          <ram:TradingBusinessName>EINVOICING TEST BUYER</ram:TradingBusinessName>
         </ram:SpecifiedLegalOrganization>
         <ram:PostalTradeAddress>
           <ram:PostcodeCode>75000</ram:PostcodeCode>

--- a/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_standard.xml
+++ b/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_standard.xml
@@ -77,7 +77,6 @@
         <ram:Name>EINVOICING TEST SELLER</ram:Name>
         <ram:SpecifiedLegalOrganization>
           <ram:ID schemeID="0002">000000001</ram:ID>
-          <ram:TradingBusinessName>EINVOICING TEST SELLER</ram:TradingBusinessName>
         </ram:SpecifiedLegalOrganization>
         <ram:DefinedTradeContact>
           <ram:PersonName>EINVOICING TEST SELLER</ram:PersonName>
@@ -107,7 +106,6 @@
         <ram:Name>EINVOICING TEST BUYER</ram:Name>
         <ram:SpecifiedLegalOrganization>
           <ram:ID schemeID="0002">000000002</ram:ID>
-          <ram:TradingBusinessName>EINVOICING TEST BUYER</ram:TradingBusinessName>
         </ram:SpecifiedLegalOrganization>
         <ram:PostalTradeAddress>
           <ram:PostcodeCode>75000</ram:PostcodeCode>


### PR DESCRIPTION
Closes #847.

## What the report shows, and what is left of it

The report carries two distinct defects. Both were reproduced on a throwaway PostgreSQL instance
built for the occasion (Dolibarr 24.0.1, PHP 8.5, PostgreSQL 16), against the released code:

**The empty element is already fixed on main, and not yet released.** An ampersand in the name of
the customer blanked the element that carried it, so the document went out with
`<ram:TradingBusinessName/>` and the Access Point refused it:

```
FA2609-0003_cii.xml : is_valid=false
  FACTUR-X_EN16931.xslt   checks=92 messages=1
     - [PEPPOL-EN16931-R008]-Document MUST not contain empty elements.
       .../ram:BuyerTradeParty/.../ram:TradingBusinessName
```

That is #695, fixed by 6ba73734. Nothing to do here beyond noting it.

**What is left is what the reporter describes**: they filled the company name *and* the commercial
name on the customer card, and neither the commercial name nor an omission came out. BT-45 carried
the legal name of the customer, a plain copy of BT-44:

```xml
<ram:Name>Riou &amp; Fils SAS</ram:Name>
<ram:SpecifiedLegalOrganization>
  <ram:ID schemeID="0002">899047773</ram:ID>
  <ram:TradingBusinessName>Riou &amp; Fils SAS</ram:TradingBusinessName>
</ram:SpecifiedLegalOrganization>
```

BT-45 is defined as "a name by which the buyer is known, **other than** the buyer name", and
Dolibarr keeps exactly that on the third party as `name_alias`, labelled *Alias name (commercial,
trademark, ...)*. The reader side of the module already pairs the two: `_syncOrCreateThirdparty...`
matches `sellerTradingName` against `$thirdparty->name_alias`. Only the writer disagreed.

BT-28 had the same shape on the seller side, copying the name of the company of the instance.

## What changed

`buildinvoicelines.inc.php` only, plus its reference fixtures:

- BT-45 is read from the `name_alias` of the resolved buyer party (invoice third party, or the
  billing-contact recipient when `EINVOICING_USE_BILLING_CONTACT_AS_BUYER` is on).
- It is left out of the document when there is none, and when it would only repeat BT-44 - the
  only case the norm asks for it, and an absent term must be an absent element, not an empty one.
- BT-28 is left out: `setMysoc()` has no commercial name to read, on any version from 18 to 25, so
  the seller states no trading name it does not have.

After, on the same three customers:

| customer | BT-44 | BT-45 |
|---|---|---|
| `Tricaland Holding SAS` / alias `Tricaland & Fils` | `Tricaland Holding SAS` | `Tricaland &amp; Fils` |
| `Riou & Fils SAS` / alias `Riou Distribution` | `Riou &amp; Fils SAS` | `Riou Distribution` |
| `Sansalias SARL` / no alias | `Sansalias SARL` | *(element absent)* |

## Tests

- **New**: `test/phpunit/TradingNameFromAliasTest.php`, 4 tests built on real invoices in the
  database. Red on main (4/4), green with the patch.
- **Reference fixtures** regenerated with `scripts/regenerate_einvoicing_fixtures.php`: the diff is
  the two duplicated elements disappearing from each of the five samples, nothing else.
- **PHPUnit grid**: 30 files x 8 cores (18 to 25), 240 runs, no new failure. The single red,
  `CdarDateFormatTest` on 19, is already on main and is what #846 fixes.
- **Access Point**: the three documents above validate at SuperPDP, `is_valid=true`, including the
  BR-FR (CTC-FR) schematron - 65 checks, no message - so an absent BT-28 is not missed by anyone.
- **Full lifecycle, both directions**, between two instances of different database engines:
  PostgreSQL 24.0.1 -> MySQL emitter, statuses 200 / 201 / 205 / 211 back on the emitter; and the
  other way round, invoice imported as a supplier invoice and 200 / 201 / 212 recorded.
- phpcs and phan clean.
