### PR TITLE
NEW: [einvoicing] Add EINVOICING_SEND_SUCCESS and EINVOICING_SEND_ERROR triggers after e-invoice transmission to Access Point

### DIFF
--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -68,7 +68,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 */
 	public function afterPDFCreation($parameters, $object, &$action, $hookmanager)
 	{
-		global $db, $langs;
+		global $db, $langs, $user;
 
 		dol_syslog(__METHOD__ . " Hook afterPDFCreation called for object " . get_class($object));
 
@@ -1260,7 +1260,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 */
 	private function sendOneInvoiceToAccessPoint($invoice, $einvoicing, $provider)
 	{
-		global $langs;
+		global $langs, $user;
 
 		$out = array('res' => 0, 'flowid' => '', 'reason' => '', 'warnings' => array(), 'errors' => array());
 

--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -214,11 +214,15 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 									$sendres = $provider->sendInvoice($invoiceObject);
 									if ($sendres) {
 										setEventMessages($langs->trans("InvoiceSuccessfullySentToPDP") . ' - ' . $langs->trans("FlowId") . ': ' . $sendres, null, 'mesgs');
+										$invoiceObject->context['einvoicing_flowid'] = (string) $sendres;
+										$invoiceObject->call_trigger('EINVOICING_SEND_SUCCESS', $user);
 									} else {
 										// Don't block validation if auto-send fails: the e-invoice is generated and can still be sent manually.
 										$senderrors = $provider->errors ?: array($provider->error);
 										$this->warnings = array_merge($this->warnings, (array) $senderrors);
 										dol_syslog(__METHOD__ . " auto-send to PA failed: " . implode('; ', (array) $senderrors), LOG_WARNING, 0, "_einvoicing");
+										$invoiceObject->context['einvoicing_errors'] = (array) $senderrors;
+										$invoiceObject->call_trigger('EINVOICING_SEND_ERROR', $user);
 									}
 								}
 							}
@@ -1309,11 +1313,15 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 		if ($flowid) {
 			$out['res'] = 1;
 			$out['flowid'] = (string) $flowid;
+			$invoice->context['einvoicing_flowid'] = (string) $flowid;
+			$invoice->call_trigger('EINVOICING_SEND_SUCCESS', $user);
 			return $out;
 		}
 
 		$out['res'] = -1;
 		$out['errors'] = $provider->errors ? $provider->errors : array($provider->error);
+		$invoice->context['einvoicing_errors'] = $out['errors'];
+		$invoice->call_trigger('EINVOICING_SEND_ERROR', $user);
 
 		return $out;
 	}


### PR DESCRIPTION
## NEW: [einvoicing] Add EINVOICING_SEND_SUCCESS and EINVOICING_SEND_ERROR triggers after e-invoice transmission to Access Point

## What does this PR do?

Fire two new triggers after each attempt to send an e-invoice to the Access Point (PDP):

- `EINVOICING_SEND_SUCCESS` — fired on successful transmission, exposes `flow_id` via `$object->context['einvoicing_flowid']`                                                                                                                  
- `EINVOICING_SEND_ERROR`   — fired on failed transmission, exposes errors via `$object->context['einvoicing_errors']`                                                                                                                         

Both triggers are fired from:
- the **auto-send path** (`afterPDFCreation` hook, when `EINVOICING_AUTO_SEND_ON_GENERATION` is enabled)
- the **manual/mass send path** (`sendOneInvoiceToAccessPoint`)
                                                                                                                                                                                                                                                
## Why?

Allow other modules to react to a successful or failed e-invoice transmission (e.g. update a status, notify a third-party system, log to an external service) by listening to these triggers.