### PR TITLE
FIX [einvoicing] The dates written into an emitted document no longer depend on a timezone

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -3275,7 +3275,7 @@ class CIIProtocol extends AbstractProtocol
 						}
 					}
 					if (!empty($expedition->date_delivery)) {
-						$deliveryDateList[] = date('Y-m-d', $expedition->date_delivery);
+						$deliveryDateList[] = dol_print_date($expedition->date_delivery, 'dayrfc', 'tzserver');
 					}
 				}
 			}
@@ -3299,14 +3299,14 @@ class CIIProtocol extends AbstractProtocol
 							if ($expeditionFetchResult > 0) {
 								if (!empty($expedition->date_delivery)) {
 									$found++;
-									$deliveryDateList[] = date('Y-m-d', $expedition->date_delivery);
+									$deliveryDateList[] = dol_print_date($expedition->date_delivery, 'dayrfc', 'tzserver');
 								}
 							}
 						}
 					}
 					if ($found == 0) {
 						if (!empty($commande->delivery_date)) {
-							$deliveryDateList[] = date('Y-m-d', $commande->delivery_date);
+							$deliveryDateList[] = dol_print_date($commande->delivery_date, 'dayrfc', 'tzserver');
 						}
 					}
 				}

--- a/einvoicing/class/utils/CdarHandler.class.php
+++ b/einvoicing/class/utils/CdarHandler.class.php
@@ -578,7 +578,9 @@ class CdarHandler
 				'TypeCode' => 'MPA',
 				'ValueAmount' => number_format($paidAmount, 2, '.', ''),
 				'CurrencyID' => $conf->currency,
-				'ValueDateTime' => dol_print_date($paidDate, '%Y%m%d')
+				// 'tzserver' like the other dates read from the invoice, and not the 'auto' default:
+				// the day the payment was made must not follow the timezone of whoever sends the status.
+				'ValueDateTime' => dol_print_date($paidDate, '%Y%m%d', 'tzserver')
 			)
 		);
 	}

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -317,7 +317,7 @@ if ($object->type == $object::TYPE_CREDIT_NOTE) {
 if ($refDocTypeCode !== '' && !empty($object->fk_facture_source)) {
 	$sourceFact = new Facture($this->db);
 	if ($sourceFact->fetch($object->fk_facture_source) > 0) {
-		$sourceFactDate = new DateTime(dol_print_date($sourceFact->date, 'dayrfc'));
+		$sourceFactDate = new DateTime(dol_print_date($sourceFact->date, 'dayrfc', 'tzserver'));
 		$invoiceRefDocs[] = [
 			'ref' => $sourceFact->ref,
 			'date' => $sourceFactDate,
@@ -327,7 +327,7 @@ if ($refDocTypeCode !== '' && !empty($object->fk_facture_source)) {
 	} else {
 		if ($object->id == 0) { // Specimen case.
 			$specimenRefDoc = $object->fk_facture_source ?? 'FA0000-SPECIMEN';
-			$sourceFactDate = new DateTime(dol_print_date(dol_now() - 100, 'dayrfc'));
+			$sourceFactDate = new DateTime(dol_print_date(dol_now() - 100, 'dayrfc', 'tzserver'));
 			$invoiceRefDocs[] = [
 				'ref' => $specimenRefDoc,
 				'date' => $sourceFactDate,
@@ -351,7 +351,7 @@ if ($object->type == $object::TYPE_SITUATION && !empty($object->situation_counte
 		$prevSituation = end($object->tab_previous_situation_invoice);
 		reset($object->tab_previous_situation_invoice);
 		if ($prevSituation && !empty($prevSituation->ref)) {
-			$prevSituationDate = new DateTime(dol_print_date($prevSituation->date, 'dayrfc'));
+			$prevSituationDate = new DateTime(dol_print_date($prevSituation->date, 'dayrfc', 'tzserver'));
 			$invoiceRefDocs[] = [
 				'ref'  => $prevSituation->ref,
 				'date' => $prevSituationDate,
@@ -455,7 +455,7 @@ foreach ($object->lines as $line) {
 			dol_syslog("Fetch origFact " . $discount->fk_facture_source . ", res=" . $resOrigFact, LOG_DEBUG);
 			if ($resOrigFact > 0) {
 				$depositFactRef  = $origFact->ref;
-				$depositFactDate = new DateTime(dol_print_date($origFact->date, 'dayrfc'));
+				$depositFactDate = new DateTime(dol_print_date($origFact->date, 'dayrfc', 'tzserver'));
 			}
 		}
 		$line->qty      = -$line->qty;				// For a deposit, ->qty should be -1.
@@ -833,7 +833,7 @@ if ($object->element == 'facture' || $object->element == 'invoice') {
 			if ($sourceDiscountFact->fetch($obj->fk_facture_source) > 0) {
 				$invoiceRefDocs[] = [
 					'ref' => $sourceDiscountFact->ref,															// BT-25
-					'date' => new DateTime(dol_print_date($sourceDiscountFact->date, 'dayrfc')),					// BT-26
+					'date' => new DateTime(dol_print_date($sourceDiscountFact->date, 'dayrfc', 'tzserver')),					// BT-26
 					'type' => $refDocTypeByInvoiceType[(int) $obj->sourcetype]
 				];
 				dol_syslog("EInvoicing invoice " . $object->id . " refers to " . $sourceDiscountFact->ref
@@ -883,9 +883,12 @@ $invoicingPeriodStart = $invoicingPeriod['start'] !== null ? $this->_tsToDateTim
 $invoicingPeriodEnd = $invoicingPeriod['end'] !== null ? $this->_tsToDateTime($invoicingPeriod['end']) : null;
 
 // Delivery date
+// $deliveryDateList already holds 'Y-m-d' days: handing one to dol_print_date(), which expects a
+// timestamp, reached a deprecated branch of the core that reads it back as midnight UTC, so BT-72
+// was emitted one day early on a server west of UTC (issue #853 on the sending side).
 $deliveryDate = !empty($deliveryDateList)
-	? new DateTime(dol_print_date($deliveryDateList[0], 'dayrfc'))
-	: new DateTime(dol_print_date($object->date, 'dayrfc'));
+	? new DateTime($deliveryDateList[0])
+	: new DateTime(dol_print_date($object->date, 'dayrfc', 'tzserver'));
 
 
 
@@ -906,7 +909,7 @@ $invoiceData = [
 	// Document part
 	'documentno'           => $object->ref,												// BT-25
 	'documenttypecode'     => $this->_getTypeOfInvoice($object),						// BT-3 Set the type of invoice (standard, deposit, credit note)
-	'documentdate'         => new DateTime(dol_print_date($object->date, 'dayrfc')),	// BT-26
+	'documentdate'         => new DateTime(dol_print_date($object->date, 'dayrfc', 'tzserver')),	// BT-26
 	'invoiceCurrency'      => $object->multicurrency_code,
 	'taxCurrency'          => null,
 	'documentname'         => null,
@@ -1022,7 +1025,7 @@ $invoiceData = [
 	'accountRef'                => $account->ref,
 	'accountLabel'              => $account->label,
 
-	'paymentDueDate'            => new DateTime(dol_print_date($object->date_lim_reglement, 'dayrfc')),
+	'paymentDueDate'            => new DateTime(dol_print_date($object->date_lim_reglement, 'dayrfc', 'tzserver')),
 	'paymentTermsText'          => $langs->transnoentitiesnoconv("PaymentConditions") . ": " . $langs->transnoentitiesnoconv("PaymentCondition" . $object->cond_reglement_code),
 
 	// Allowances / charges part

--- a/einvoicing/test/phpunit/CdarDateFormatTest.php
+++ b/einvoicing/test/phpunit/CdarDateFormatTest.php
@@ -300,4 +300,32 @@ class CdarDateFormatTest extends CommonClassTest
 			$this->assertSame($input, CdarHandler::formatDate($input), 'formatDate() no longer passes "' . $input . '" through');
 		}
 	}
+
+	/**
+	 * The payment date of the MPA block was the one date of the file left on the 'auto' default of
+	 * dol_print_date(): it followed the timezone of the session as soon as MAIN_TZUSERINPUTKEY was
+	 * 'tzuserrel', where the day the payment was made must not.
+	 *
+	 * @return void
+	 */
+	public function testThePaymentDateDoesNotFollowTheSession()
+	{
+		global $conf;
+
+		$handler = new CdarHandler($GLOBALS['db']);
+		$conf->tzuserinputkey = 'tzuserrel';
+
+		foreach ($this->timezones() as $tz) {
+			date_default_timezone_set($tz);
+
+			// The epoch is left out: the method reads an empty date as "no date given" and stamps dol_now().
+			foreach (array_filter($this->timestamps()) as $ts) {
+				$_SESSION['dol_tz_string'] = 'Pacific/Kiritimati';	// UTC+14, a day ahead of most of the map
+
+				$mpa = $handler->getPaymentSentCharacteristics(new stdClass(), array('amount' => 12.0, 'date' => $ts));
+
+				$this->assertSame(date('Ymd', $ts), $mpa[0]['ValueDateTime'], 'Payment date changed for timestamp ' . $ts . ' in ' . $tz);
+			}
+		}
+	}
 }


### PR DESCRIPTION
The sending side of the defect reported in #853, found by auditing every date the module reads or writes. Independent of #856 (the receiving side): different files, and the two merge in either order to the same tree.

### Two defects, both measured on Dolibarr 18 and 24

**BT-72, the delivery date, comes out one day early on a server west of UTC.** The date is put into `$deliveryDateList` as a `'Y-m-d'` string, then handed to `dol_print_date()`, which expects a timestamp. The core answers that on a branch it marks as deprecated: it logs `called with a bad value` at every generation, reads the string back with `dol_mktime(..., true)` — midnight **UTC** — and prints it in the server timezone. The list already holds days, so the `DateTime` is now built from the string it holds and the round trip disappears.

**The other dates of the document follow the timezone of whoever generates it.** `dol_print_date($object->date, 'dayrfc')` leaves the third argument out, so the core resolves it to `$conf->tzuserinputkey`, which `MAIN_TZUSERINPUTKEY` can set to `'tzuserrel'`. BT-2, BT-9 and the BT-26 of every referenced invoice then follow the session. They take `'tzserver'`, the timezone `DoliDB::jdate()` built those timestamps in — the same reasoning as #817, which pinned the CDAR dates.

One invoice dated 2026-09-02, linked to an order announcing a delivery on 2026-09-02, generated four times:

| server | session | before | after |
|---|---|---|---|
| Europe/Paris | — | BT-2 `20260902`, BT-72 `20260902` | unchanged |
| **America/New_York** | — | BT-2 `20260902`, **BT-72 `20260901`** | both `20260902` |
| Europe/Paris | Pacific/Kiritimati, `tzuserrel` | both `20260902` | unchanged |
| Europe/Paris | **America/New_York**, `tzuserrel` | **BT-2 `20260901`**, BT-72 `20260902` | both `20260902` |

Same table on 18.0.10 and 24.0.1.

### Also in the sweep

The payment date of the CDAR (`ValueDateTime` of the MPA block, status 212) was the one date of that file still on the `'auto'` default when #817 pinned the others. It takes `'tzserver'` like the invoice dates around it.

The three delivery dates read from a shipment or an order go through `dol_print_date()` instead of a raw `date()`: same output, one way of writing a date in the module, and the timezone said out loud.

Checked and left alone: the issuance stamps of the CDAR (instants, `'gmt'`, #817), `updatedAfter` sent to the platform (already `'gmt'`), the token expiry (a symmetric `'gmt'` pair), the date filters of the two list pages (user input, `'tzuserrel'` on purpose), and the `dol_print_date()` of the log lines and of the import key.

### Tests

The whole module suite (29 files) on Dolibarr 18 to 25, green. `CdarDateFormatTest` gains one method: the payment date of the MPA block is the day of the payment in five timezones, with the session put a day ahead.
