### PR TITLE
FIX #853 [einvoicing] The dates of a received document keep the day they state

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -969,7 +969,7 @@ class CIIProtocol extends AbstractProtocol
 			return ['res' => -1, 'message' => 'Unfounded dolibarr corresponding Invoice code for document type code: ' . dol_escape_htmltag((string) ($parsedHeader['documenttypecode'] ?? 'NA'))];
 		}
 		// documentdate is already formatted into 'Y-m-d' by the parser ZugFerd and CII
-		$supplierInvoice->date = !empty($parsedHeader['documentdate']) ? dol_stringtotime($parsedHeader['documentdate']) : null;
+		$supplierInvoice->date = !empty($parsedHeader['documentdate']) ? dol_stringtotime($parsedHeader['documentdate'], 'tzserver') : null;
 
 		// For credit notes and replacement invoices, link to the source invoice via fk_facture_source
 		// (BT-25). A replacement invoice (BT-3 = 384) corrects the invoice it references just as a credit
@@ -1697,18 +1697,18 @@ class CIIProtocol extends AbstractProtocol
 	/**
 	 * Billing period of a received line (BG-26 / BT-134 / BT-135), as the timestamps a Dolibarr line holds.
 	 *
-	 * The dates arrive as 'Y-m-d' strings and a line stores a timestamp, read with dol_stringtotime() the way the
-	 * invoice date already is (issue #576). One side alone is kept, BR-CO-20 accepting a start or an end. A period
-	 * that ends before it starts is dropped, keeping the line: updateline() answers -1 on that pair
-	 * (ErrorStartDateGreaterEnd), which would fail the whole import over a period.
+	 * The dates arrive as 'Y-m-d' strings and a line stores a timestamp, read in the timezone of the server the
+	 * way every other date of the document is (issue #576, then #853). One side alone is kept, BR-CO-20 accepting a
+	 * start or an end. A period that ends before it starts is dropped, keeping the line: updateline() answers -1 on
+	 * that pair (ErrorStartDateGreaterEnd), which would fail the whole import over a period.
 	 *
 	 * @param	array<string,mixed>				$parsedLine		One line as parseInvoiceLines() returns it
 	 * @return	array{start: ?int, end: ?int}					Timestamps to store, null for a side with nothing
 	 */
 	private function resolveLinePeriod(array $parsedLine)
 	{
-		$start = !empty($parsedLine['linePeriodStart']) ? dol_stringtotime((string) $parsedLine['linePeriodStart']) : null;
-		$end = !empty($parsedLine['linePeriodEnd']) ? dol_stringtotime((string) $parsedLine['linePeriodEnd']) : null;
+		$start = !empty($parsedLine['linePeriodStart']) ? dol_stringtotime((string) $parsedLine['linePeriodStart'], 'tzserver') : null;
+		$end = !empty($parsedLine['linePeriodEnd']) ? dol_stringtotime((string) $parsedLine['linePeriodEnd'], 'tzserver') : null;
 
 		// dol_stringtotime() answers false or '' on something it cannot read, and that must not reach idate().
 		$start = is_int($start) && $start > 0 ? $start : null;

--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -2150,7 +2150,7 @@ trait CommonProtocol
 		//------------------------
 		$dueDate = null;
 		if (!empty($parsedHeader['paymentDueDate'])) {
-			$dueDateTimestamp = dol_stringtotime($parsedHeader['paymentDueDate']);
+			$dueDateTimestamp = dol_stringtotime($parsedHeader['paymentDueDate'], 'tzserver');
 			if ($dueDateTimestamp) {
 				$dueDate = $dueDateTimestamp;
 				$supplierInvoice->date_echeance = $dueDate;
@@ -2163,7 +2163,7 @@ trait CommonProtocol
 		// Payment Terms (derived from Invoice date <-> Payment due on)
 		//---------------------------------------------------------------
 		if ($dueDate && !empty($supplierInvoice->date)) {
-			$invoiceDateTimestamp = is_numeric($supplierInvoice->date) ? $supplierInvoice->date : dol_stringtotime((string) $supplierInvoice->date);
+			$invoiceDateTimestamp = is_numeric($supplierInvoice->date) ? $supplierInvoice->date : dol_stringtotime((string) $supplierInvoice->date, 'tzserver');
 
 			if ($invoiceDateTimestamp) {
 				$nbDays = (int) round(($dueDate - $invoiceDateTimestamp) / 86400);

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -744,7 +744,7 @@ class FacturXProtocol extends CIIProtocol
 			return ['res' => -1, 'message' => 'Unfounded dolibarr corresponding Invoice code for document type code: ' . ($parsedHeader['documenttypecode'] ?? 'NA')];
 		}
 		// documentdate is already formatted into 'Y-m-d' by the parser ZugFerd and CII
-		$supplierInvoice->date = !empty($parsedHeader['documentdate']) ? dol_stringtotime($parsedHeader['documentdate']) : null;
+		$supplierInvoice->date = !empty($parsedHeader['documentdate']) ? dol_stringtotime($parsedHeader['documentdate'], 'tzserver') : null;
 
 		// For credit notes and replacement invoices, link to the source invoice via fk_facture_source
 		// (BT-25). A replacement invoice (BT-3 = 384) corrects the invoice it references just as a credit

--- a/einvoicing/test/phpunit/CIIProtocolTest.php
+++ b/einvoicing/test/phpunit/CIIProtocolTest.php
@@ -20,10 +20,12 @@
  *      \file       test/phpunit/CIIProtocolTest.php
  *      \ingroup    test
  *      \brief      PHPUnit test for the line billing period (EN 16931 BG-26 / BT-134 / BT-135), in
- *                  both directions.
+ *                  both directions, and for the timezone the dates of a received document are read in.
  *                  Export (issue #435): buildLineItem() must place BillingSpecifiedPeriod where the
  *                  CII D22B schema sequence requires it. Import (issue #576): resolveLinePeriod()
  *                  must keep one side alone and refuse a period that ends before it starts.
+ *                  Import (issue #853): a date of the document must be stored as the day it states,
+ *                  whatever the timezone of the server that reads it.
  *      \remarks    To run this script as CLI: phpunit filename.php
  */
 
@@ -54,6 +56,9 @@ require_once __DIR__ . '/CommonClassTestCompat.inc.php';
  */
 class CIIProtocolTest extends CommonClassTest
 {
+	/** @var string	PHP default timezone saved at setUp() */
+	private $savtz;
+
 	/**
 	 * Call the private CIIProtocol::buildLineItem() through reflection: pure line-level XML
 	 * generation logic (no DB access, no side effect), the kind of private method the project
@@ -296,8 +301,8 @@ class CIIProtocolTest extends CommonClassTest
 
 		$this->assertIsInt($period['start']);
 		$this->assertIsInt($period['end']);
-		$this->assertSame('2026-06-01', dol_print_date($period['start'], '%Y-%m-%d', 'gmt'));
-		$this->assertSame('2026-06-30', dol_print_date($period['end'], '%Y-%m-%d', 'gmt'));
+		$this->assertSame('2026-06-01', dol_print_date($period['start'], '%Y-%m-%d', 'tzserver'));
+		$this->assertSame('2026-06-30', dol_print_date($period['end'], '%Y-%m-%d', 'tzserver'));
 	}
 
 	/**
@@ -313,12 +318,12 @@ class CIIProtocolTest extends CommonClassTest
 		$protocol = new CIIProtocol($db);
 
 		$startOnly = $this->callResolveLinePeriod($protocol, ['linePeriodStart' => '2026-06-01', 'linePeriodEnd' => null]);
-		$this->assertSame('2026-06-01', dol_print_date($startOnly['start'], '%Y-%m-%d', 'gmt'));
+		$this->assertSame('2026-06-01', dol_print_date($startOnly['start'], '%Y-%m-%d', 'tzserver'));
 		$this->assertNull($startOnly['end']);
 
 		$endOnly = $this->callResolveLinePeriod($protocol, ['linePeriodStart' => null, 'linePeriodEnd' => '2026-06-30']);
 		$this->assertNull($endOnly['start']);
-		$this->assertSame('2026-06-30', dol_print_date($endOnly['end'], '%Y-%m-%d', 'gmt'));
+		$this->assertSame('2026-06-30', dol_print_date($endOnly['end'], '%Y-%m-%d', 'tzserver'));
 	}
 
 	/**
@@ -421,7 +426,125 @@ class CIIProtocolTest extends CommonClassTest
 		$this->assertSame('2026-06-30', $lines[0]['linePeriodEnd'], 'the parser normalises BT-135 to Y-m-d');
 
 		$period = $this->callResolveLinePeriod($protocol, $lines[0]);
-		$this->assertSame('2026-06-01', dol_print_date($period['start'], '%Y-%m-%d', 'gmt'));
-		$this->assertSame('2026-06-30', dol_print_date($period['end'], '%Y-%m-%d', 'gmt'));
+		$this->assertSame('2026-06-01', dol_print_date($period['start'], '%Y-%m-%d', 'tzserver'));
+		$this->assertSame('2026-06-30', dol_print_date($period['end'], '%Y-%m-%d', 'tzserver'));
+	}
+
+	/**
+	 * Save the timezone the tests below move.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->savtz = date_default_timezone_get();
+	}
+
+	/**
+	 * Put it back.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void
+	{
+		date_default_timezone_set($this->savtz);
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Timezones the dates are read in: UTC, one west of it (where issue #853 was reported), two east
+	 * of it, one of them with a fractional offset, and the one furthest ahead.
+	 *
+	 * @return string[]	Timezone identifiers
+	 */
+	private function timezones(): array
+	{
+		return array('UTC', 'America/New_York', 'Europe/Paris', 'Asia/Kolkata', 'Pacific/Kiritimati');
+	}
+
+	/**
+	 * The day DoliDB::idate() writes into the column for a timestamp, which is where issue #853
+	 * happened: it formats with 'tzserver' on the seven supported cores.
+	 *
+	 * @param	int|string	$timestamp	Timestamp the import would store
+	 * @return	string					The day the row carries
+	 */
+	private function storedDay($timestamp): string
+	{
+		return dol_print_date($timestamp, '%Y-%m-%d', 'tzserver');
+	}
+
+	/**
+	 * The dates of a received document reach the row as the days the document states, on a server in
+	 * any timezone: the period of a line (BT-134 / BT-135) and the due date (BT-9), read back the way
+	 * DoliDB::idate() writes them. The dates of the invoice of issue #853.
+	 *
+	 * @return void
+	 */
+	public function testTheDayWrittenIsTheDayOfTheDocument()
+	{
+		global $db;
+
+		require_once DOL_DOCUMENT_ROOT . '/fourn/class/fournisseur.facture.class.php';
+
+		$protocol = new CIIProtocol($db);
+		$payment = new ReflectionMethod(CIIProtocol::class, '_applyPaymentInfoToSupplierInvoice');
+		$payment->setAccessible(true);
+
+		foreach ($this->timezones() as $tz) {
+			date_default_timezone_set($tz);
+
+			$period = $this->callResolveLinePeriod($protocol, array('linePeriodStart' => '2026-09-01', 'linePeriodEnd' => '2027-08-31'));
+			$this->assertSame('2026-09-01', $this->storedDay($period['start']), 'wrong start on a server in ' . $tz);
+			$this->assertSame('2027-08-31', $this->storedDay($period['end']), 'wrong end on a server in ' . $tz);
+
+			$supplierInvoice = new FactureFournisseur($db);
+			$payment->invoke($protocol, $supplierInvoice, array('paymentDueDate' => '2026-09-02'));
+			$this->assertSame('2026-09-02', $this->storedDay($supplierInvoice->date_echeance), 'wrong due date on a server in ' . $tz);
+		}
+	}
+
+	/**
+	 * What the second argument buys, on the timezone the defect was reported from: left out,
+	 * dol_stringtotime() answers midnight UTC, which idate() writes as the day before.
+	 *
+	 * @return void
+	 */
+	public function testTheDefaultOfTheCoreLosesADayWestOfUtc()
+	{
+		global $db;
+
+		date_default_timezone_set('America/New_York');
+
+		$this->assertSame('2026-09-01', $this->storedDay(dol_stringtotime('2026-09-02')), 'the state of issue #853');
+		$this->assertSame('2026-09-02', $this->storedDay(dol_stringtotime('2026-09-02', 'tzserver')));
+
+		$period = $this->callResolveLinePeriod(new CIIProtocol($db), array('linePeriodStart' => '2026-09-02'));
+		$this->assertSame('2026-09-02', $this->storedDay($period['start']), 'the import must read the day in the timezone of the server');
+	}
+
+	/**
+	 * The instant stored for a day, whatever the timezone: midnight of the server day, which is what
+	 * the line form of the core writes for the same field.
+	 *
+	 * @return void
+	 */
+	public function testALinePeriodIsMidnightOfTheServerDay()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		foreach ($this->timezones() as $tz) {
+			date_default_timezone_set($tz);
+
+			$period = $this->callResolveLinePeriod($protocol, array('linePeriodStart' => '2026-09-01', 'linePeriodEnd' => '2026-09-30'));
+
+			$this->assertSame('2026-09-01 00:00:00', dol_print_date($period['start'], '%Y-%m-%d %H:%M:%S', 'tzserver'), 'wrong start in ' . $tz);
+			$this->assertSame('2026-09-30 00:00:00', dol_print_date($period['end'], '%Y-%m-%d %H:%M:%S', 'tzserver'), 'wrong end in ' . $tz);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #853.

### The defect

The import read the dates of a received document with `dol_stringtotime()` left on its default, and that default is `$gm = 1` on the seven supported cores, so it answers **midnight UTC**. `DoliDB::idate()` then writes that instant back **in the server timezone**: on a server west of UTC the row carries the day before the one the document states. The date of the invoice, the payment due date (BT-9) and the billing period of every line (BT-134 / BT-135) were all one day early, which is what the OVH invoice of the report shows.

### The fix

A date of a document is a day, not an instant, and the core already has the argument that says so:

```php
dol_stringtotime($string, 'tzserver')
```

It reads the day in the timezone `DoliDB::idate()` writes in and `DoliDB::jdate()` reads back in, so the day written is the day stated. The four call sites pass it — the date of the document on the CII and the Factur-X path, the due date, and the two ends of a line period — and nothing else changes. No conversion of our own, no helper on the module side.

### Measured, before and after

One import of a CII issued and due on 2026-09-02, with a line billed 2026-09-01 to 2027-08-31, the row read back **from a second database connection**:

| core | server timezone | before | after |
|---|---|---|---|
| 18.0.10 / 23.0.4 / 24.0.1 | Europe/Paris | `2026-09-02`, `2026-09-02`, `2026-09-01 → 2027-08-31` | unchanged |
| 18.0.10 / 23.0.4 / 24.0.1 | America/New_York | `2026-09-01`, `2026-09-01`, `2026-08-31 → 2027-08-30` | `2026-09-02`, `2026-09-02`, `2026-09-01 → 2027-08-31` |

The second line is the report, to the day.

### Tests

PHPUnit: the whole module suite (29 files) on Dolibarr 18 to 25, green.

`CIIProtocolTest` gains three cases: the day written is the day of the document in five timezones (the line period and the due date, read the way `idate()` writes them), the default of the core losing a day west of UTC while the second argument keeps it, and the instant stored for a day being midnight of the server day.

The three existing period assertions move from `'gmt'` to `'tzserver'`: they read the timestamps in UTC, which is what this fix stops producing.
