### PR TITLE
Qual: callApi() is documented as refusing the body it is mostly given

### DIFF
--- a/einvoicing/class/providers/AbstractPDPProvider.class.php
+++ b/einvoicing/class/providers/AbstractPDPProvider.class.php
@@ -591,7 +591,7 @@ abstract class AbstractPDPProvider
 	 *
 	 * @param string 						$resource 	    Resource relative URL ('Flows', 'healthcheck' or others)
 	 * @param 'POST'|'GET'|'HEAD'|'PUT'|'PUTALREADYFORMATED'|'POSTALREADYFORMATED'|'DELETE' $method         HTTP method (dolibarr's types)
-	 * @param string|false 	$options 	    Options for the request (JSON encoded)
+	 * @param string|false|array<string,mixed> 	$options 	    Body of the request: a JSON encoded string, or an array carrying a CURLFile for a multipart upload. False when there is none.
 	 * @param array<string, string>         $extraHeaders   Optional additional headers
 	 * @param string|null                   $callType       Functional type of the API call for logging purposes (e.g., 'sync_flows', 'send_invoice')
 	 *

--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -731,7 +731,7 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 	 *
 	 * @param string 						$resource 	    Resource relative URL ('token', 'healthcheck', 'Flows', or others)
 	 * @param 'POST'|'GET'|'HEAD'|'PUT'|'PUTALREADYFORMATED'|'POSTALREADYFORMATED'|'DELETE' $method         HTTP method (dolibarr's types)
-	 * @param string|false 	$params 	    Options for the request (JSON encoded)
+	 * @param string|false|array<string,mixed> 	$params 	    Body of the request: a JSON encoded string, or an array carrying a CURLFile for a multipart upload. False when there is none.
 	 * @param array<string, string>         $extraHeaders   Optional additional headers
 	 * @param string|null                   $callType       Functional type of the API call for logging purposes (e.g., 'sync_flows', 'send_invoice')
 	 *

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -1406,7 +1406,7 @@ class SuperPDPProvider extends AbstractPDPProvider
 	 *
 	 * @param string 						$resource 	    Resource relative URL ('token', 'healthcheck', 'Flows', or others)
 	 * @param 'POST'|'GET'|'HEAD'|'PUT'|'PUTALREADYFORMATED'|'POSTALREADYFORMATED'|'DELETE' $method         HTTP method (dolibarr's types)
-	 * @param string|false 	$params 	    Options for the request (JSON encoded)
+	 * @param string|false|array<string,mixed> 	$params 	    Body of the request: a JSON encoded string, or an array carrying a CURLFile for a multipart upload. False when there is none.
 	 * @param array<string, string>         $extraHeaders   Optional additional headers
 	 * @param string|null                   $callType       Functional type of the API call for logging purposes (e.g., 'sync_flows', 'send_invoice')
 	 *


### PR DESCRIPTION
## Problem

The three declarations of `callApi()` say the body is a JSON string or `false`:

```php
 * @param string|false 	$params 	    Options for the request (JSON encoded)
```

Every document upload of the two providers hands it an array instead:

```php
$params = ['flowInfo' => json_encode([...]), 'file' => new CURLFile($invoice_path, ...)];
$response = $this->callApi("flows", "POSTALREADYFORMATED", $params, $extraHeaders, 'send_invoice');
```

That array is what curl needs to build a multipart request, and it is passed straight to
`getURLContent()`. The code is right, the documentation is not.

## Fix

Say so, on the abstract declaration and on the two implementations. Documentation only, no code
change.

## Testing

Bench, eight instances, Dolibarr 18.0.10 to 24.0.1 plus the 25.0.0 development branch: 256 PHPUnit
runs green, 126 generations, 16 end-to-end cycles through the platform — which is what exercises
those multipart uploads — and 48 pages, all unchanged.

`phan` without the baseline loses the seven findings this raised.
