### PR TITLE
FIX einvoicing: providers write an undeclared $error property

### DIFF
--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -38,6 +38,9 @@ abstract class AbstractPDPProvider
 	/** @var DoliDB Database handler */
 	public $db;
 
+	/** @var string Error message */
+	public $error;
+
 	/** @var array Error messages */
 	public $errors = [];
 


### PR DESCRIPTION
## Problem

`AbstractProtocol` declares `$error`, `AbstractPDPProvider` does not — it only has `$errors`.
So the twelve `$this->error = ...` of `SuperPDPProvider` and `EsalinkPDPProvider` create a
**dynamic property**, deprecated since PHP 8.2, on the very path that already carries a failure:

```
PHP Deprecated: Creation of dynamic property EsalinkPDPProvider::$error is deprecated
```

The setup page and `actions_einvoicing` then read `$provider->error` back, which warns about an
undefined property whenever nothing set it first.

## Fix

Declare `$error` next to `$errors`, exactly as `AbstractProtocol` does.

## Testing

Bench, eight instances, Dolibarr 18.0.10 / 19.0.4 / 20.0.4 / 21.0.4 / 22.0.5 / 23.0.4 / 24.0.1 /
25.0.0 (development), each under the PHP version its core targets (7.4 to 8.5):

- writing `->error` on a provider raises no deprecation any more, checked with an `E_DEPRECATED`
  handler; a control class without the property still trips that same handler on PHP >= 8.2;
- 256 PHPUnit runs green (32 files x 8 instances);
- 126 e-invoice generations (7 invoice types x CII and Factur-X x 9 instances) unchanged;
- 16 end-to-end cycles through the platform, both directions, unchanged;
- 48 pages served with no error and no warning.

`phan` without the baseline goes from 88 to 69 findings: 19 of them were this one property.
