### PR TITLE
FIX [einvoicing] The extra order references only reach the profiles that declare them

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -2351,10 +2351,10 @@ class CIIProtocol extends AbstractProtocol
 
 		// Additional order references: when an invoice covers several purchase orders, the first is emitted as BT-13
 		// (BuyerOrderReferencedDocument above) and the others are listed here as AdditionalReferencedDocument/TypeCode=130.
-		// Restricted to profiles that carry AdditionalReferencedDocument in the agreement section (not MINIMUM), and
-		// skipped for Chorus (which does not accept these extra nodes). Sequence position: after
+		// ram:AdditionalReferencedDocument is only declared in the agreement section from EN16931 up - MINIMUM, BASIC WL
+		// and BASIC do not have it - and Chorus does not accept these extra nodes. Sequence position: after
 		// ContractReferencedDocument, before SpecifiedProcuringProject (CII schema order).
-		if (!$invoiceData['_chorus'] && $profile !== 'MINIMUM' && !empty($invoiceData['_customerOrderReferenceList'])) {
+		if (!$invoiceData['_chorus'] && $this->isEn16931Profile($profile) && !empty($invoiceData['_customerOrderReferenceList'])) {
 			foreach ($invoiceData['_customerOrderReferenceList'] as $additionalOrderRef) {
 				if ($additionalOrderRef === $invoiceData['orderReference']) {
 					continue;

--- a/einvoicing/test/phpunit/CIIProfileShapeTest.php
+++ b/einvoicing/test/phpunit/CIIProfileShapeTest.php
@@ -398,7 +398,8 @@ class CIIProfileShapeTest extends CommonClassTest
 	}
 
 	/**
-	 * Invoice data carrying the three header references, on top of the base fixture.
+	 * Invoice data carrying the header references, on top of the base fixture: an invoice covering
+	 * three purchase orders, so the first lands on BT-13 and the other two on BT-18.
 	 *
 	 * @return	array<string,mixed>
 	 */
@@ -416,6 +417,9 @@ class CIIProfileShapeTest extends CommonClassTest
 		$data['buyerReference'] = 'SERVICE-EXEC-01';		// BT-10
 		$data['contractReference'] = 'CTR-2026-118';		// BT-12
 		$data['_project'] = $project;						// BT-11
+		$data['orderReference'] = 'BC-2026-0007';			// BT-13
+		// An invoice covering three orders: BT-13 takes the first, the other two go to BT-18
+		$data['_customerOrderReferenceList'] = ['BC-2026-0007', 'BC-2026-0008', 'BC-2026-0009'];
 
 		return $data;
 	}
@@ -587,6 +591,41 @@ class CIIProfileShapeTest extends CommonClassTest
 	}
 
 	/**
+	 * The order references an invoice carries beyond BT-13 are emitted as invoiced object identifiers
+	 * (BT-18), an element ram:AdditionalReferencedDocument only declares from EN16931 up.
+	 *
+	 * @return void
+	 */
+	public function testAdditionalOrderReferencesFollowTheProfileSchema()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		foreach (CIIProtocol::SUPPORTED_XML_PROFILES as $profile) {
+			$xml = $protocol->buildXML($this->invoiceDataWithReferences(), $this->baseLinesData(), $profile);
+			$count = $this->countTag($xml, 'ram:AdditionalReferencedDocument');
+
+			if (!in_array($profile, ['EN16931', 'EXTENDED', 'EXTENDEDFR'], true)) {
+				$this->assertSame(0, $count, $profile . ' does not declare ram:AdditionalReferencedDocument in the agreement section');
+				continue;
+			}
+
+			$this->assertSame(2, $count, $profile . ' must carry the two order references BT-13 does not hold');
+
+			$doc = new DOMDocument();
+			$doc->loadXML($xml);
+			$found = [];
+			foreach ($doc->getElementsByTagName('AdditionalReferencedDocument') as $node) {
+				$this->assertSame('130', $node->getElementsByTagName('TypeCode')->item(0)->nodeValue, $profile . ' BT-18 type code');
+				$found[] = $node->getElementsByTagName('IssuerAssignedID')->item(0)->nodeValue;
+			}
+			// The reference already emitted as BT-13 must not be repeated here
+			$this->assertSame(['BC-2026-0008', 'BC-2026-0009'], $found, $profile . ' BT-18 values');
+		}
+	}
+
+	/**
 	 * The project reference (BT-11) only exists from EN16931 up, and its type makes both ram:ID and
 	 * ram:Name mandatory.
 	 *
@@ -657,6 +696,7 @@ class CIIProfileShapeTest extends CommonClassTest
 			$this->assertSame(0, $this->countTag($xml, 'ram:BuyerReference'), $profile . ' must not carry an empty BT-10');
 			$this->assertSame(0, $this->countTag($xml, 'ram:ContractReferencedDocument'), $profile . ' must not carry an empty BT-12');
 			$this->assertSame(0, $this->countTag($xml, 'ram:SpecifiedProcuringProject'), $profile . ' must not carry an empty BT-11');
+			$this->assertSame(0, $this->countTag($xml, 'ram:AdditionalReferencedDocument'), $profile . ' must not carry an empty BT-18');
 		}
 	}
 


### PR DESCRIPTION
## What happens

When an invoice covers several customer orders, the first order reference goes to BT-13
(`ram:BuyerOrderReferencedDocument`) and the others are emitted as
`ram:AdditionalReferencedDocument` / `ram:TypeCode` = `130`, the invoiced object identifier
(BT-18), in the header agreement section.

That element is only declared in `HeaderTradeAgreementType` **from EN16931 up**. The MINIMUM,
BASIC WL and BASIC schemas do not declare it at all:

| profile | `AdditionalReferencedDocument` in the agreement section |
|---|---|
| MINIMUM | no |
| BASIC WL | no |
| BASIC | no |
| EN16931 | yes |
| EXTENDED / EXTENDED-CTC-FR | yes |

The guard only excluded MINIMUM, so a `BASIC` or `BASICWL` document generated for an invoice
linked to two orders or more stopped validating against its own Factur-X schema:

```
Element '{urn:...:ReusableAggregateBusinessInformationEntity:100}AdditionalReferencedDocument':
This element is not expected. Expected is ( {urn:...}ContractReferencedDocument ).
```

Negative control on the bench, same invoice shape with a single linked order: valid. The
element is the only cause.

## The fix

Use the `isEn16931Profile()` guard the project reference (BT-11) already uses a few lines below:
BT-11 and BT-18 appear at the same profile level, so the same test states the same fact. The
Chorus exclusion is unchanged.

## Bench

Real generation on a Dolibarr instance, invoice linked to three validated orders carrying
distinct customer references, one run per profile, before and after.

| profile | before | after |
|---|---|---|
| MINIMUM | 0 x BT-18, XSD valid | unchanged |
| BASIC WL | 2 x BT-18, **XSD invalid** | 0 x BT-18, XSD valid |
| BASIC | 2 x BT-18, **XSD invalid** | 0 x BT-18, XSD valid |
| EN16931 | 2 x BT-18, XSD valid | unchanged |
| EXTENDED | 2 x BT-18, XSD valid | unchanged |
| EXTENDED-CTC-FR | 2 x BT-18, XSD valid | unchanged |

The Chorus guard and the deduplication against BT-13 were checked at the same time: with
`EINVOICING_USE_CHORUS` on, nothing is emitted; the reference already carried by BT-13 is never
repeated as BT-18.

The six documents produced after the fix were also run through the FNFE CTC-FR (Flux 2) chain
- XSD, profile XSLT, `BR-FR-Flux2-Schematron-CII` in its fatal variant - and through the public
validator of an access point: valid on every profile that has a validator. Nothing regressed on
the EN16931 and EXTENDED paths, which is where the feature is meant to work.

`CIIProfileShapeTest` is red on the current `main` with the new fixture and green with the fix,
on eight instances, Dolibarr 18.0.10 to 24.0.0 and the develop branch: the whole PHPUnit suite
is 32/32 per instance.

## Note, out of the scope of this fix

The extra order references are written into BT-18, "invoiced object identifier", which the
French referential scopes with the AFL and AVV scheme identifiers (BR-FR-29). EN 16931 gives
BT-18 a cardinality of 0..1 and models no second order reference at header level. No validator
we have - CEN, FNFE CTC-FR, access point - rejects the several occurrences, and this PR does not
change that behaviour, which predates the single builder. It is worth a separate decision.
