### PR TITLE
FIX #880 [einvoicing] Skip InvoiceReferencedDocument check for standard invoices (TypeCode 380)

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -924,7 +924,9 @@ class CIIProtocol extends AbstractProtocol
 		}
 
 		// Check if all referenced documents in the invoice exist in Dolibarr for the same supplier, if not return with error since we need them for correct linking in the invoice
-		if (!empty($parsedHeader['invoiceRefDocs']) && is_array($parsedHeader['invoiceRefDocs'])) {
+		// Only check for invoice types that require a linked document (credit notes 381/503, replacement 384) — for standard invoices (380) BG-3 is optional and may contain vendor placeholders.
+		$refDocCheckTypes = ['381', '503', '384'];
+		if (in_array($parsedHeader['documenttypecode'] ?? null, $refDocCheckTypes) && !empty($parsedHeader['invoiceRefDocs']) && is_array($parsedHeader['invoiceRefDocs'])) {
 			foreach ($parsedHeader['invoiceRefDocs'] as $invoiceRefDoc) {
 				$refDoc = $invoiceRefDoc['IssuerAssignedID'] ?? null;
 				$dateDoc = $invoiceRefDoc['FormattedIssueDateTime'] ?? null;

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -924,9 +924,7 @@ class CIIProtocol extends AbstractProtocol
 		}
 
 		// Check if all referenced documents in the invoice exist in Dolibarr for the same supplier, if not return with error since we need them for correct linking in the invoice
-		// Only check for invoice types that require a linked document (credit notes 381/503, replacement 384) — for standard invoices (380) BG-3 is optional and may contain vendor placeholders.
-		$refDocCheckTypes = ['381', '503', '384'];
-		if (in_array($parsedHeader['documenttypecode'] ?? null, $refDocCheckTypes) && !empty($parsedHeader['invoiceRefDocs']) && is_array($parsedHeader['invoiceRefDocs'])) {
+		if (!empty($parsedHeader['invoiceRefDocs']) && is_array($parsedHeader['invoiceRefDocs'])) {
 			foreach ($parsedHeader['invoiceRefDocs'] as $invoiceRefDoc) {
 				$refDoc = $invoiceRefDoc['IssuerAssignedID'] ?? null;
 				$dateDoc = $invoiceRefDoc['FormattedIssueDateTime'] ?? null;
@@ -937,9 +935,17 @@ class CIIProtocol extends AbstractProtocol
 					return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($refDocInvoiceId, $refDoc, 'required by received document ' . ($parsedHeader['documentno'] ?? ''))];
 				}
 				if ($refDocInvoiceId == 0) {
-					// The document references an invoice this Dolibarr does not hold. Nothing has been created at this
-					// point, so the flow is postponed and retried on the next synchronization rather than failed, and
-					// the message spells out what to create with a link to the screen that creates it.
+					// An unqualified reference (no ram:TypeCode in the XML) is a placeholder that the import
+					// does not consume — some vendors (e.g. DSV Road) always emit BG-3 with a dummy value
+					// such as "XXXX" when no preceding invoice applies. Skip it silently so it does not block
+					// the import and does not reach the post-creation loop.
+					if (empty($typeDoc)) {
+						dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Skipping unqualified InvoiceReferencedDocument ref="' . $refDoc . '" (no TypeCode) for ' . ($parsedHeader['documentno'] ?? ''), LOG_DEBUG);
+						continue;
+					}
+					// The document references a qualified invoice this Dolibarr does not hold yet. Nothing has
+					// been created at this point, so the flow is postponed and retried on the next
+					// synchronization rather than failed, and the message spells out what to create.
 					$langs->load("bills");
 					$action = $langs->trans('CreateTheMissingSupplierInvoiceToImport', $refDoc);
 					$action .= ' <a class="butAction small smallpaddingimp nomarginleft" href="' . DOL_URL_ROOT . '/fourn/facture/card.php?action=create&socid=' . (int) $socId . '&ref_supplier=' . urlencode($refDoc) . '" target="_blank">';
@@ -1073,6 +1079,12 @@ class CIIProtocol extends AbstractProtocol
 						return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($linkedObjectId, $refDoc, 'required by received document ' . ($parsedHeader['documentno'] ?? ''))];
 					}
 					if ($linkedObjectId == 0) {
+						// Unqualified references (no TypeCode) were already skipped by the pre-check above and
+						// should not reach this point. As a safety net, skip them here too rather than failing.
+						if (empty($typeDoc)) {
+							dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Skipping unqualified InvoiceReferencedDocument ref="' . $refDoc . '" (no TypeCode) in post-creation loop for ' . ($parsedHeader['documentno'] ?? ''), LOG_DEBUG);
+							continue;
+						}
 						return ['res' => -1, 'message' => 'Document ' . dol_escape_htmltag((string) $refDoc) . ', required by received document ' . dol_escape_htmltag((string) ($parsedHeader['documentno'] ?? '')) . ', was not found in Dolibarr'];
 					}
 
@@ -2008,6 +2020,7 @@ class CIIProtocol extends AbstractProtocol
 						'IssuerAssignedID' => $this->getXPathValue($xpath, 'ram:IssuerAssignedID', $n),
 						'issueDate' => $this->normDate($this->getXPathValue($xpath, 'ram:FormattedIssueDateTime/qdt:DateTimeString', $n)
 							?? $this->getXPathValue($xpath, 'ram:IssueDateTime/udt:DateTimeString', $n)),
+						'TypeCode' => $this->getXPathValue($xpath, 'ram:TypeCode', $n),
 					];
 					break;
 

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -702,9 +702,7 @@ class FacturXProtocol extends CIIProtocol
 		}
 
 		// Check if all referenced documents in the invoice exist in Dolibarr for the same supplier, if not return with error since we need them for correct linking in the invoice
-		// Only check for invoice types that require a linked document (credit notes 381/503, replacement 384) — for standard invoices (380) BG-3 is optional and may contain vendor placeholders.
-		$refDocCheckTypes = ['381', '503', '384'];
-		if (in_array($parsedHeader['documenttypecode'] ?? null, $refDocCheckTypes) && !empty($parsedHeader['invoiceRefDocs']) && is_array($parsedHeader['invoiceRefDocs'])) {
+		if (!empty($parsedHeader['invoiceRefDocs']) && is_array($parsedHeader['invoiceRefDocs'])) {
 			foreach ($parsedHeader['invoiceRefDocs'] as $invoiceRefDoc) {
 				$refDoc = $invoiceRefDoc['IssuerAssignedID'] ?? null;
 				$dateDoc = $invoiceRefDoc['FormattedIssueDateTime'] ?? null;
@@ -715,9 +713,17 @@ class FacturXProtocol extends CIIProtocol
 					return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($refDocInvoiceId, $refDoc, 'linked to document ' . ($parsedHeader['documentno'] ?? ''))];
 				}
 				if ($refDocInvoiceId == 0) {
-					// The invoice references a document this Dolibarr does not hold (deposit, credited or
-					// replaced invoice). Nothing has been created yet, so the flow is postponed rather than
-					// failed, and the message spells out what to create with a link to the creation screen.
+					// An unqualified reference (no ram:TypeCode in the XML) is a placeholder that the import
+					// does not consume — some vendors (e.g. DSV Road) always emit BG-3 with a dummy value
+					// such as "XXXX" when no preceding invoice applies. Skip it silently so it does not block
+					// the import and does not reach the post-creation loop.
+					if (empty($typeDoc)) {
+						dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Skipping unqualified InvoiceReferencedDocument ref="' . $refDoc . '" (no TypeCode) for ' . ($parsedHeader['documentno'] ?? ''), LOG_DEBUG);
+						continue;
+					}
+					// The invoice references a qualified document this Dolibarr does not hold yet (deposit,
+					// credited or replaced invoice). Nothing has been created yet, so the flow is postponed
+					// rather than failed, and the message spells out what to create.
 					$langs->load("bills");
 					$action = $langs->trans('CreateTheMissingSupplierInvoiceToImport', $refDoc);
 					$action .= ' <a class="butAction small smallpaddingimp nomarginleft" href="' . DOL_URL_ROOT . '/fourn/facture/card.php?action=create&socid=' . (int) $socId . '&ref_supplier=' . urlencode($refDoc) . '" target="_blank">';
@@ -851,6 +857,12 @@ class FacturXProtocol extends CIIProtocol
 						return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($linkedObjectId, $refDoc, 'linked to document ' . ($parsedHeader['documentno'] ?? ''))];
 					}
 					if ($linkedObjectId == 0) {
+						// Unqualified references (no TypeCode) were already skipped by the pre-check above and
+						// should not reach this point. As a safety net, skip them here too rather than failing.
+						if (empty($typeDoc)) {
+							dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Skipping unqualified InvoiceReferencedDocument ref="' . $refDoc . '" (no TypeCode) in post-creation loop for ' . ($parsedHeader['documentno'] ?? ''), LOG_DEBUG);
+							continue;
+						}
 						return ['res' => -1, 'message' => 'Document : ' . $refDoc . ' linked to document ' . $parsedHeader['documentno'] . ' not found in Dolibarr'];
 					}
 

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -702,7 +702,9 @@ class FacturXProtocol extends CIIProtocol
 		}
 
 		// Check if all referenced documents in the invoice exist in Dolibarr for the same supplier, if not return with error since we need them for correct linking in the invoice
-		if (!empty($parsedHeader['invoiceRefDocs']) && is_array($parsedHeader['invoiceRefDocs'])) {
+		// Only check for invoice types that require a linked document (credit notes 381/503, replacement 384) — for standard invoices (380) BG-3 is optional and may contain vendor placeholders.
+		$refDocCheckTypes = ['381', '503', '384'];
+		if (in_array($parsedHeader['documenttypecode'] ?? null, $refDocCheckTypes) && !empty($parsedHeader['invoiceRefDocs']) && is_array($parsedHeader['invoiceRefDocs'])) {
 			foreach ($parsedHeader['invoiceRefDocs'] as $invoiceRefDoc) {
 				$refDoc = $invoiceRefDoc['IssuerAssignedID'] ?? null;
 				$dateDoc = $invoiceRefDoc['FormattedIssueDateTime'] ?? null;


### PR DESCRIPTION
## FIX #880 [einvoicing] Skip InvoiceReferencedDocument check for standard invoices (TypeCode 380)
A standard invoice (TypeCode 380) containing an `InvoiceReferencedDocument` (BG-3/BT-25) with a placeholder value (e.g. `XXXX`, `0`) was indefinitely blocked on import: the module searched for that reference in Dolibarr, found nothing, and postponed the flow on every synchronization.

The existence check is only meaningful for invoice types that actually need a linked document in Dolibarr: credit notes (381/503) and replacement invoices (384). For standard invoices, BG-3 is optional per EN 16931 and some vendors populate it with a placeholder when it does not apply.

The fix restricts the check to TypeCodes 381, 503 and 384 in both CIIProtocol and FacturXProtocol, consistent with the downstream code that already limits `fk_facture_source` linking to those same types.
                                                                                                                                                                                                                                                
Fixes #880