### PR TITLE
Qual: AbstractProtocol declares the method every protocol is called through

### DIFF
--- a/einvoicing/class/protocols/AbstractProtocol.class.php
+++ b/einvoicing/class/protocols/AbstractProtocol.class.php
@@ -79,6 +79,19 @@ abstract class AbstractProtocol
 	abstract public function generateXML($invoice, $outputlangs = null);
 
 	/**
+	 * Generate the e-invoice file of a given invoice, and return where it was written.
+	 *
+	 * The entry point of a protocol: the hooks and the sample generation of CommonProtocol call it on
+	 * whatever protocol the user selected, so every protocol has to answer to it.
+	 *
+	 * @param	int|Facture		$invoice_id		Invoice id, or invoice object, to process
+	 * @param	?Translate		$outputlangs	Output language
+	 * @param	string			$sourceFilePath	Source document the file is built from, when the format needs one
+	 * @return	-1|string						-1 if ko, path of the generated file if ok
+	 */
+	abstract public function generateInvoice($invoice_id, $outputlangs = null, $sourceFilePath = '');
+
+	/**
 	 * Create a supplier invoice in Dolibarr from Factur-X content.
 	 *
 	 * This function parses the provided Factur-X XML content


### PR DESCRIPTION
## Problem

`generateInvoice()` is the entry point of a protocol: the invoice hooks call it on whatever
protocol the user selected, and the `CommonProtocol` trait calls it on itself to build the sample
invoice. Neither has anything but `AbstractProtocol` to go by, and that class did not declare it.

Nothing therefore said a protocol has to answer to it, and a protocol shipped without it would only
fail the day a user generates a document.

## Fix

Declare it next to `generateXML()`, with the signature the two protocols already share.

## Testing

Bench, eight instances, Dolibarr 18.0.10 to 24.0.1 plus the 25.0.0 development branch:

- both protocols still implement it, checked by reflection on each core;
- 126 e-invoice generations (7 invoice types x CII and Factur-X x 9 instances): the 24 XML files
  regenerated from the same invoices are byte for byte what they were, apart from the generation
  stamp that carries the commit;
- 256 PHPUnit runs green, 16 end-to-end cycles, 48 pages, all unchanged.

`phan` without the baseline loses the two findings this raised.
