### PR TITLE
FIX einvoicing: the setup page fatals on a provider without initFormSetup

### DIFF
--- a/einvoicing/admin/setup.php
+++ b/einvoicing/admin/setup.php
@@ -170,6 +170,7 @@ if (GETPOST('code') && GETPOST('state') && $provider instanceof AbstractPDPProvi
 		setEventMessages($langs->trans('EINVOICING_SUPERPDP_OAUTH_STATE_MISMATCH'), null, 'errors');
 	} else {
 		unset($_SESSION['einvoicing_superpdp_oauth_state']);
+		// @phan-suppress-next-line PhanUndeclaredMethod  Guarded by the method_exists() above: only a provider using an authorization code flow declares it.
 		$token = $provider->exchangeAuthorizationCode(GETPOST('code'));
 		if ($token) {
 			setEventMessages("Token generated successfully", null, 'mesgs');

--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -415,6 +415,26 @@ abstract class AbstractPDPProvider
 
 
 	/**
+	 * Set the setup factory specific to the provider.
+	 *
+	 * Optional: a provider with nothing of its own to configure keeps this empty block, and the setup
+	 * page then simply shows nothing under the common one.
+	 *
+	 * @param FormSetup $formSetup 			The form setup object to initialize
+	 * @param string 	$prefix 			The prefix for configuration keys ('EINVOICING_MYPDP_')
+	 * @param string 	$prefixenv 			'prod' or 'test', depending on EINVOICING_LIVE
+	 * @param array 	$providersConfig 	The array containing providers configuration
+	 * @param array 	$TFieldProtocols 	The array of available protocols to set in the select field
+	 * @param array 	$TFieldProfiles 	The array of available profiles to set in the select field
+	 * @return void
+	 */
+	public function initFormSetup(&$formSetup, $prefix, $prefixenv, $providersConfig, $TFieldProtocols, $TFieldProfiles)
+	{
+		// Nothing to add to the setup page by default.
+	}
+
+
+	/**
 	 * Try to get a flow data from its id and doc type, using API
 	 *
 	 * @param string	$flowId 		The id of the flow


### PR DESCRIPTION
## Problem

`initFormSetup()` is documented as optional in `doc/ADD-A-PDP-PROVIDER.md`:

> Not abstract but required in practice: `initFormSetup(...)` builds the configuration block of your
> provider in the setup page. **Without it the page shows nothing to configure.**

That is not what happens. `admin/setup.php` calls it unguarded on the selected provider, so a
provider that ships without it — which the `classpath` entry lets an external module bring — takes
the whole setup page down with "call to undefined method", and the setup can no longer be reached
to select another provider.

## Fix

Give `AbstractPDPProvider` an empty default, so the documented behaviour is the real one.

The call to `exchangeAuthorizationCode()` a few lines above stays as it is: it is guarded by
`method_exists()`, only a provider using an authorization code flow declares it, and the guard is
what says so. The line only tells the analysis that.

## Testing

Bench, eight instances, Dolibarr 18.0.10 to 24.0.1 plus the 25.0.0 development branch:

- a provider implementing only the abstract methods now answers `initFormSetup()` instead of
  fatalling, and reflection confirms it inherits it from the base class;
- the setup page of the eight instances still shows the block of the configured provider, and
  serves with no error and no warning;
- 256 PHPUnit runs green, 126 generations, 16 end-to-end cycles, all unchanged.
