### PR TITLE
FIX [einvoicing] Read the 'Converted' CDAR when the access point holds no 'Original'

### DIFF
--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -2482,17 +2482,15 @@ class SuperPDPProvider extends AbstractPDPProvider
 				*/
 
 				// 2. Read CDAR and update status of linked customer invoice
-				$flowResource = 'flows/' . $flowId;
-				$flowUrlparams = array(
-					'docType' => 'Original', // docType can be 'Metadata', 'Original', 'Converted' or 'ReadableView'
-				);
-				$flowResource .= '?' . http_build_query($flowUrlparams);
-				$flowResponse = $this->callApi(
-					$flowResource,
-					"GET",
-					false,
-					['Accept' => 'application/octet-stream']
-				);
+				// Some flows have no 'Original' on the platform, only the converted copy, and the sync then
+				// stops on that flow and on every flow behind it. Both carry the same CDAR, so fall back on
+				// the converted one. docType can be 'Metadata', 'Original', 'Converted' or 'ReadableView'.
+				$flowResponse = $this->fetchFlowData($flowId, 'Original');
+
+				if ($flowResponse['status_code'] != 200) {
+					dol_syslog(__METHOD__ . " No 'Original' document for flowId: " . $flowId . " (HTTP " . $flowResponse['status_code'] . "), reading the CDAR from the 'Converted' document instead", LOG_WARNING);
+					$flowResponse = $this->fetchFlowData($flowId, 'Converted');
+				}
 
 				if ($flowResponse['status_code'] != 200) {
 					return array('res' => -1, 'message' => "Failed to retrieve flow details for flowId: " . $flowId);


### PR DESCRIPTION
`SuperPDPProvider::syncFlow()`, case `"CustomerInvoiceLC"`, asks the access point for the `Original`
document of the flow and fails the flow when there is none:

```php
$flowUrlparams = array('docType' => 'Original', ...);
...
if ($flowResponse['status_code'] != 200) {
	return array('res' => -1, 'message' => "Failed to retrieve flow details for flowId: " . $flowId);
}
```

An incoming lifecycle flow is not a document we uploaded: its original is whatever the sender's
platform put there, and it is not always materialized - the converted copy is. Both carry the same
CDAR.

That is not a theoretical case: it is **#449**, "Sync blocked - Original document not found
(also absent on the platform itself, not just on the integration side). Only the Converted version was
available. The synchronization remained blocked and could not proceed, with no way to bypass it" - the
reporter's workaround was to edit `docType` to `Converted` by hand, re-run, and put it back. `90c792e9`
fixed it on `EsalinkPDPProvider` only; `SuperPDPProvider` kept the same code as before, so the same
report on a SuperPDP account still ends the same way today.

This is the same two lines on the SuperPDP side, through `fetchFlowData()` (which already centralizes
that URL and its `Accept: application/octet-stream` header) rather than a third inline copy of the
same GET.

## Why the `-1` costs more than one flow

That return happens before the single `$document->create($user)` of `syncFlow()`
(`SuperPDPProvider.class.php:2806`), so nothing is stored for the flow. `getLastSyncDate()` being
`MAX(updatedat)` over the **stored** documents (`AbstractPDPProvider.class.php:848-851`), the flow
never leaves the synchronization window: the batch aborts on it, and aborts on it again on every later
run, with everything behind it in the listing.

## Tested

Bench, 11 instances (Dolibarr 18.0 to 25.0-alpha), real SuperPDP account, `syncFlow()` replayed on a
real `CustomerInvoiceLC` flow inside a transaction that is rolled back afterwards. The access point
holding no original is simulated by forcing the `docType=Original` GET to 404 and serving the CDAR on
`docType=Converted`:

| | `main` (`11f0f787`) | this PR |
|---|---|---|
| nominal, `Original` present | `res: 1`, flow stored | `res: 1`, flow stored - unchanged |
| no `Original`, CDAR on `Converted` | `res: -1`, no second attempt, **nothing stored** | `res: 1`, CDAR read, status 211 recorded, flow stored |
| neither document available | `res: -1`, nothing stored | `res: -1`, nothing stored - unchanged |

PHPUnit file by file on the 8 cores: **256/256**.

The negative return itself is left byte for byte as it is: it is one of the five returns of that case
that #879 settles, and touching it here would make the two conflict for nothing. The last `Original`
read with no fallback, in `processIncomingSupplierInvoiceStatus()`, is handled by #877.
