### PR TITLE
Pin the line allowance whose base is stated as zero (follow-up to #845)

### DIFF
--- a/einvoicing/test/phpunit/ReceivedInvoiceLinesTest.php
+++ b/einvoicing/test/phpunit/ReceivedInvoiceLinesTest.php
@@ -997,6 +997,30 @@ class ReceivedInvoiceLinesTest extends CommonClassTest
 	}
 
 	/**
+	 * A base stated as zero is a base the document did not state. Some issuers write BT-137 = 0.00 next
+	 * to a real allowance amount, and the null coalescing that used to pick the base kept that zero: the
+	 * guard below it sent the discount back false and the line was imported at its gross (PR #845).
+	 *
+	 * @return	void
+	 */
+	public function testABaseStatedAsZeroFallsBackTheSameWay()
+	{
+		global $db;
+
+		$protocol = new CIIProtocol($db);
+
+		$zeroBase = $protocol->parseInvoiceLines($this->discountedLine(5.0, 100.05, 50.03, 450.22, 0.00));
+		$this->assertSame(0.0, $zeroBase[0]['lineAllowances'][0]['basisAmount'], 'BT-137 is read, and it is zero');
+
+		$discount = $this->call('resolveLineDiscountPercent', array($zeroBase[0]['lineAllowances'], $zeroBase[0]['lineTotalAmount']));
+
+		$this->assertNotFalse($discount, 'the discount is resolved and not dropped');
+		$this->assertEqualsWithDelta(500.25, $discount['base'], 0.011, 'the amount before the allowance, as when BT-137 is absent');
+		$this->assertEqualsWithDelta(10.001, $discount['percent'], 0.0001);
+		$this->assertEqualsWithDelta(450.22, $this->importedLine($zeroBase[0])['rebuilt'], 0.011, 'and the line totals BT-131');
+	}
+
+	/**
 	 * A line carrying a charge as well as an allowance (issue #735) keeps the treatment that issue gave
 	 * it: the charge leaves by a line of its own, so it is out of the base and out of the unit price.
 	 *


### PR DESCRIPTION
PR #845 is merged and correct. What it left behind is a shape nobody pins.

`toFloat()` answers `null` for an absent `ram:BasisAmount` and `0.0` for `<ram:BasisAmount>0.00</ram:BasisAmount>`, so the `??` that used to pick the base only ever caught the first. A stated zero went through as the base, `if (!$base)` then sent `resolveLineDiscountPercent()` back `false`, and the line landed on the invoice at its gross. `!empty()` catches both.

`ReceivedInvoiceLinesTest.php` covers the two neighbouring shapes of that base — `testADocumentStatingItsBaseIsUnchanged` and `testTheFallbackRebuildsTheBaseTheDocumentDidNotState` — and **the 49 other tests of that file stay green on the code #845 replaced**. Only the third shape tells the two apart, so the next tidy-up of that line puts the null coalescing back unnoticed.

This test sits next to the other two and reuses their document: a line of 5 × 100.05 with an allowance of 50.03, `BasisAmount` 0.00 and `LineTotalAmount` 450.22.

**Measured.** Module suite file by file on **18.0.10, 19.0.4, 20.0.4, 21.0.4, 22.0.5, 23.0.4, 24.0.1 and 25.0.0-alpha**, one PHP per core as the CI gives it:

| | result |
|---|---|
| this branch | **32 files OK on each of the 8 cores** |
| base taken from the null coalescing again | the new test alone fails, on each core: *"Failed asserting that false is not false"* |

On 18.0.10 with that one line put back: `Tests: 50, Assertions: 203, Failures: 1` — the failure is this test and nothing else.

No production code touched, so nothing to regress: the diff is 24 lines in one test file.
