### PR TITLE
Qual: read the recipient once in checkRecipientRoutableForSend()

### DIFF
--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -2818,7 +2818,11 @@ class EInvoicing
 		if (!is_object($object->thirdparty ?? null)) {
 			$object->fetch_thirdparty();
 		}
-		$siren = is_object($object->thirdparty ?? null) ? preg_replace('/[^0-9]/', '', (string) $object->thirdparty->idprof1) : '';
+		$thirdparty = $object->thirdparty;
+		if (!is_object($thirdparty)) {
+			return $res;	// no recipient loaded: nothing to look up
+		}
+		$siren = preg_replace('/[^0-9]/', '', (string) $thirdparty->idprof1);
 		if ($siren === '') {
 			return $res;	// no SIREN: the standard required-information checks handle this
 		}
@@ -2834,7 +2838,7 @@ class EInvoicing
 		// declare several reception addresses, only the one written into the document decides whether
 		// the transmission is accepted. Same call as getBuyerCommunicationURI() makes at generation, so
 		// what is checked and what is emitted can never drift apart.
-		$routingid = $this->getBuyerCommunicationURI($object->thirdparty, $object);
+		$routingid = $this->getBuyerCommunicationURI($thirdparty, $object);
 
 		$dir = $provider->checkRecipientDirectory($siren, $routingid);
 		$res['status'] = isset($dir['status']) ? $dir['status'] : 'error';


### PR DESCRIPTION
## Problem

`checkRecipientRoutableForSend()` tested `$object->thirdparty` for being an object twice and read it
three times, so nothing held the result of the test and the routing lookup was still handed a
possibly null property.

## Fix

Keep the recipient in a variable, return early when there is none, and read that variable
afterwards. Behaviour is unchanged: a thirdparty that could not be loaded gave an empty SIREN, which
already returned the same result two lines further down.

## Testing

Bench, eight instances, Dolibarr 18.0.10 to 24.0.1 plus the 25.0.0 development branch:

- the check on an invoice with nothing loaded returns the same array as before and raises no
  warning, notice or deprecation, on each core;
- 256 PHPUnit runs green, 126 e-invoice generations, 16 end-to-end cycles through the platform, 48
  pages, all unchanged.
