### PR TITLE
Qual: thirdpartyidprof() reads the thirdparty it just tested

### DIFF
--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -211,7 +211,7 @@ function thirdpartyidprof($object)
 {
 	$object->fetch_thirdparty();
 	$thirdparty = $object->thirdparty;
-	return $thirdparty ? idprof($object->thirdparty) : '';
+	return $thirdparty ? idprof($thirdparty) : '';
 }
 
 /**


### PR DESCRIPTION
## Problem

```php
$thirdparty = $object->thirdparty;
return $thirdparty ? idprof($object->thirdparty) : '';
```

The guard is on the local variable, the call is on the property it was read from. Nothing ties the
two together, so the value handed to `idprof()`, which takes a `Societe`, is still the nullable
property.

## Fix

Use the variable that was tested.

## Testing

Bench, eight instances, Dolibarr 18.0.10 to 24.0.1 plus the 25.0.0 development branch: 256 PHPUnit
runs green — `EinvoicingLibTest` covers this library — 126 e-invoice generations, 16 end-to-end
cycles, 48 pages, all unchanged.
