### PR TITLE
FIX [einvoicing] A customer order with a blank reference no longer makes the invoice invalid

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -2356,7 +2356,8 @@ class CIIProtocol extends AbstractProtocol
 		// ContractReferencedDocument, before SpecifiedProcuringProject (CII schema order).
 		if (!$invoiceData['_chorus'] && $profile !== 'MINIMUM' && !empty($invoiceData['_customerOrderReferenceList'])) {
 			foreach ($invoiceData['_customerOrderReferenceList'] as $additionalOrderRef) {
-				if ($additionalOrderRef === $invoiceData['orderReference']) {
+				// A blank reference would become an empty BT-18, which BR-52 rejects as fatal
+				if ($additionalOrderRef === $invoiceData['orderReference'] || trim((string) $additionalOrderRef) === '') {
 					continue;
 				}
 				$addRef = $doc->createElement('ram:AdditionalReferencedDocument');
@@ -3348,8 +3349,10 @@ class CIIProtocol extends AbstractProtocol
 					if (!empty($expedition->origin) && $expedition->origin == "commande" && !empty($expedition->origin_id)) {
 						$commande = new Commande($this->db);
 						$commandeFetchResult = $commande->fetch($expedition->origin_id);
-						if ($commandeFetchResult > 0 && !empty($commande->ref_client)) {
-							$customerOrderReferenceList[] = $commande->ref_client;
+						// empty() would let a reference made of spaces through - it becomes an empty BT-13 or
+						// BT-18, which BR-52 rejects - and would drop one that reads "0", which is a reference.
+						if ($commandeFetchResult > 0 && trim((string) $commande->ref_client) !== '') {
+							$customerOrderReferenceList[] = trim((string) $commande->ref_client);
 						}
 					}
 					if (!empty($expedition->date_delivery)) {
@@ -3365,8 +3368,8 @@ class CIIProtocol extends AbstractProtocol
 				$commande = new Commande($this->db);
 				$commandeFetchResult = $commande->fetch($commandeId);
 				if ($commandeFetchResult > 0) {
-					if (!empty($commande->ref_client)) {
-						$customerOrderReferenceList[] = $commande->ref_client;
+					if (trim((string) $commande->ref_client) !== '') {
+						$customerOrderReferenceList[] = trim((string) $commande->ref_client);
 					}
 					$commande->fetchObjectLinked();
 					$found = 0;

--- a/einvoicing/test/phpunit/CIITextEscapingTest.php
+++ b/einvoicing/test/phpunit/CIITextEscapingTest.php
@@ -180,7 +180,9 @@ class CIITextEscapingTest extends CommonClassTest
 			'_chorus' => false,
 			'_depositlines' => [],
 			'_globalDiscounts' => [['value' => 10.0, 'reason' => 'Geste commercial R' . self::AMP, 'taxRate' => 20.0, 'categoryVAT' => 'S']],
-			'_customerOrderReferenceList' => [],
+			// An invoice covering three orders, one of which has a blank customer reference: the first
+			// entry repeats BT-13 and the blank one must not become an empty BT-18 (BR-52).
+			'_customerOrderReferenceList' => ['CMD-2026' . self::AMP, '   ', 'CMD-2027' . self::AMP],
 			'_project' => null,
 		];
 	}
@@ -334,6 +336,31 @@ class CIITextEscapingTest extends CommonClassTest
 
 			$this->assertSame([], $empty, $profile . ' carries empty elements: ' . implode(', ', $empty));
 		}
+	}
+
+	/**
+	 * A customer order whose reference is blank is collected by the same loop as the others, and it
+	 * used to reach the document as an empty BT-18. BR-52 rejects that as fatal, on the Access Point
+	 * validator as well as on the CTC-FR chain.
+	 *
+	 * @return void
+	 */
+	public function testABlankOrderReferenceIsNotEmittedAsAnEmptyBt18()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+		$doc = $this->load($protocol->buildXML($this->poisonedInvoiceData(), $this->poisonedLinesData(), 'EN16931'));
+		$xpath = $this->xpathOf($doc);
+
+		$path = '/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:AdditionalReferencedDocument';
+		$emitted = [];
+		foreach ($xpath->query($path) as $node) {
+			$emitted[] = $node->getElementsByTagName('IssuerAssignedID')->item(0)->nodeValue;
+		}
+
+		// Only the third order is left: the first repeats BT-13, the second one is blank
+		$this->assertSame(['CMD-2027' . self::AMP], $emitted);
 	}
 
 	/**


### PR DESCRIPTION
## What happens

The references of the customer orders an invoice covers are collected with `empty()`, which
lets through a reference made of spaces. A blank reference then does damage twice:

- the list is sorted, and a blank sorts before anything else, so it becomes **BT-13** - the real
  purchase order number is pushed out of `ram:BuyerOrderReferencedDocument` and into BT-18;
- when the invoice carries its own customer reference, BT-13 is already taken and every collected
  reference goes to BT-18, the blank one included, as a
  `ram:AdditionalReferencedDocument/ram:IssuerAssignedID` holding nothing but spaces.

That element is rejected as **fatal**, by BR-52 on the EXTENDED-CTC-FR chain and by the validator
of an access point:

```
[BR-52] Each Additional supporting document (BG-24) shall contain a Supporting document
reference (BT-122).
```

A single customer order whose "Réf. client" was left as a space is enough. Nothing in Dolibarr
stops one being saved that way.

## Measured

Real invoices generated on a Dolibarr instance, from linked orders, one of them carrying a single
space as its customer reference. Both documents run through the FNFE CTC-FR chain (XSD, profile
XSLT, `BR-FR-Flux2-Schematron-CII`) and through the public validator of an access point:

| invoice | before | after |
|---|---|---|
| blank order + a real one, invoice carrying its own reference | **INVALID**, `[BR-52]` fatal on both validators | valid, BT-18 = the real reference only |
| blank order + a real one, invoice with no reference of its own | valid, but `BT-13 = "   "` and the real reference banished to BT-18 | valid, `BT-13` = the real reference, no BT-18 |

The same run on a fuzzing corpus of 23 reference shapes across the six profiles - ampersand,
angle brackets, a closing tag, quotes, accents, an emoji, newlines, control characters `0x0B` and
`0x00`, a 300 character reference, duplicates, leading zeros, 50 linked orders - shows that the
blank family was the only one producing a finding, and that it is the only behaviour this change
alters. Everything else comes out byte for byte the same.

## The change

Collect on the trimmed value, and skip a blank one at emission as well, so no feeder can put an
empty BT-18 back. `empty()` also drops a reference that reads `0`, but that one cannot be reached:
`Commande::set_ref_client()` of the core stores `0` as `NULL` for the very same reason.

`CIITextEscapingTest` now carries an invoice whose orders include a blank reference.
`testGeneratedDocumentHasNoEmptyElement()` does not catch it - a node holding spaces is not an
empty node - so the case gets a test of its own: red on `main`, green here.

Whole suite: 32/32 test files on eight instances, Dolibarr 18.0.10 to 24.0.0 and the develop
branch.
