### PR TITLE
FIX [einvoicing] The short reference fixture of the supplier lookup test is unique per run

### DIFF
--- a/einvoicing/test/phpunit/SupplierInvoiceHelperTest.php
+++ b/einvoicing/test/phpunit/SupplierInvoiceHelperTest.php
@@ -1111,6 +1111,18 @@ class SupplierInvoiceHelperTest extends CommonClassTest
 	}
 
 	/**
+	 * A reference shorter than the default minimum length of the tolerant fallback, and unique per
+	 * call. It carries a letter on purpose: an all digits reference is refused by another rule, and
+	 * the test that uses this one is about the length, not about the digits.
+	 *
+	 * @return string
+	 */
+	private function uniqueShortSupplierRef()
+	{
+		return 'A' . strtoupper(bin2hex(random_bytes(2)));
+	}
+
+	/**
 	 * Create a draft supplier invoice carrying an explicit ref_supplier.
 	 *
 	 * @param	string	$refSupplier	Value to store in ref_supplier
@@ -1301,7 +1313,9 @@ class SupplierInvoiceHelperTest extends CommonClassTest
 	{
 		global $conf;
 
-		$shortRef = 'AB12';
+		// A fixed value here survives any run that dies before the class-wide rollback, and the
+		// lookup below then answers "ambiguous" on that instance for good.
+		$shortRef = $this->uniqueShortSupplierRef();
 		$numericRef = (string) mt_rand(100000000, 999999999);
 		$invoice = $this->createSupplierInvoiceWithRef('PAY123 - ' . $shortRef . ' - ' . $numericRef . ' - dinner');
 


### PR DESCRIPTION
## What happens

`SupplierInvoiceHelperTest` builds every one of its database fixtures on `uniqueSupplierRef()`.
One test does not: `testFindIdByRefNeverSubstringSearchesAShortOrNumericReference()` stores the
literal reference `AB12`.

The class runs inside a transaction opened by `setUpBeforeClass()` and rolled back by
`tearDownAfterClass()`, so in the normal case nothing is left behind. But a run that dies before
the rollback - a fatal in another test, an interrupted run, a killed process - leaves that
supplier invoice in place. From then on, on that database, the lookup finds two candidates and
answers `-2` (ambiguous) instead of the id:

```
Failed asserting that -2 is identical to 15901.
```

and the test is red for good. The CI never sees it, because it starts from an empty database
every time. Only an instance that lives on does.

## Measured

On a bench instance carrying exactly one such leftover, dated from an earlier interrupted run:

| | `testFindIdByRefNeverSubstringSearches...` |
|---|---|
| current `main` | red, `-2` instead of the invoice id |
| this branch | green |

The rest of the suite is unchanged: 32/32 test files on eight instances, Dolibarr 18.0.10 to
24.0.0 and the develop branch.

## The change

The short reference is now drawn per run, like every other fixture of the file. It stays short -
that is what the test is about, the minimum length of the tolerant fallback - and keeps a letter
on purpose: an all digits reference is refused by another rule of the same fallback, which would
make the test prove the wrong thing.
