### PR TITLE
FIX: [einvoicing] A telecom invoice no longer stops the whole synchronization

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -1223,6 +1223,25 @@ class CIIProtocol extends AbstractProtocol
 
 
 	/**
+	 * Tell whether a document referenced by a line is the identifier of the object being billed
+	 * rather than a document this Dolibarr could hold.
+	 *
+	 * A ReferenceTypeCode (BT-128-1) qualifies the scheme of an "Invoiced object identifier"
+	 * (BT-128): what the line bills - a phone number, a meter, a subscription - and never a document.
+	 * Telecom and utility issuers put one on every line, so looking those up as supplier invoices
+	 * fails each of their invoices, and from the scheduler it stops the whole synchronization on the
+	 * first one. The deposit references this module itself emits carry no ReferenceTypeCode, which is
+	 * what keeps them out of this test and on the lookup path.
+	 *
+	 * @param 	array 	$refDoc		One entry of the line's additionalRefDocs, as parseInvoiceLines() returns it
+	 * @return 	bool				True when the reference designates the billed object, not a document
+	 */
+	protected function lineRefDocIsInvoicedObjectIdentifier(array $refDoc): bool
+	{
+		return !empty($refDoc['referenceTypeCode']);
+	}
+
+	/**
 	 * Add lines to a supplier invoice from e-invoice parsed lines
 	 *
 	 * @param 	FactureFournisseur 	$supplierInvoice						The supplier invoice to add lines on
@@ -1252,6 +1271,10 @@ class CIIProtocol extends AbstractProtocol
 					$lineRefDocId = $refDoc['IssuerAssignedID'] ?? null;
 					$lineRefDocType = $refDoc['typeCode'] ?? null;
 					$lineRefDocDate = $refDoc['issueDate'] ?? null;
+
+					if ($this->lineRefDocIsInvoicedObjectIdentifier($refDoc)) {
+						continue;
+					}
 
 					$linkedObjectId = SupplierInvoiceHelper::findIdByRef($lineRefDocId, (int) $parsedLine['supplierId']);
 					if ($linkedObjectId < 0) {

--- a/einvoicing/test/phpunit/ReceivedInvoiceLinesTest.php
+++ b/einvoicing/test/phpunit/ReceivedInvoiceLinesTest.php
@@ -1344,4 +1344,95 @@ class ReceivedInvoiceLinesTest extends CommonClassTest
 			array('indicator' => 'false', 'actualAmount' => 5.00, 'reason' => 'Commercial gesture', 'rateApplicablePercent' => 20.0),
 		)));
 	}
+
+	/**
+	 * Call CIIProtocol::lineRefDocIsInvoicedObjectIdentifier() through reflection: pure decision
+	 * logic, no DB access and no side effect.
+	 *
+	 * @param	CIIProtocol		$protocol	Protocol instance
+	 * @param	array			$refDoc		One entry of the line's additionalRefDocs
+	 * @return	bool						What the caller would decide
+	 */
+	private function callLineRefDocIsInvoicedObjectIdentifier(CIIProtocol $protocol, array $refDoc)
+	{
+		$method = new ReflectionMethod(CIIProtocol::class, 'lineRefDocIsInvoicedObjectIdentifier');
+		$method->setAccessible(true);
+
+		return $method->invoke($protocol, $refDoc);
+	}
+
+	/**
+	 * A telecom issuer writes the billed line on each invoice line as an Invoiced object identifier
+	 * (BT-128): TypeCode 130 and, what tells it apart, a ReferenceTypeCode qualifying its scheme.
+	 * That identifier is a phone number, not a document, and it used to be looked up as a supplier
+	 * invoice - failing every such invoice, and stopping the scheduled synchronization on the first.
+	 *
+	 * The number below is taken from the 0639 98 00 00 - 0639 98 99 99 range the ARCEP reserves for
+	 * fiction, so that no test data points at a real subscriber.
+	 *
+	 * @return	void
+	 */
+	public function testAnInvoicedObjectIdentifierIsNotLookedUpAsADocument()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$xml = $this->documentWithLine('
+      <ram:AssociatedDocumentLineDocument><ram:LineID>000001</ram:LineID></ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct><ram:Name>Forfait 250Go 5G SIM Seule</ram:Name></ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:AdditionalReferencedDocument>
+          <ram:IssuerAssignedID>0639980000</ram:IssuerAssignedID>
+          <ram:TypeCode>130</ram:TypeCode>
+          <ram:ReferenceTypeCode>AWV</ram:ReferenceTypeCode>
+        </ram:AdditionalReferencedDocument>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation><ram:LineTotalAmount>39.16</ram:LineTotalAmount></ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>');
+
+		$lines = $protocol->parseInvoiceLines($xml);
+		$this->assertCount(1, $lines);
+		$this->assertCount(1, $lines[0]['additionalRefDocs'], 'the reference is read');
+		$this->assertSame('AWV', $lines[0]['additionalRefDocs'][0]['referenceTypeCode'], 'BT-128-1 reaches the parsed line');
+
+		$this->assertTrue(
+			$this->callLineRefDocIsInvoicedObjectIdentifier($protocol, $lines[0]['additionalRefDocs'][0]),
+			'a qualified identifier is the billed object, so no invoice is looked up for it'
+		);
+	}
+
+	/**
+	 * The deposit reference this module emits on a line carries TypeCode 130 too, but no
+	 * ReferenceTypeCode: it does designate an invoice, and must keep going through the lookup.
+	 * This is what forbids keying the decision on TypeCode 130 alone.
+	 *
+	 * @return	void
+	 */
+	public function testADepositReferenceIsStillLookedUp()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$xml = $this->documentWithLine('
+      <ram:AssociatedDocumentLineDocument><ram:LineID>000001</ram:LineID></ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct><ram:Name>(DEPOSIT)</ram:Name></ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:AdditionalReferencedDocument>
+          <ram:IssuerAssignedID>FA2601-0042</ram:IssuerAssignedID>
+          <ram:TypeCode>130</ram:TypeCode>
+        </ram:AdditionalReferencedDocument>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation><ram:LineTotalAmount>-100.00</ram:LineTotalAmount></ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>');
+
+		$lines = $protocol->parseInvoiceLines($xml);
+		$this->assertCount(1, $lines);
+		$this->assertSame('130', $lines[0]['additionalRefDocs'][0]['typeCode'], 'the same TypeCode as the telecom case');
+		$this->assertEmpty($lines[0]['additionalRefDocs'][0]['referenceTypeCode'], 'and no scheme qualifying it');
+
+		$this->assertFalse(
+			$this->callLineRefDocIsInvoicedObjectIdentifier($protocol, $lines[0]['additionalRefDocs'][0]),
+			'an unqualified reference still designates a document to look up'
+		);
+	}
 }


### PR DESCRIPTION
## What

A scheduled sync stopped on a received telecom invoice with:

```
Document "06XXXXXXXX" linked to line 000001 was not found in Dolibarr. [...]
you must manually create the invoice using the supplier invoice reference "06XXXXXXXX".
```

That reference is not an invoice. It is the mobile line the invoice bills. The document says so:

```xml
<ram:AdditionalReferencedDocument>
  <ram:IssuerAssignedID>06XXXXXXXX</ram:IssuerAssignedID>
  <ram:TypeCode>130</ram:TypeCode>
  <ram:ReferenceTypeCode>AWV</ram:ReferenceTypeCode>
</ram:AdditionalReferencedDocument>
```

`TypeCode 130` with a `ReferenceTypeCode` is BT-128, *Invoiced object identifier*: what the line bills — a phone number, a meter, a subscription. Never a document this Dolibarr could hold.

`createSupplierInvoiceLinesFromSource()` treated every `AdditionalReferencedDocument` of a line as a supplier invoice to find. It read `$lineRefDocType` and the parser filled `referenceTypeCode`, but neither was ever consulted.

Two consequences:

- **No telecom or utility invoice could be imported at all** — they all carry one identifier per line.
- **From the scheduler, the first one aborted the entire batch.** The flows behind it never synchronized, and since the cause never goes away, every following run stopped at the same place. Following the message and creating an invoice named after a phone number would not have helped: the next monthly invoice carries the same identifier, and each line of a fleet would ask for one more.

## How

`TypeCode 130` alone cannot carry the decision — **this module emits its own deposit lines with it**, building an `AdditionalReferencedDocument` with `TypeCode` 130. Keying on it would break the round trip of our own invoices.

The `ReferenceTypeCode` can: it qualifies the identifier as a billed object, and the deposit references emitted here have none. That single distinction is extracted into `lineRefDocIsInvoicedObjectIdentifier()`, tested through reflection the way the neighbouring decision helpers are.

## Test

Two cases added to `ReceivedInvoiceLinesTest`: the telecom shape is recognized as a billed object, and the deposit shape — same `TypeCode 130`, no `ReferenceTypeCode` — still goes through the lookup. The test number comes from the range the ARCEP reserves for fiction, so no test data points at a real subscriber.

Checked against a real flow from a French telecom issuer, imported inside a rolled-back transaction:

```
before -> res: -1   Document "06XXXXXXXX" linked to line 000001 was not found in Dolibarr.

after  -> res: <id>  Supplier Invoice created or updated
          ref_supplier=<the issuer's own invoice number>  HT=29.16  TTC=34.99  lines=3
```

The invoice imports under its real number instead of being refused, with the amounts the document announces.

Dolibarr 22, Factur-X CIUS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
