### PR TITLE
FIX [einvoicing] A lifecycle status about an invoice we sent no longer stalls the synchronization

### DIFF
--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -1491,7 +1491,18 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 				}
 
 				if ($flowResponse['status_code'] != 200) {
-					return array('res' => -1, 'message' => "Failed to retrieve flow details (neither 'Original' nor 'Converted' document) for flowId: " . $flowId);
+					// Transient, and nothing was stored for this flow: without 'postponeflow' the batch
+					// aborts here and on every run after it, since an unstored flow never leaves the
+					// synchronization window. The #718 convention is meant for exactly this.
+					return array(
+						'res' => -1,
+						'postponeflow' => 1,
+						'message' => "Failed to retrieve flow details (neither 'Original' nor 'Converted' document) for flowId: " . $flowId,
+						'actioncode' => 'CANT_RECORD_SENT_INVOICE_LIFECYCLE_STATUS',
+						'actionurl' => '',
+						'action' => $langs->trans('CheckSyncLogCantRecordSentInvoiceStatus'),
+						'businessmessage' => $langs->trans('CantRecordTheStatusOfTheInvoiceYouSent', $flowId)
+					);
 				}
 				$cdarXml = $flowResponse['response'];
 
@@ -1501,13 +1512,29 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 
 				try {
 					// Parse the CDAR document (returns an array)
-					$cdarDocument = $cdarHandler->readFromString($cdarXml);
+					try {
+						$cdarDocument = $cdarHandler->readFromString($cdarXml);
+					} catch (Exception $e) {
+						// Malformed XML (a JSON error body, an HTML page): it will not parse any better on
+						// a later run, so it falls into the guard below instead of the catch at the end.
+						dol_syslog(__METHOD__ . " FlowId " . $flowId . " - " . $e->getMessage(), LOG_WARNING);
+						$cdarDocument = array();
+					}
 
 					//var_dump($cdarDocument); exit;
 
-					// Check if parsing was successful
-					if (empty($cdarDocument) || !isset($cdarDocument['AcknowledgementDocument'])) {
-						return array('res' => -1, 'message' => "FlowId: " . $flowId . " - Failed to parse CDAR document");
+					// Check the lifecycle code this case exists to record, not the array: a parsed CDAR
+					// always carries every key, empty or not (CdarHandler::parseReferencedDocument()), so
+					// a non-empty array proves nothing. Left untested, IssuerAssignedID below reads as ''
+					// and Facture::fetch(0, '') returns -1 on its own guard - which aborted the batch on
+					// a message naming an empty reference, and aborted it again on every later run.
+					if (empty($cdarDocument['AcknowledgementDocument']['ReferenceReferencedDocument']['ProcessConditionCode'])) {
+						// Not transient: a document that carries no lifecycle status never will. Stored, so
+						// the next synchronization skips it instead of reading it again.
+						dol_syslog(__METHOD__ . " FlowId " . $flowId . " carries no readable CDAR", LOG_WARNING);
+						$returnRes = 0;
+						$returnMessage = "FlowId: " . $flowId . " - Failed to parse CDAR document";
+						break;
 					}
 
 					$factureObj = new Facture($this->db);
@@ -1518,13 +1545,24 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 
 					$res = $factureObj->fetch(0, $issuerAssignedID);
 					if ($res < 0) {
+						// A reference matching no invoice returns 0, and is stored below with no invoice
+						// attached: a negative result is an SQL failure only, so it is worth retrying.
 						return array(
 							'res' => -1,
-							'message' => "FlowId " . $flowId . " - Failed to fetch customer invoice using CDAR IssuerAssignedID/ref: " . $issuerAssignedID
+							'postponeflow' => 1,
+							'message' => "FlowId " . $flowId . " - Failed to fetch customer invoice using CDAR IssuerAssignedID/ref: " . $issuerAssignedID,
+							'actioncode' => 'CANT_RECORD_SENT_INVOICE_LIFECYCLE_STATUS',
+							'actionurl' => '',
+							'action' => $langs->trans('CheckSyncLogCantRecordSentInvoiceStatus'),
+							'businessmessage' => $langs->trans('CantRecordTheStatusOfTheInvoiceYouSent', $flowId)
 						);
 					}
 					if ($factureObj->entity && $factureObj->entity != $conf->entity) {
-						return array('res' => -1, 'message' => "Processing flowId: " . $flowId . " - Failed to fetch customer invoice ref " . $document->tracking_idref . " in entity " . $conf->entity);
+						// That invoice belongs to another entity, so this flow is not this one's business:
+						// treated exactly like a reference matching nothing (the flow is stored, with no
+						// invoice attached), instead of aborting the batch and every flow behind it.
+						dol_syslog(__METHOD__ . " FlowId " . $flowId . " refers to customer invoice " . $factureObj->ref . " of entity " . $factureObj->entity . ", not entity " . $conf->entity, LOG_WARNING);
+						$factureObj = new Facture($this->db);
 					}
 
 
@@ -1630,9 +1668,17 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 							break;
 					}
 				} catch (Exception $e) {
+					// Nothing is committed when this is reached: the inner block rolls back before it
+					// rethrows, and what runs after its commit cannot throw. So the flow was not stored
+					// either, and postponing it retries it whole rather than aborting the batch for good.
 					return array(
 						'res' => -1,
-						'message' => "FlowId " . $flowId . " - Error processing CDAR document - " . $e->getMessage()
+						'postponeflow' => 1,
+						'message' => "FlowId " . $flowId . " - Error processing CDAR document - " . $e->getMessage(),
+						'actioncode' => 'CANT_RECORD_SENT_INVOICE_LIFECYCLE_STATUS',
+						'actionurl' => '',
+						'action' => $langs->trans('CheckSyncLogCantRecordSentInvoiceStatus'),
+						'businessmessage' => $langs->trans('CantRecordTheStatusOfTheInvoiceYouSent', $flowId)
 					);
 				}
 

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -2495,7 +2495,18 @@ class SuperPDPProvider extends AbstractPDPProvider
 				);
 
 				if ($flowResponse['status_code'] != 200) {
-					return array('res' => -1, 'message' => "Failed to retrieve flow details for flowId: " . $flowId);
+					// Transient, and nothing was stored for this flow: without 'postponeflow' the batch
+					// aborts here and on every run after it, since an unstored flow never leaves the
+					// synchronization window. The #718 convention is meant for exactly this.
+					return array(
+						'res' => -1,
+						'postponeflow' => 1,
+						'message' => "Failed to retrieve flow details for flowId: " . $flowId,
+						'actioncode' => 'CANT_RECORD_SENT_INVOICE_LIFECYCLE_STATUS',
+						'actionurl' => '',
+						'action' => $langs->trans('CheckSyncLogCantRecordSentInvoiceStatus'),
+						'businessmessage' => $langs->trans('CantRecordTheStatusOfTheInvoiceYouSent', $flowId)
+					);
 				}
 				$cdarXml = $flowResponse['response'];
 
@@ -2505,13 +2516,29 @@ class SuperPDPProvider extends AbstractPDPProvider
 
 				try {
 					// Parse the CDAR document (returns an array)
-					$cdarDocument = $cdarHandler->readFromString($cdarXml);
+					try {
+						$cdarDocument = $cdarHandler->readFromString($cdarXml);
+					} catch (Exception $e) {
+						// Malformed XML (a JSON error body, an HTML page): it will not parse any better on
+						// a later run, so it falls into the guard below instead of the catch at the end.
+						dol_syslog(__METHOD__ . " FlowId " . $flowId . " - " . $e->getMessage(), LOG_WARNING);
+						$cdarDocument = array();
+					}
 
 					//var_dump($cdarDocument); exit;
 
-					// Check if parsing was successful
-					if (empty($cdarDocument) || !isset($cdarDocument['AcknowledgementDocument'])) {
-						return array('res' => -1, 'message' => "FlowId: " . $flowId . " - Failed to parse CDAR document");
+					// Check the lifecycle code this case exists to record, not the array: a parsed CDAR
+					// always carries every key, empty or not (CdarHandler::parseReferencedDocument()), so
+					// a non-empty array proves nothing. Left untested, IssuerAssignedID below reads as ''
+					// and Facture::fetch(0, '') returns -1 on its own guard - which aborted the batch on
+					// a message naming an empty reference, and aborted it again on every later run.
+					if (empty($cdarDocument['AcknowledgementDocument']['ReferenceReferencedDocument']['ProcessConditionCode'])) {
+						// Not transient: a document that carries no lifecycle status never will. Stored, so
+						// the next synchronization skips it instead of reading it again.
+						dol_syslog(__METHOD__ . " FlowId " . $flowId . " carries no readable CDAR", LOG_WARNING);
+						$returnRes = 0;
+						$returnMessage = "FlowId: " . $flowId . " - Failed to parse CDAR document";
+						break;
 					}
 
 					$factureObj = new Facture($this->db);
@@ -2522,13 +2549,24 @@ class SuperPDPProvider extends AbstractPDPProvider
 
 					$res = $factureObj->fetch(0, $issuerAssignedID);
 					if ($res < 0) {
+						// A reference matching no invoice returns 0, and is stored below with no invoice
+						// attached: a negative result is an SQL failure only, so it is worth retrying.
 						return array(
 							'res' => -1,
-							'message' => "FlowId " . $flowId . " - Failed to fetch customer invoice using CDAR IssuerAssignedID/ref: " . $issuerAssignedID
+							'postponeflow' => 1,
+							'message' => "FlowId " . $flowId . " - Failed to fetch customer invoice using CDAR IssuerAssignedID/ref: " . $issuerAssignedID,
+							'actioncode' => 'CANT_RECORD_SENT_INVOICE_LIFECYCLE_STATUS',
+							'actionurl' => '',
+							'action' => $langs->trans('CheckSyncLogCantRecordSentInvoiceStatus'),
+							'businessmessage' => $langs->trans('CantRecordTheStatusOfTheInvoiceYouSent', $flowId)
 						);
 					}
 					if ($factureObj->entity && $factureObj->entity != $conf->entity) {
-						return array('res' => -1, 'message' => "Processing flowId: " . $flowId . " - Failed to fetch customer invoice ref " . $document->tracking_idref . " in entity " . $conf->entity);
+						// That invoice belongs to another entity, so this flow is not this one's business:
+						// treated exactly like a reference matching nothing (the flow is stored, with no
+						// invoice attached), instead of aborting the batch and every flow behind it.
+						dol_syslog(__METHOD__ . " FlowId " . $flowId . " refers to customer invoice " . $factureObj->ref . " of entity " . $factureObj->entity . ", not entity " . $conf->entity, LOG_WARNING);
+						$factureObj = new Facture($this->db);
 					}
 
 					$document->fk_element_id = !empty($factureObj->id) ? $factureObj->id : 0;
@@ -2634,9 +2672,17 @@ class SuperPDPProvider extends AbstractPDPProvider
 							break;
 					}
 				} catch (Exception $e) {
+					// Nothing is committed when this is reached: the inner block rolls back before it
+					// rethrows, and what runs after its commit cannot throw. So the flow was not stored
+					// either, and postponing it retries it whole rather than aborting the batch for good.
 					return array(
 						'res' => -1,
-						'message' => "FlowId " . $flowId . " - Error processing CDAR document - " . $e->getMessage()
+						'postponeflow' => 1,
+						'message' => "FlowId " . $flowId . " - Error processing CDAR document - " . $e->getMessage(),
+						'actioncode' => 'CANT_RECORD_SENT_INVOICE_LIFECYCLE_STATUS',
+						'actionurl' => '',
+						'action' => $langs->trans('CheckSyncLogCantRecordSentInvoiceStatus'),
+						'businessmessage' => $langs->trans('CantRecordTheStatusOfTheInvoiceYouSent', $flowId)
 					);
 				}
 

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -742,3 +742,7 @@ DiscountFromDepositNoSource=Down payment deducted
 DiscountFromExcessReceivedNoSource=Payment in excess deducted
 DiscountFromExcessPaidNoSource=Payment in excess deducted
 FxCheckErrorLinesWithNoName=The following lines have neither a product label nor a description, so the item name of the e-invoice (BT-153) would be empty, which rule BR-25 refuses: %s. Enter a description on each of them (rank in the document, then line id).
+
+# A lifecycle status about an invoice we sent, that this run could not record (flow left unstored, retried later)
+CantRecordTheStatusOfTheInvoiceYouSent=The status of an invoice you sent, carried by flow %s, could not be recorded. Nothing was stored, the flow will be retried on the next synchronization.
+CheckSyncLogCantRecordSentInvoiceStatus=Nothing to do here: this flow is retried automatically on the next synchronization. If it keeps failing, the synchronization log gives the technical reason.


### PR DESCRIPTION
Follow-up to #858, on the other half of the same defect: `"SupplierInvoiceLC"` was settled there,
`"CustomerInvoiceLC"` has the same shape and is in `main` since well before it.

Every negative return of that case happens **before** the single `$document->create($user)` of
`syncFlow()` (`EsalinkPDPProvider.class.php:1803`, `SuperPDPProvider.class.php:2806`), so none of them
stores anything - and none of them carries `postponeflow`. Each therefore aborts the whole batch, and
keeps aborting it: `getLastSyncDate()` is `MAX(updatedat)` over the **stored** documents
(`AbstractPDPProvider.class.php:848-851`), so a flow that is never stored never leaves the
synchronization window. Everything behind it in the listing stops with it, run after run.

## The one that needs no platform failure at all

The guard before reading the CDAR only tested `AcknowledgementDocument`:

```php
if (empty($cdarDocument) || !isset($cdarDocument['AcknowledgementDocument'])) {
```

`CdarHandler::readFromString()` always returns that key, and `parseAcknowledgementDocument()` always
returns its four, `parseReferencedDocument()` always its seven - filled with `''` when the XML carries
nothing. So the guard passes on any well-formed XML, `$issuerAssignedID` reads as `''` two lines below,
and `Facture::fetch(0, '')` returns `-1` on its own guard (`if (empty($rowid) && empty($ref) &&
empty($ref_ext)) return -1;`, `facture.class.php:2152` on 18/19/20/21, `:2239` on 24 and develop). The
synchronization then stalls for good on:

```
FlowId <id> - Failed to fetch customer invoice using CDAR IssuerAssignedID/ref:
```

with nothing after the colon - a message that names the wrong thing entirely. The test is now on the
lifecycle code the case exists to record, the same one `processIncomingSupplierInvoiceStatus()` uses.

## Each failure settled on whether trying again can change anything

| Failure | Nature | Now |
|---|---|---|
| Neither `Original` nor `Converted` retrievable | transient | `-1` + `postponeflow` |
| Document carries no lifecycle status (unparseable, or not a CDAR) | permanent | `res = 0`, stored and skipped |
| `Facture::fetch()` returns `< 0` | transient - an SQL failure only, a ref matching nothing returns `0` and is already handled below | `-1` + `postponeflow` |
| Invoice found in another entity | permanent | treated like the `(NOTFOUND)` case right below it: stored, no invoice attached |
| Any exception while processing the CDAR | transient - the inner block rolls back before it rethrows, and what runs after its commit cannot throw | `-1` + `postponeflow` |

`postponeflow` is the #718 convention, and the branch that reads it already exists in both providers'
`syncFlows()`: nothing was stored, so the flow comes back on the next run and the batch carries on with
the flows behind it meanwhile.

Two lang keys are added for the postponed cases. They sit at the end of the file on purpose: #877 adds
its own pair for the supplier side and there is no reason for the two to collide.

## Tested

Bench (11 instances, Dolibarr 18.0 to 25.0-alpha, real access point), same harness run against `main`
and against this branch, everything inside a transaction and rolled back:

**The five paths, `syncFlow()` on a real `CustomerInvoiceLC` flow:**

| Flow document served | `main` | this PR |
|---|---|---|
| the real CDAR | `res: 1`, stored | `res: 1`, stored - unchanged |
| a CDAR with its `ReferenceReferencedDocument` removed | `res: -1`, **nothing stored**, `...IssuerAssignedID/ref: ` (empty) | `res: 0`, stored and skipped |
| a well-formed XML that is not a CDAR | `res: -1`, **nothing stored**, same misleading message | `res: 0`, stored and skipped |
| not XML at all (a JSON error body) | `res: -1`, **nothing stored** | `res: 0`, stored and skipped |
| HTTP 404 | `res: -1`, **nothing stored** | `res: -1` + `postponeflow`, nothing stored |

**The batch, `syncFlows()` over 20 flows with one `CustomerInvoiceLC` forced to 404:**

- `main`: `Synchronisation interrompue sur le flux # 5 / 20`, `res: -1`, 1 flow synchronized, the five
  behind it never processed, and the failing flow not stored - so the next run stops on it again.
- this PR: `res: 1`, 20 flows synchronized, `Nombre total de flux reportés ...: 1`,
  `Flow <id> postponed, it will be retried on the next synchronization`, and the flow still not stored,
  so it does come back.

PHPUnit file by file on the 8 cores: **256/256**. (One failure seen on dd18,
`MandatoryThirdpartyExtrafieldTest`, reproduces identically on `main` at `11f0f787`: bench data, not
this branch.)

Two honest limits:

- The *entity* case could not be reached on the bench: `Facture::fetch()` by ref already scopes on
  `f.entity IN (getEntity('invoice'))` (checked on 18, 24 and develop), so the guard only fires under
  multi-company invoice sharing. Forcing `$conf->entity` gives the same result before and after (the
  fetch finds nothing, the `(NOTFOUND)` path takes over) - so no regression there, but the fix on that
  line is alignment, not a stall I reproduced.
- `EsalinkPDPProvider` is not exercised live, no Esalink account being configured on the bench; it
  receives the same edit as its SuperPDP twin, byte for byte.
