### PR TITLE
FIX [einvoicing] The API call trace can be numbered on PostgreSQL

### DIFF
--- a/einvoicing/class/call.class.php
+++ b/einvoicing/class/call.class.php
@@ -1233,11 +1233,23 @@ class Call extends CommonObject
 
 		// Read on the connection this record will be written on ($dbhistory), not on the global $db: a
 		// snapshot read from another transaction returns a stale number and the insert dies on
-		// uk_einvoicing_call_callid. FOR UPDATE makes it a locking read and holds the range until insert.
+		// uk_einvoicing_call_callid. The read must therefore be a locking one, held until the insert.
+		$ispgsql = ($this->db->type == 'pgsql');
+
+		if ($ispgsql) {
+			// PostgreSQL refuses FOR UPDATE on an aggregate (SQLSTATE 0A000), so serialize the readers
+			// with an advisory lock instead. It is held until the transaction ends, like FOR UPDATE.
+			if (!$this->db->query("SELECT pg_advisory_xact_lock(1)")) {
+				return null;
+			}
+		}
+
 		$sql = "SELECT MAX(CAST(SUBSTRING(call_id, ".(strlen($prefix) + 1).") AS INTEGER)) AS maxref";
 		$sql .= " FROM ".$this->db->prefix().$this->table_element;
 		$sql .= " WHERE call_id LIKE '".$this->db->escape($prefix)."%'";
-		$sql .= " FOR UPDATE";
+		if (!$ispgsql) {
+			$sql .= " FOR UPDATE";
+		}
 
 		$resql = $this->db->query($sql);
 		if (!$resql) {


### PR DESCRIPTION
Fixes #876.

## The defect

`Call::getNextCallId()` reserved the next `Call-NNNNNN` number with a locking read:

```sql
SELECT MAX(CAST(SUBSTRING(call_id, 6) AS INTEGER)) AS maxref
  FROM llx_einvoicing_call WHERE call_id LIKE 'Call-%' FOR UPDATE
```

PostgreSQL refuses `FOR UPDATE` on an aggregate. The read returns nothing, `getNextCallId()`
returns `null`, and `logCall()` can no longer write the trace of a call to the platform.
Reproduced on Dolibarr 23.0.4 / PostgreSQL 16.14 / PHP 8.4, the configuration of the report:

```
db type   : pgsql
getNextCallId: NULL
lasterror : ERROR:  0A000: FOR UPDATE is not allowed with aggregate functions
            LOCATION:  CheckSelectLocking, analyze.c:3267
lastqueryerror: SELECT MAX(CAST(SUBSTRING(call_id, 6) AS INTEGER)) AS maxref
                FROM llx_einvoicing_call WHERE call_id ILIKE 'Call-%' FOR UPDATE
```

(`AS SIGNED` was already turned into `AS INTEGER` by 07ae9aef, and the pgsql driver of the core
rewrites `LIKE` into `ILIKE` on its own: the locking clause is what is left of the report.)

## The fix

As suggested in the issue: keep the current query on MySQL, and on PostgreSQL replace the
locking clause with a transaction-scoped advisory lock taken just before the read. Both hold
until the transaction that inserts the row ends, which is exactly what the number needs.

## What was measured

Two concurrent processes, each in its own transaction, the first sleeping 3 s between taking
the number and committing:

| tree | database | process A | process B |
|---|---|---|---|
| this branch | PostgreSQL 16 | `Call-000001`, committed | blocked 2.05 s, `Call-000002`, committed |
| this branch | MySQL (MariaDB 11.4) | `Call-000001`, committed | blocked 2.03 s, `Call-000002`, committed |
| control: `FOR UPDATE` simply dropped, no advisory lock | PostgreSQL 16 | `Call-000001`, committed | **`Call-000001`**, `ErrorRefAlreadyExists`, trace lost |

The control is the reason the lock is not optional: without it two parallel calls take the same
number and the second trace is lost on `uk_einvoicing_call_callid`.

PHPUnit, module suite, one process per file:

- Dolibarr 23.0.4 + MariaDB 11.4, PHP 8.4 — 32 files, 32 OK
- Dolibarr 23.0.4 + PostgreSQL 16.14, PHP 8.4 — 32 files, 32 OK

The PostgreSQL instance was installed from scratch for this (`install/step1-2-5`, 272 tables);
activating the module created its 6 tables there without a word.

## End to end against the Access Point

A PostgreSQL 16.14 instance of Dolibarr 23.0.4 was given the SuperPDP account and the routing
identifiers of the MySQL bench instance, then run through the whole lifecycle in both directions
against the real Access Point.

**Emitting from PostgreSQL** (`DD23-FA-2609-0002`, flow `i_501265`): sent, received by the
instance in front as supplier invoice #810, approved (205) and paid (211) there, statuses came
back on the emitter, and the emitter cashed it in (212).

```
lifecycle_msg 200  flow=ie_1524692
lifecycle_msg 201  flow=ie_1524693
lifecycle_msg 205  flow=ie_1524707
lifecycle_msg 211  flow=ie_1524709
lifecycle_msg 212  flow=ie_1524739
```

**Receiving on PostgreSQL** (`TRI-FA-2609-0907`, flow `i_501289`): imported as supplier invoice
#456, approved and paid from the PostgreSQL side, 200/201/205/211/212 recorded on the emitter.

Over the two cycles the instance wrote **482 traces, `Call-000001` to `Call-000482`, contiguous
and all distinct**, and the log holds no `FOR UPDATE is not allowed` at all.

## What the defect actually costs, measured on that same instance

Sending is not blocked — the invoice does leave. What is lost is the trace of every exchange.
Same instance, same minute, one invoice emitted on each tree:

| tree | traces in `llx_einvoicing_call` | log | PHP |
|---|---|---|---|
| main | 491 → **491** (nothing written) | 4 × `FOR UPDATE is not allowed with aggregate functions` | `Undefined array key "id"` and `"call_id"`, SuperPDPProvider.class.php:1179-1180 |
| this branch | 491 → **493** | clean | clean |

The two warnings are `logCall()` returning null and `sendInvoice()` reading `$response['id']` /
`$response['call_id']` from it, so the event written on the invoice timeline ends on a bare
`CallID` with nothing after it. On PostgreSQL the module therefore keeps no record of what it
sent to the platform.
