### PR TITLE
FIX [einvoicing] Read a received Factur-X with the PDF parser of the core

### DIFF
--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -28,18 +28,16 @@
 
 //use custom\facturx\Fidry\FileSystem\FS;
 use horstoeko\zugferd\ZugferdDocumentPdfReader;
-use horstoeko\zugferd\ZugferdDocumentPdfReaderExt;
-
-require __DIR__ . "/../../vendor/autoload.php";
 
 dol_include_once('einvoicing/class/protocols/CIIProtocol.class.php');
 dol_include_once('einvoicing/class/protocols/CommonProtocol.class.php');
 dol_include_once('einvoicing/class/utils/XmlPatcher.class.php');
-dol_include_once('einvoicing/class/utils/CtcFrPdfMerger.class.php');
-// FacturxTcpdfMerger is NOT included here: it descends from TCPDF, which the core only loads when a
-// PDF is actually rendered. Requiring it at load time would make every page that instantiates this
-// protocol die on "Class TCPDF not found". It is included where it is used, which is precisely the
-// branch where the core has already loaded TCPDF.
+dol_include_once('einvoicing/class/utils/PdfAttachmentExtractor.class.php');
+// Neither vendor/autoload.php nor the two mergers are required here. Both mergers descend from a
+// composer class, and that autoloader refuses to run below the PHP its libraries need, so loading
+// them at file scope would make a received Factur-X fatal on a PHP that reads it perfectly well.
+// They belong to generateInvoice(), the only place that writes a container. The same reasoning has
+// always applied to FacturxTcpdfMerger, which descends from TCPDF and needs the core PDF stack.
 
 
 /**
@@ -269,6 +267,9 @@ class FacturXProtocol extends CIIProtocol
 			pdf_getInstance();
 		}
 
+		// From here on the container is written, which is what needs horstoeko/zugferd
+		require_once __DIR__ . '/../../vendor/autoload.php';
+
 		try {
 			if (class_exists('FPDF', false) && is_subclass_of('FPDF', 'TCPDF')) {
 				// Below Dolibarr 24, htdocs/includes/tcpdi/tcpdi.php declares "class FPDF extends TCPDF {}".
@@ -282,6 +283,7 @@ class FacturXProtocol extends CIIProtocol
 				// CtcFrPdfMerger behaves exactly like ZugferdDocumentPdfMerger, except that it can still
 				// supply the attachment and XMP parameters when the guideline URN is one the library does
 				// not know — which is the case of EXTENDED-CTC-FR.
+				dol_include_once('einvoicing/class/utils/CtcFrPdfMerger.class.php');
 				$merger = new CtcFrPdfMerger($xmlfile, $orig_pdf);
 			}
 
@@ -431,9 +433,9 @@ class FacturXProtocol extends CIIProtocol
 
 
 		// --- Read the Factur-X file
-		// Only the embedded CII is extracted here: getInvoiceDocumentContentFromFile() reads the PDF/A-3
-		// attachment and never looks at the profile the document declares.
-		$embeddedXml = ZugferdDocumentPdfReaderExt::getInvoiceDocumentContentFromFile($tempFile);
+		// Only the embedded CII is extracted here: the PDF/A-3 attachment is read as it stands, and the
+		// profile the document declares is never looked at.
+		$embeddedXml = PdfAttachmentExtractor::getInvoiceXmlFromFile($tempFile);
 
 		$parsedHeader = [];
 		$parsedLines = [];
@@ -446,6 +448,7 @@ class FacturXProtocol extends CIIProtocol
 			// its own table, which has no entry for EXTENDED-CTC-FR - the French profile this very module
 			// emits. Instantiating that reader is therefore only done on the path that actually uses it,
 			// instead of on every received Factur-X (issue #742).
+			require_once __DIR__ . '/../../vendor/autoload.php';
 			$document = ZugferdDocumentPdfReader::readAndGuessFromFile($tempFile);
 
 			$document->getDocumentInformation($documentno, $documenttypecode, $documentdate, $invoiceCurrency, $taxCurrency, $documentname, $documentlanguage, $effectiveSpecifiedPeriod);
@@ -993,7 +996,7 @@ class FacturXProtocol extends CIIProtocol
 	 */
 	public function extractXmlFromFileContent(string $fileContent)
 	{
-		$extractedXml = ZugferdDocumentPdfReaderExt::getInvoiceDocumentContentFromContent($fileContent);
+		$extractedXml = PdfAttachmentExtractor::getInvoiceXmlFromContent($fileContent);
 		return $extractedXml;
 	}
 }

--- a/einvoicing/class/utils/PdfAttachmentExtractor.class.php
+++ b/einvoicing/class/utils/PdfAttachmentExtractor.class.php
@@ -1,0 +1,390 @@
+<?php
+/* Copyright (C) 2026		Pierre Grasswill			<da.grumpf@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    einvoicing/class/utils/PdfAttachmentExtractor.class.php
+ * \ingroup einvoicing
+ * \brief   Read the invoice attached to a received Factur-X PDF, with the core PDF parser.
+ */
+
+// tcpdi_parser is the PDF parser of the core and pulls nothing but tcpdf_filters.php: no TCPDF, no
+// FPDF, no composer. TCPDI_PATH is the constant filefunc.inc.php defines for it, on every version.
+$tcpdiPath = defined('TCPDI_PATH') ? constant('TCPDI_PATH') : DOL_DOCUMENT_ROOT.'/includes/tcpdi/';
+require_once $tcpdiPath.'tcpdi_parser.php';
+
+
+/**
+ * Extract the files embedded in a PDF/A-3 container.
+ *
+ * Reception only. It stands on tcpdi_parser, which the core ships and which pulls nothing but
+ * tcpdf_filters.php: no composer, no TCPDF, no FPDF, so it runs wherever Dolibarr itself runs.
+ * Emission keeps horstoeko/zugferd, whose merger writes the container this class reads.
+ */
+class PdfAttachmentExtractor extends tcpdi_parser
+{
+	/**
+	 * Names Factur-X, ZUGFeRD and XRechnung give to the invoice they attach
+	 */
+	const INVOICE_ATTACHMENT_NAMES = array('factur-x.xml', 'zugferd-invoice.xml', 'ZUGFeRD-invoice.xml', 'xrechnung.xml');
+
+	/**
+	 * Files found in the container, keyed by their declared name
+	 *
+	 * @var array<string,string>
+	 */
+	private $attachments = array();
+
+	/**
+	 * Whether the container was walked already
+	 *
+	 * @var bool
+	 */
+	private $collected = false;
+
+	/**
+	 * Return the invoice attached to a Factur-X container.
+	 *
+	 * @param	string		$pdfContent		Raw content of the PDF
+	 * @return	string						The embedded XML
+	 * @throws	Exception					When the container carries no invoice
+	 */
+	public static function getInvoiceXmlFromContent($pdfContent)
+	{
+		$parser = new PdfAttachmentExtractor($pdfContent, md5($pdfContent));
+		$attachments = $parser->getEmbeddedFiles();
+		$parser->cleanUp();
+
+		foreach (self::INVOICE_ATTACHMENT_NAMES as $name) {
+			if (isset($attachments[$name])) {
+				return $attachments[$name];
+			}
+		}
+
+		throw new Exception('No invoice attachment found in the PDF');
+	}
+
+	/**
+	 * Return the invoice attached to a Factur-X container held in a file.
+	 *
+	 * @param	string		$pdfFilename	Full path of the PDF
+	 * @return	string						The embedded XML
+	 * @throws	Exception					When the file cannot be read or carries no invoice
+	 */
+	public static function getInvoiceXmlFromFile($pdfFilename)
+	{
+		if (!is_readable($pdfFilename)) {
+			throw new Exception('PDF file is not readable: '.basename($pdfFilename));
+		}
+
+		return self::getInvoiceXmlFromContent((string) file_get_contents($pdfFilename));
+	}
+
+	/**
+	 * Refuse a PDF that cannot be read, instead of ending the request on the spot.
+	 *
+	 * tcpdi_parser::Error() calls die() - unconditionally below Dolibarr 24, and above it unless the
+	 * instance asked TCPDF for exceptions. A truncated container coming from an access point would
+	 * take the whole synchronization down with it, so the failure is raised as the exception the
+	 * reception already knows how to report.
+	 *
+	 * @param	string		$msg			Message from the parser
+	 * @return	void
+	 * @throws	Exception					Always
+	 */
+	public function Error($msg)			// phpcs:ignore PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
+	{
+		throw new Exception('PDF cannot be read: '.$msg);
+	}
+
+	/**
+	 * Return every file embedded in the container, keyed by its declared name.
+	 *
+	 * @return	array<string,string>		Name => raw content, empty when the PDF carries none
+	 */
+	public function getEmbeddedFiles()
+	{
+		if ($this->collected) {
+			return $this->attachments;
+		}
+		$this->collected = true;
+
+		$root = $this->dictOf(isset($this->xref['trailer'][1]['/Root']) ? $this->xref['trailer'][1]['/Root'] : null);
+		if ($root === null) {
+			return $this->attachments;
+		}
+
+		// The name tree of the catalog, where a PDF lists what it embeds since version 1.4
+		if (isset($root['/Names'])) {
+			$names = $this->dictOf($root['/Names']);
+			if ($names !== null && isset($names['/EmbeddedFiles'])) {
+				$this->walkNameTree($names['/EmbeddedFiles'], 0);
+			}
+		}
+
+		// The associated files of the catalog, the form PDF/A-3 requires and Factur-X mandates
+		if (isset($root['/AF'])) {
+			foreach ($this->arrayOf($root['/AF']) as $fileSpec) {
+				$this->readFileSpec($fileSpec);
+			}
+		}
+
+		return $this->attachments;
+	}
+
+	/**
+	 * Walk one node of a name tree, its children first, then the pairs it holds itself.
+	 *
+	 * @param	array		$node			Node element
+	 * @param	int			$depth			Current depth, the tree is not trusted to end
+	 * @return	void
+	 */
+	private function walkNameTree($node, $depth)
+	{
+		if ($depth > 32) {
+			return;
+		}
+		$dict = $this->dictOf($node);
+		if ($dict === null) {
+			return;
+		}
+
+		if (isset($dict['/Kids'])) {
+			foreach ($this->arrayOf($dict['/Kids']) as $kid) {
+				$this->walkNameTree($kid, $depth + 1);
+			}
+		}
+
+		if (isset($dict['/Names'])) {
+			$pairs = $this->arrayOf($dict['/Names']);
+			$count = count($pairs);
+			for ($i = 1; $i < $count; $i += 2) {		// a name tree alternates name and value
+				$this->readFileSpec($pairs[$i]);
+			}
+		}
+	}
+
+	/**
+	 * Store the content of one file specification, when it does carry an embedded stream.
+	 *
+	 * @param	array		$element		File specification, or a reference to one
+	 * @return	void
+	 */
+	private function readFileSpec($element)
+	{
+		$spec = $this->dictOf($element);
+		if ($spec === null || !isset($spec['/EF'])) {
+			return;
+		}
+		$embedded = $this->dictOf($spec['/EF']);
+		if ($embedded === null) {
+			return;
+		}
+
+		$streamRef = isset($embedded['/F']) ? $embedded['/F'] : (isset($embedded['/UF']) ? $embedded['/UF'] : null);
+		if ($streamRef === null || $streamRef[0] != PDF_TYPE_OBJREF) {
+			return;
+		}
+		$object = $this->getObjectVal($streamRef);
+		if ($object[0] != PDF_TYPE_STREAM) {
+			return;
+		}
+		$content = $this->applyFilters($object[1][1], $object[2][1]);
+		if ($content === null) {
+			return;
+		}
+
+		$name = '';
+		foreach (array('/UF', '/F') as $key) {			// the unicode name first, it is the reliable one
+			if (isset($spec[$key]) && in_array($spec[$key][0], array(PDF_TYPE_STRING, PDF_TYPE_HEX))) {
+				$name = $this->decodeText($spec[$key][0], (string) $spec[$key][1]);
+				if ($name !== '') {
+					break;
+				}
+			}
+		}
+		if ($name === '') {
+			$name = 'attachment-'.count($this->attachments);
+		}
+
+		$this->attachments[$name] = $content;
+	}
+
+	/**
+	 * Undo the filter chain of a stream.
+	 *
+	 * tcpdi_parser::decodeStream() is not used: its branch for a /Filter written as an array sits
+	 * under a test on PDF_TYPE_TOKEN, so it never runs and such a stream comes back still encoded,
+	 * with an empty list of filters left to apply. Silently wrong is worse than unsupported.
+	 *
+	 * @param	array		$dict			Stream dictionary
+	 * @param	string		$stream			Raw stream
+	 * @return	string|null					Decoded content, null when a filter cannot be undone
+	 */
+	private function applyFilters($dict, $stream)
+	{
+		$filters = array();
+		if (isset($dict['/Filter'])) {
+			$filter = $dict['/Filter'];
+			if ($filter[0] == PDF_TYPE_OBJREF) {
+				$resolved = $this->getObjectVal($filter);
+				$filter = ($resolved[0] == PDF_TYPE_OBJECT) ? $resolved[1] : $resolved;
+			}
+			if ($filter[0] == PDF_TYPE_TOKEN) {
+				$filters[] = $filter[1];
+			} elseif ($filter[0] == PDF_TYPE_ARRAY) {
+				foreach ($filter[1] as $one) {
+					if ($one[0] == PDF_TYPE_TOKEN) {
+						$filters[] = $one[1];
+					}
+				}
+			}
+		}
+
+		$available = TCPDF_FILTERS::getAvailableFilters();
+		foreach ($filters as $filter) {
+			if ($filter === 'Crypt' || !in_array($filter, $available)) {
+				return null;							// an encrypted or exotic stream is not ours to read
+			}
+			$stream = TCPDF_FILTERS::decodeFilter($filter, $stream);
+			if (!is_string($stream)) {
+				return null;
+			}
+		}
+
+		return $stream;
+	}
+
+	/**
+	 * Turn a PDF text string into UTF-8.
+	 *
+	 * @param	int			$type			PDF_TYPE_STRING or PDF_TYPE_HEX
+	 * @param	string		$value			Raw value, as tcpdi_parser returned it
+	 * @return	string						Decoded name, empty when nothing could be decoded
+	 */
+	private function decodeText($type, $value)
+	{
+		if ($type == PDF_TYPE_HEX) {
+			$hex = preg_replace('/[^0-9A-Fa-f]/', '', $value);
+			if (strlen($hex) % 2) {
+				$hex .= '0';							// an odd hexadecimal string is padded with a zero
+			}
+			$value = pack('H*', $hex);
+		} else {
+			$value = $this->unescapeLiteral($value);
+		}
+
+		if (strncmp($value, "\xFE\xFF", 2) !== 0) {		// the byte order mark of a UTF-16BE text string
+			return $value;
+		}
+
+		$utf16 = substr($value, 2);
+		$utf8 = '';
+		for ($i = 0, $count = strlen($utf16) - 1; $i < $count; $i += 2) {
+			$code = (ord($utf16[$i]) << 8) | ord($utf16[$i + 1]);
+			if ($code < 0x80) {
+				$utf8 .= chr($code);
+			} elseif ($code < 0x800) {
+				$utf8 .= chr(0xC0 | ($code >> 6)).chr(0x80 | ($code & 0x3F));
+			} else {
+				$utf8 .= chr(0xE0 | ($code >> 12)).chr(0x80 | (($code >> 6) & 0x3F)).chr(0x80 | ($code & 0x3F));
+			}
+		}
+
+		return $utf8;
+	}
+
+	/**
+	 * Undo the escape sequences of a PDF literal string.
+	 *
+	 * @param	string		$value			Content of the string, parentheses excluded
+	 * @return	string						Decoded bytes
+	 */
+	private function unescapeLiteral($value)
+	{
+		if (strpos($value, '\\') === false) {
+			return $value;
+		}
+
+		$named = array('n' => "\n", 'r' => "\r", 't' => "\t", 'b' => "\x08", 'f' => "\x0C", '(' => '(', ')' => ')', '\\' => '\\');
+		$out = '';
+		for ($i = 0, $count = strlen($value); $i < $count; $i++) {
+			if ($value[$i] !== '\\' || $i + 1 >= $count) {
+				$out .= $value[$i];
+				continue;
+			}
+
+			$next = $value[++$i];
+			if (isset($named[$next])) {
+				$out .= $named[$next];
+			} elseif ($next >= '0' && $next <= '7') {
+				$octal = $next;
+				while (strlen($octal) < 3 && isset($value[$i + 1]) && $value[$i + 1] >= '0' && $value[$i + 1] <= '7') {
+					$octal .= $value[++$i];
+				}
+				$out .= chr(octdec($octal) & 0xFF);
+			} elseif ($next === "\n") {
+				continue;								// a backslash at end of line continues the string
+			} elseif ($next === "\r") {
+				if (isset($value[$i + 1]) && $value[$i + 1] === "\n") {
+					$i++;
+				}
+			} else {
+				$out .= $next;							// before anything else the backslash is dropped
+			}
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Resolve an element down to a dictionary, following one indirect reference.
+	 *
+	 * @param	array|null	$element		Element
+	 * @return	array|null					Content of the dictionary, null when it is not one
+	 */
+	private function dictOf($element)
+	{
+		if (!is_array($element)) {
+			return null;
+		}
+		if ($element[0] == PDF_TYPE_OBJREF) {
+			$object = $this->getObjectVal($element);
+			$element = ($object[0] == PDF_TYPE_STREAM || $object[0] == PDF_TYPE_OBJECT) ? $object[1] : $object;
+		}
+
+		return (is_array($element) && $element[0] == PDF_TYPE_DICTIONARY) ? $element[1] : null;
+	}
+
+	/**
+	 * Resolve an element down to an array, following one indirect reference.
+	 *
+	 * @param	array|null	$element		Element
+	 * @return	array						Content of the array, empty when it is not one
+	 */
+	private function arrayOf($element)
+	{
+		if (!is_array($element)) {
+			return array();
+		}
+		if ($element[0] == PDF_TYPE_OBJREF) {
+			$object = $this->getObjectVal($element);
+			$element = ($object[0] == PDF_TYPE_OBJECT) ? $object[1] : $object;
+		}
+
+		return (is_array($element) && $element[0] == PDF_TYPE_ARRAY) ? $element[1] : array();
+	}
+}

--- a/einvoicing/test/phpunit/PdfAttachmentExtractorTest.php
+++ b/einvoicing/test/phpunit/PdfAttachmentExtractorTest.php
@@ -1,0 +1,171 @@
+<?php
+/* Copyright (C) 2026		Pierre Grasswill			<da.grumpf@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/PdfAttachmentExtractorTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for PdfAttachmentExtractor, which reads the invoice attached to a
+ *                  received Factur-X PDF with the PDF parser of the core. The point of the class is
+ *                  that the reception path no longer loads composer at all, so that is asserted here
+ *                  too: this file must never make a horstoeko class exist.
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+dol_include_once('einvoicing/class/utils/PdfAttachmentExtractor.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class PdfAttachmentExtractorTest extends CommonClassTest
+{
+	/**
+	 * A Factur-X container shipped by this repository, which a received document looks like.
+	 *
+	 * @return	string				Full path of the sample
+	 */
+	private function facturxSample()
+	{
+		return dirname(__FILE__) . '/../samples/INVTEST-dol_ok.facturx.pdf';
+	}
+
+	/**
+	 * A PDF that carries no attachment at all: the carrier the mergers build on.
+	 *
+	 * @return	string				Full path of the sample
+	 */
+	private function plainPdfSample()
+	{
+		return dirname(__FILE__) . '/../../doc/00_ZugferdDocumentPdfBuilder_PrintLayout.pdf';
+	}
+
+	/**
+	 * The invoice attached to a Factur-X container is read back, and it is the CII the module parses.
+	 *
+	 * @return	void
+	 */
+	public function testTheAttachedInvoiceIsRead()
+	{
+		$sample = $this->facturxSample();
+		$this->assertFileExists($sample, 'The Factur-X sample of the repository is missing');
+
+		$xml = PdfAttachmentExtractor::getInvoiceXmlFromFile($sample);
+
+		$this->assertNotEmpty($xml, 'Nothing was extracted from the Factur-X sample');
+		$dom = new DOMDocument();
+		$this->assertTrue($dom->loadXML($xml), 'What was extracted is not parsable XML');
+		$this->assertSame('CrossIndustryInvoice', $dom->documentElement->localName, 'What was extracted is not a CII invoice');
+	}
+
+	/**
+	 * Reading the container from its content and from its path give the very same bytes.
+	 *
+	 * @return	void
+	 */
+	public function testReadingFromContentAndFromFileAgree()
+	{
+		$sample = $this->facturxSample();
+
+		$fromFile = PdfAttachmentExtractor::getInvoiceXmlFromFile($sample);
+		$fromContent = PdfAttachmentExtractor::getInvoiceXmlFromContent((string) file_get_contents($sample));
+
+		$this->assertSame($fromFile, $fromContent, 'The same container read two ways gave two different invoices');
+	}
+
+	/**
+	 * The name under which the invoice is attached is decoded, whatever form the container used.
+	 *
+	 * @return	void
+	 */
+	public function testTheAttachmentIsNamedAsFacturxRequires()
+	{
+		$parser = new PdfAttachmentExtractor((string) file_get_contents($this->facturxSample()), 'test');
+		$attachments = $parser->getEmbeddedFiles();
+		$parser->cleanUp();
+
+		$this->assertArrayHasKey('factur-x.xml', $attachments, 'The attachment was not found under the name Factur-X gives it, but as: ' . implode(', ', array_keys($attachments)));
+	}
+
+	/**
+	 * A PDF carrying no invoice is refused, rather than answered with something empty that the rest
+	 * of the reception would take for a document.
+	 *
+	 * @return	void
+	 */
+	public function testAPdfWithoutAnyAttachmentIsRefused()
+	{
+		$sample = $this->plainPdfSample();
+		$this->assertFileExists($sample, 'The plain PDF sample of the repository is missing');
+
+		$caught = null;
+		try {
+			PdfAttachmentExtractor::getInvoiceXmlFromFile($sample);
+		} catch (Exception $e) {
+			$caught = $e;
+		}
+
+		$this->assertNotNull($caught, 'A PDF with no attachment was read as if it carried an invoice');
+	}
+
+	/**
+	 * A file that is not a PDF is refused too, and by an exception the reception already catches.
+	 *
+	 * @return	void
+	 */
+	public function testSomethingThatIsNotAPdfIsRefused()
+	{
+		$caught = null;
+		try {
+			PdfAttachmentExtractor::getInvoiceXmlFromContent('<?xml version="1.0"?><a/>');
+		} catch (Exception $e) {
+			$caught = $e;
+		}
+
+		$this->assertNotNull($caught, 'A file that is not a PDF was read as if it carried an invoice');
+	}
+
+	/**
+	 * What all of the above is for: reading a received Factur-X pulls no composer library, so it
+	 * cannot be stopped by the PHP those libraries ask for.
+	 *
+	 * @return	void
+	 * @depends testTheAttachedInvoiceIsRead
+	 */
+	public function testReadingAContainerLoadsNoComposerLibrary()
+	{
+		$this->assertFalse(
+			class_exists('horstoeko\zugferd\ZugferdDocumentPdfReaderExt', false),
+			'Reading a Factur-X container brought a composer class in, which is what puts a floor under the PHP version of the reception'
+		);
+	}
+}


### PR DESCRIPTION
Follow-up to #840 and #866, and a replacement for both. Those two looked at the PHP floor from the setup side — raise it, or guard against it. This one removes the reason there is a floor on the receiving side at all.

**Only the inbound path changes, and it changes to functions the core already ships.** Emission is untouched and keeps `horstoeko/zugferd`.

## What the library is actually used for

| | what the module calls |
|---|---|
| **Reception** | `ZugferdDocumentPdfReaderExt::getInvoiceDocumentContentFrom{File,Content}()` — three call sites |
| Reception, off by default | `ZugferdDocumentPdfReader::readAndGuessFromFile()`, behind `EINVOICING_USE_EXTERNAL_FACTURX_READER` |
| **Emission** | `CtcFrPdfMerger extends ZugferdDocumentPdfMerger`, and `FacturxTcpdfMerger` for `ZugferdProfileResolver`, `ZugferdProfiles::PROFILEDEF` and the XMP asset |

The XML that comes out is parsed by the module's own CII parser — `parseInvoiceHeader()` and `parseInvoiceLines()`, the same ones a plain CII document goes through. So on the inbound side the library does exactly one thing: pull the attachment out of the container. Twenty-five lines of its own (`collectAttachmentsFromPdfContent()`: `getObjectsByType('Filespec')`, two filters, read `/EF` `/F`).

Those twenty-five lines cost a PHP 7.3 floor — `horstoeko/*`, `jms/serializer` and `goetas-webservices` all require it — and `vendor/autoload.php` was required at file scope, so `vendor/composer/platform_check.php` ended the request as soon as a Factur-X arrived, on a PHP that reads the document perfectly well.

## What the core already ships

`htdocs/includes/tcpdi/tcpdi_parser.php`. It is self-contained: it pulls `tcpdf_filters.php` and nothing else, defines its own `PDF_TYPE_*` constants, and needs neither TCPDF, nor FPDF, nor FPDI — so it is also out of reach of the FPDF/TCPDF class collision the mergers have to work around. It reads a classic cross-reference table and a cross-reference stream, object streams, and undoes stream filters. It is there from Dolibarr 18 to 25, behind the `TCPDI_PATH` constant `filefunc.inc.php` defines, and it is byte for byte the same file in 24 and in develop.

There is nothing else to reuse: `grep -ri "facturx\|zugferd" htdocs` returns nothing on 24 and on 25. The core neither writes nor reads Factur-X.

## What this changes

- `PdfAttachmentExtractor` stands on that parser and walks the two places a container declares what it embeds: the `/Names` `/EmbeddedFiles` name tree of the catalog, and its `/AF` array — the associated files, the form PDF/A-3 requires and Factur-X mandates.
- The three reception call sites use it.
- `vendor/autoload.php` and `CtcFrPdfMerger` move from file scope into `generateInvoice()`, the only method that writes a container. `FacturxTcpdfMerger` was already lazy, for the same kind of reason.
- The optional external reader keeps the library and loads the autoloader itself.

Three things the fixtures brought out while writing it, all handled:

- `tcpdi_parser::decodeStream()` cannot read a `/Filter` written as an array: that branch sits under a test on `PDF_TYPE_TOKEN`, so it never runs, and the stream comes back still encoded **with an empty list of filters left to apply** — silently wrong. The class runs its own chain over `TCPDF_FILTERS`.
- `tcpdi_parser::Error()` calls `die()`. A truncated container from an access point would have taken the whole synchronization down, so it is overridden to throw the exception the reception already reports.
- Attachment names arrive raw: `(factur\055x\056xml)` in octal escapes, and `/UF` as UTF-16BE with a byte order mark. Undecoded, the invoice is found and never recognized.

## Measured

Eight instances, **Dolibarr 18.0.10, 19.0.4, 20.0.4, 21.0.4, 22.0.5, 23.0.4, 24.0.1 and 25.0.0-alpha**, each one on the PHP its core gets in the CI matrix (7.4 to 8.5), plus the seven PHP built side by side for the version sweep.

**Extraction, against the library it replaces.** Every Factur-X the bench holds — produced by the module across the eight cores, plus what came back from the access point:

| | files per core | identical to `horstoeko/zugferd` |
|---|---|---|
| the 8 cores, each under its own PHP | 1933 | **1933 on each**, byte for byte |

The same 1933 documents were then read again under **PHP 7.0, 7.1 and 7.2**, with the `tcpdi_parser` of each of the eight cores: 24 combinations, 46 392 extractions, **0 difference** with the reference of the same core.

**Reception of a real Factur-X, in process, one distinct document per cell:**

| Dolibarr | PHP 7.0 | PHP 7.1 | PHP 7.2 | its own PHP |
|---|---|---|---|---|
| 18.0.10 → 24.0.1 (7 cores) | **imported** | **imported** | **imported** | imported |
| 25.0.0-alpha | extracted, then the core itself stops | **imported** | **imported** | imported |

Before this change, the same 24 cells are a fatal error from `vendor/composer/platform_check.php`, on every core, with nothing imported.

The one cell that is not green is not the module: Dolibarr 25 does not parse under PHP 7.0 (`public const` in `contact/class/contact.class.php`), and both 24 and 25 declare 7.1 as their own floor in `install/check.php`. The attachment had already been extracted at that point. Everywhere the core runs, the reception runs.

In all of those runs the extracted XML has the same SHA-1 as the run under the core's own PHP, and "is a composer class loaded?" answers no.

**Non-regression:**

- PHPUnit, 30 files × 8 cores, one process per file: **239/240**, against 231/232 for `main` in the same bench state — the single failure is `SupplierInvoiceHelperTest` on Dolibarr 20.0.4, which fails identically on `main`. The new test file passes on the eight.
- Generation matrix, every invoice type, CII and Factur-X, on the eight cores and the emitter: 14 generations and 14 files per instance, **identical to `main`**.
- One full cycle through the access point: a Factur-X emitted by Dolibarr 23.0.4, routed, received and imported on another 23.0.4 (100.00 HT / 120.00 TTC, VAT 20 %), statuses back.
- phpcs and phan clean.

## What is left on the library

Emission. A site that only receives, or that emits CII, no longer loads composer at all — so the PHP its e-invoicing needs is the PHP Dolibarr itself needs.
