### PR TITLE
FIX einvoicing: deleting a token ignores the entity holding the setup

### DIFF
--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -820,6 +820,19 @@ abstract class AbstractPDPProvider
 
 
 	/**
+	 * Delete the access token of this provider.
+	 * Called by the setup page only.
+	 *
+	 * @param	int		$forceentity		0=Use current entity, >0=Use specific entity
+	 * @return	bool						True if success, false otherwise
+	 */
+	public function deleteAccessToken($forceentity = 0)
+	{
+		return $this->deleteOAuthTokenDB($forceentity);
+	}
+
+
+	/**
 	 * Get the last synchronization date with the PDP provider.
 	 * Retrieves the timestamp of the most recent successful flow synchronization
 	 * for this provider. If no sync has occurred yet, returns 0.

--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -351,18 +351,6 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 	}
 
 	/**
-	 * Delete access token.
-	 * Called by the setup page only.
-	 *
-	 * @return 	bool                	       	True if success, false otherwise
-	 */
-	public function deleteAccessToken()
-	{
-		$result = $this->deleteOAuthTokenDB();
-		return $result;
-	}
-
-	/**
 	 * Perform a health check call for PDP provider.
 	 *
 	 * @return array Contains 'status' (bool) and 'message' (string)

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -756,18 +756,6 @@ class SuperPDPProvider extends AbstractPDPProvider
 	}
 
 	/**
-	 * Delete access token.
-	 * Called by the setup page only.
-	 *
-	 * @return 	bool                	       	True if success, false otherwise
-	 */
-	public function deleteAccessToken()
-	{
-		$result = $this->deleteOAuthTokenDB();
-		return $result;
-	}
-
-	/**
 	 * Perform a health check call for PDP provider.
 	 *
 	 * @return array Contains 'status' (bool) and 'message' (string)


### PR DESCRIPTION
## Problem

In multicompany, `EINVOICING_MULTICOMPANY_USE_MASTER_SETUP` names the entity the OAuth token is
stored in, and every token call of the module is given it:

```php
$this->tokenData = $this->fetchOAuthTokenDB(getDolGlobalInt("EINVOICING_MULTICOMPANY_USE_MASTER_SETUP"));
```

The setup page hands it to `deleteAccessToken()` too, but both providers declared that method
**without a parameter**, so PHP dropped the argument and `deleteOAuthTokenDB()` fell back to
`$conf->entity`. Deleting the connection from an entity that is not the master therefore removes
nothing, leaves the token the module really uses in place, and reports "Token deleted successfully".

A provider that ships without the method at all — the sample one — takes the page down instead.

## Fix

Move the method up to `AbstractPDPProvider`, next to the token storage it forwards to, with the
entity parameter. The two providers held the same three lines, so nothing else is needed.

## Testing

Bench, eight instances, Dolibarr 18.0.10 to 24.0.1 plus the 25.0.0 development branch, each under
the PHP version its core targets (7.4 to 8.5):

- a provider whose token storage records what it is asked to delete receives 7 then 0, where it
  received 0 then 0 before;
- both providers now inherit the method from the base class;
- 256 PHPUnit runs green, 126 generations, 16 end-to-end cycles, 48 pages, all unchanged.
