### PR TITLE
Qual: say what getProvider() builds, and drop the test that cannot fail

### DIFF
--- a/einvoicing/class/providers/PDPProviderManager.class.php
+++ b/einvoicing/class/providers/PDPProviderManager.class.php
@@ -279,10 +279,10 @@ class PDPProviderManager
 		}
 
 		$provider = new $classnametouse($db);
-
-		if ($provider) {
-			$provider->providerName = $name;
-		}
+		// The is_subclass_of() above is what makes this type true, and a constructor never returns
+		// anything falsy: the object is usable as an AbstractPDPProvider from here on.
+		'@phan-var-force AbstractPDPProvider $provider';
+		$provider->providerName = $name;
 
 		return $provider;
 	}


### PR DESCRIPTION
## Problem

`getProvider()` builds the provider from a class name held in a string, so nothing said what the
object is, and the return of a method documented as giving back an `AbstractPDPProvider` was read as
an unrelated union of scalars. The `is_subclass_of()` check a few lines above is what makes the type
true — it just was not said.

The `if ($provider)` that followed guarded against a constructor returning something falsy, which
PHP does not do.

## Fix

State the type the way the module already does elsewhere, and assign the provider name outright.

## Testing

Bench, eight instances, Dolibarr 18.0.10 to 24.0.1 plus the 25.0.0 development branch:

- `getProvider()` still returns the configured provider, carrying its name, and still returns null
  for an unknown or disabled one, on each core;
- the existing `PDPProviderManagerTest` covers the paths that must keep returning null: green on the
  eight instances;
- 256 PHPUnit runs green, 126 generations, 16 end-to-end cycles, 48 pages, all unchanged.
