### PR TITLE
FIX [einvoicing] A received Factur-X no longer fatals on PHP below 7.3

### DIFF
--- a/einvoicing/class/document.class.php
+++ b/einvoicing/class/document.class.php
@@ -1660,6 +1660,9 @@ class Document extends CommonObject
 			throw new Exception(__METHOD__ . " : protocol not detected for XML data");
 		}
 		$protocol = $protocolManager->getProtocol($detectedProtocolName);
+		if (!is_object($protocol)) {
+			throw new Exception(__METHOD__ . " : protocol " . $detectedProtocolName . " is not available on this server");
+		}
 		$protocolClassName = get_class($protocol);
 
 		$cleanedXmlData = $protocolClassName::removeAttachmentFromXml($xmlData);

--- a/einvoicing/class/protocols/ProtocolManager.class.php
+++ b/einvoicing/class/protocols/ProtocolManager.class.php
@@ -37,6 +37,10 @@ class ProtocolManager
 	const EXCEPTION_UNSUPPORTED_FORMAT = -100;
 	const EXCEPTION_UNKNOWN_FORMAT = -101;
 
+	// Factur-X is read and written by horstoeko/zugferd, whose vendor tree refuses to load below this
+	// version with a fatal error raised by vendor/composer/platform_check.php, not with a message.
+	const PHP_MIN_FACTURX = '7.3';
+
 	/**
 	 * Initialize available protocols.
 	 * @param DoliDB $db db
@@ -60,7 +64,7 @@ class ProtocolManager
 				'protocol_label' => 'Factur-X',
 				'description' => 'Factur-X is a French-German hybrid e-invoicing format combining a readable PDF invoice with embedded XML data for seamless automated processing.',
 				'is_enabled' => $facturexIsOk,
-				'is_greyed' => (version_compare(PHP_VERSION, '7.3.0') < 0) ? 'PHP 7.3+' : ''
+				'is_greyed' => self::isProtocolRunnableOnThisPhp('FACTURX') ? '' : 'PHP '.self::PHP_MIN_FACTURX.'+'
 				//'protocol_dol_min' => '24.0'	//experience a lot of trouble with autoload/tcpdf lib conflict and more with < 24.0. Use is possible but must be SERIOUSLY discouraged.
 			),
 			'UBL' => array(
@@ -69,6 +73,30 @@ class ProtocolManager
 				'is_enabled' => $ublIsOk
 			)
 		);
+	}
+
+	/**
+	 * PHP version a protocol needs on top of the one Dolibarr itself requires.
+	 *
+	 * @param	string	$name	Protocol name ('FACTURX', 'CII', 'UBL')
+	 * @return	string			Minimum PHP version, '' when the protocol asks for nothing of its own
+	 */
+	public static function getProtocolPhpMin($name)
+	{
+		return (strtoupper(str_replace('-', '', (string) $name)) == 'FACTURX') ? self::PHP_MIN_FACTURX : '';
+	}
+
+	/**
+	 * Whether the PHP running here can load the libraries a protocol needs.
+	 *
+	 * @param	string	$name	Protocol name ('FACTURX', 'CII', 'UBL')
+	 * @return	bool			True when the protocol can be used on this server
+	 */
+	public static function isProtocolRunnableOnThisPhp($name)
+	{
+		$phpmin = self::getProtocolPhpMin($name);
+
+		return ($phpmin === '' || version_compare(PHP_VERSION, $phpmin) >= 0);
 	}
 
 	/**
@@ -124,6 +152,14 @@ class ProtocolManager
 	{
 		// Check if protocol exists and is enabled in protocolsList
 		if (!isset($this->protocolsList[$name]) || !$this->protocolsList[$name]['is_enabled']) {
+			return null;
+		}
+
+		// A protocol whose libraries cannot run on this PHP is not available here. Answering null keeps
+		// the caller on the path it already has for an unsupported syntax, where including the class
+		// would raise a fatal error from the autoloader of the library.
+		if (!self::isProtocolRunnableOnThisPhp($name)) {
+			dol_syslog(__METHOD__." ".$name." needs PHP ".self::getProtocolPhpMin($name).", this server runs ".PHP_VERSION, LOG_WARNING, 0, "_einvoicing");
 			return null;
 		}
 

--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -455,7 +455,7 @@ abstract class AbstractPDPProvider
 	 *
 	 * @param	string			$flowId				Identifier of the flow to read
 	 * @param	ProtocolManager	$protocolManager	Protocol factory used to recognize the documents
-	 * @return	array{file:?string,protocol:?AbstractProtocol,protocol_name:string,doc_type:string,fetched:int,attempts:string[],client_not_configured:bool}	The importable document, or a null protocol and the reason each shape was rejected
+	 * @return	array{file:?string,protocol:?AbstractProtocol,protocol_name:string,doc_type:string,fetched:int,attempts:string[],client_not_configured:bool,php_too_old_for:string}	The importable document, or a null protocol and the reason each shape was rejected
 	 */
 	protected function fetchImportableFlowDocument($flowId, $protocolManager)
 	{
@@ -466,7 +466,8 @@ abstract class AbstractPDPProvider
 			'doc_type' => '',
 			'fetched' => 0,				// nb of documents the access point did return, whatever their syntax
 			'attempts' => array(),
-			'client_not_configured' => false
+			'client_not_configured' => false,
+			'php_too_old_for' => ''		// label of a syntax this module reads, but not on the PHP running here
 		);
 
 		// EINVOICING_PREFER_ORIGINAL: fetch the issuer's Original document (its Factur-X, which carries
@@ -497,7 +498,15 @@ abstract class AbstractPDPProvider
 
 			$protocol = $protocolManager->getProtocol($protocolName);
 			if (empty($protocol)) {
-				$result['attempts'][] = $docType . ": " . $protocolName . " is not supported";
+				if (!ProtocolManager::isProtocolRunnableOnThisPhp($protocolName)) {
+					// The syntax is one this module reads, the PHP of this server is what stands in the
+					// way. Kept apart from a plain "not supported", because what to do about it differs.
+					$protocolsList = $protocolManager->getProtocolsList();
+					$result['php_too_old_for'] = isset($protocolsList[$protocolName]['protocol_label']) ? $protocolsList[$protocolName]['protocol_label'] : $protocolName;
+					$result['attempts'][] = $docType . ": " . $protocolName . " needs PHP " . ProtocolManager::getProtocolPhpMin($protocolName) . ", this server runs " . PHP_VERSION;
+				} else {
+					$result['attempts'][] = $docType . ": " . $protocolName . " is not supported";
+				}
 				continue;
 			}
 

--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -1358,12 +1358,19 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 					if ($importable['client_not_configured']) {
 						$action = $langs->trans('AccessPointConversionFormatNotSet') . ' ' . $action;
 					}
+					$actioncode = 'CONVERSION_FORMAT_NOT_SUPPORTED';
+					if (!empty($importable['php_too_old_for'])) {
+						// Nothing is wrong with the document nor with the account: this PHP cannot read that
+						// syntax. Both ways out are the user's to choose, so name them instead of picking one.
+						$actioncode = 'FORMAT_NEEDS_NEWER_PHP';
+						$action = $langs->trans('ReceivedFormatNeedsNewerPhp', $importable['php_too_old_for'], ProtocolManager::getProtocolPhpMin($importable['php_too_old_for']), PHP_VERSION);
+					}
 
 					return array(
 						'res' => -1,
 						'postponeflow' => 1,
 						'message' => $errorcode . " No document this module can read for SupplierInvoice flow (flowId: " . $flowId . ") - " . implode(' | ', $importable['attempts']),
-						'actioncode' => 'CONVERSION_FORMAT_NOT_SUPPORTED',
+						'actioncode' => $actioncode,
 						'actionurl' => '',
 						'action' => $action,
 						'actiondata' => array()

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -2354,12 +2354,19 @@ class SuperPDPProvider extends AbstractPDPProvider
 					if ($importable['client_not_configured']) {
 						$action = $langs->trans('AccessPointConversionFormatNotSet') . ' ' . $action;
 					}
+					$actioncode = 'CONVERSION_FORMAT_NOT_SUPPORTED';
+					if (!empty($importable['php_too_old_for'])) {
+						// Nothing is wrong with the document nor with the account: this PHP cannot read that
+						// syntax. Both ways out are the user's to choose, so name them instead of picking one.
+						$actioncode = 'FORMAT_NEEDS_NEWER_PHP';
+						$action = $langs->trans('ReceivedFormatNeedsNewerPhp', $importable['php_too_old_for'], ProtocolManager::getProtocolPhpMin($importable['php_too_old_for']), PHP_VERSION);
+					}
 
 					return array(
 						'res' => -1,
 						'postponeflow' => 1,
 						'message' => $errorcode . " No document this module can read for SupplierInvoice flow (flowId: " . $flowId . ") - " . implode(' | ', $importable['attempts']),
-						'actioncode' => 'CONVERSION_FORMAT_NOT_SUPPORTED',
+						'actioncode' => $actioncode,
 						'actionurl' => '',
 						'action' => $action,
 						'actiondata' => array()

--- a/einvoicing/class/utils/SupplierInvoiceHelper.class.php
+++ b/einvoicing/class/utils/SupplierInvoiceHelper.class.php
@@ -84,6 +84,9 @@ class SupplierInvoiceHelper
 			return false;
 		}
 		$protocol = $protocolManager->getProtocol($detectedProtocolName);
+		if (!is_object($protocol)) {
+			return false;
+		}
 
 		// Extract XML header data
 		$parsedHeader = $protocol->parseInvoiceHeader($xmlData);

--- a/einvoicing/document_list.php
+++ b/einvoicing/document_list.php
@@ -1023,7 +1023,8 @@ if ($action == 'confirm_sync' && getDolGlobalString('EINVOICING_PDP') && $confir
 		} else {
 			if ((is_null($sync_result['totalFlows']) || $sync_result['totalFlows'] > $sync_result['batchlimit'])
 				&& empty($sync_result['syncedFlows'])
-				&& !empty($sync_result['alreadyExist'])) {
+				&& !empty($sync_result['alreadyExist'])
+				&& empty($sync_result['actions'])) {		// the run already says why nothing came in
 				if (empty($sync_result['batchlimit']) || ($sync_result['batchlimit'] <= $sync_result['alreadyExist'])) {
 					$cssclass = 'warning';
 					$sync_result['actions']['LIMIT_TOO_LOW'] = array('action' => $langs->trans("TryToIncreaseStartDateOrMax", $langs->transnoentitiesnoconv("maxNumberToProcess")));

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -413,6 +413,7 @@ EInvoicingLineCharge=Line charge
 EInvoicingLineChargeOfLine=charge of line %s
 AccessPointConversionFormatNotSet=Your Access Point reports that no conversion format is configured for this client.
 SetTheAccessPointConversionFormat=On your Access Point account, set the preferred conversion format to a syntax supported here (CII or Factur-X, not UBL): it decides in which syntax a received invoice is handed over to this module.
+ReceivedFormatNeedsNewerPhp=An invoice was received in the %s format, which needs PHP %s or higher to be read, while this server runs PHP %s. Either set the preferred conversion format of your Access Point account to CII, so received invoices are handed over in a syntax this PHP can read, or upgrade PHP on this server. Nothing is lost: the flow is kept and a later synchronization imports it once one of the two is done.
 DisabledInProductionMode=Disabled in production mode.
 ConnectTo=Connect
 UnknownVATEX1=Unknown exempting VAT reason for the line %s that has the VAT rate %s and VAT code '%s'.


### PR DESCRIPTION
Follow-up to #840, from the other end. That pull request raised the module's declared `phpmin`, and it was refused: upgrading an ERP is the user's decision, not ours. This one leaves that decision alone. It removes the fatal error and says what the choice is.

## What happens today

`horstoeko/zugferd` is resolved for PHP 7.3 (`vendor/composer/platform_check.php`), and `FacturXProtocol.class.php` requires its autoloader at file scope. Reception picks the protocol from the document that **arrived**, not from `EINVOICING_PROTOCOL`, so a site set to CII reaches that include as soon as a supplier sends a Factur-X:

```
syncFlows -> syncFlow -> fetchImportableFlowDocument -> ProtocolManager::getProtocol
          -> dol_include_once(FacturXProtocol) -> vendor/composer/platform_check.php:24
```

## What this changes

- `ProtocolManager::getProtocol()` answers `null` for a protocol whose libraries cannot run on this PHP, **before** the include. The greyed "PHP 7.3+" entry of the setup page now reads its minimum from the same place.
- The reception keeps the flow pending, as it already did for a syntax it cannot read, and adds a suggested action: set the conversion format of the Access Point account to CII, or upgrade PHP.
- `Document::cleanXmlData()` and `SupplierInvoiceHelper` dereferenced the protocol without checking it; they now fail the way they already did when no protocol is detected.

## Measured

Dolibarr 18.0.10, receiver on `EINVOICING_PROTOCOL=CII`, real invoices through an access point, five PHP built side by side.

| PHP | before | after, issuer sends CII | after, issuer sends Factur-X |
|---|---|---|---|
| 7.0 / 7.1 / 7.2 | fatal error, exit 255, HTTP 500 | imported (the CII `Original` is read) | flow kept, action shown |
| 7.3 / 7.4 | imported | imported | imported |

The same flow stayed pending under 7.0, 7.1 and 7.2, then was imported by the 7.3 run: nothing is lost. Over HTTP the synchronization page went from a 107-byte HTTP 500 carrying the raw Composer message to a normal page. PHPUnit: 29 files x 8 cores, 232 OK.

The same click on **Synchronize**, Dolibarr 18.0.10 on PHP 7.0, before :

<img width="1200" alt="before: HTTP 500" src="https://github.com/user-attachments/assets/e1c97eb7-fdee-45eb-b07d-e1a6bfd3b059" />

and after:
<img width="1255" alt="after: the flow is kept and the action is explained" src="https://github.com/user-attachments/assets/995f35b9-c3ab-4b73-8afd-1f14f0e00846" />
