### PR TITLE
Qual: a call and a document have no thirdparty to clone

### DIFF
--- a/einvoicing/call_card.php
+++ b/einvoicing/call_card.php
@@ -393,7 +393,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 			// Clone
 			if ($permissiontoadd) {
-				print dolGetButtonAction('', $langs->trans('ToClone'), 'clone', $_SERVER['PHP_SELF'].'?id='.$object->id.(!empty($object->socid) ? '&socid='.$object->socid : '').'&action=clone&token='.newToken(), '', $permissiontoadd);
+				print dolGetButtonAction('', $langs->trans('ToClone'), 'clone', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=clone&token='.newToken(), '', $permissiontoadd);
 			}
 
 			// Delete (with preloaded confirm popup)

--- a/einvoicing/class/call.class.php
+++ b/einvoicing/class/call.class.php
@@ -357,7 +357,7 @@ class Call extends CommonObject
 
 		if (!$error) {
 			// copy external contacts if same company  @phan-suppress-next-line PhanUndeclaredProperty
-			if (!empty($object->socid) && ((property_exists($this, 'fk_soc') && ($this->fk_soc == $object->socid)) || (property_exists($this, 'socid') && ($this->socid == $object->socid)))) {	// @phpstan-ignore-line
+			if (!empty($object->socid) && ((property_exists($this, 'fk_soc') && ($this->fk_soc == $object->socid)) || (property_exists($this, 'socid') && ($this->socid == $object->socid)))) {	// @phpstan-ignore-line @phan-suppress-current-line PhanUndeclaredProperty
 				if ($this->copy_linked_contact($object, 'external') < 0) {
 					$error++;
 				}

--- a/einvoicing/class/document.class.php
+++ b/einvoicing/class/document.class.php
@@ -376,7 +376,7 @@ class Document extends CommonObject
 
 		if (!$error) {
 			// copy external contacts if same company
-			if (!empty($object->socid) && ((property_exists($this, 'fk_soc') && ($this->fk_soc == $object->socid)) || (property_exists($this, 'socid') && ($this->socid == $object->socid)))) {	// @phpstan-ignore-line
+			if (!empty($object->socid) && ((property_exists($this, 'fk_soc') && ($this->fk_soc == $object->socid)) || (property_exists($this, 'socid') && ($this->socid == $object->socid)))) {	// @phpstan-ignore-line @phan-suppress-current-line PhanUndeclaredProperty
 				if ($this->copy_linked_contact($object, 'external') < 0) {
 					$error++;
 				}

--- a/einvoicing/document_card.php
+++ b/einvoicing/document_card.php
@@ -589,7 +589,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 			// Clone
 			if ($permissiontoadd) {
-				print dolGetButtonAction('', $langs->trans('ToClone'), 'clone', $_SERVER['PHP_SELF'].'?id='.$object->id.(!empty($object->socid) ? '&socid='.$object->socid : '').'&action=clone&token='.newToken(), '', $permissiontoadd);
+				print dolGetButtonAction('', $langs->trans('ToClone'), 'clone', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=clone&token='.newToken(), '', $permissiontoadd);
 			}
 
 			/*


### PR DESCRIPTION
## Problem

Neither `Call` nor `Document` has a `socid`, and neither table has a column for one, yet the clone
button of both card pages built the parameter from it:

```php
$_SERVER['PHP_SELF'].'?id='.$object->id.(!empty($object->socid) ? '&socid='.$object->socid : '').'&action=clone...'
```

The condition is always false, so the parameter never appeared: it is dead weight left from the
module template.

## Fix

Drop it.

The two `createFromClone()` keep the copy of the external contacts as the core writes it, guarded by
`property_exists()` for the subclasses that do have the property — the line already says so to
phpstan, it now says it to phan as well.

## Testing

Bench, eight instances, Dolibarr 18.0.10 to 24.0.1 plus the 25.0.0 development branch:

- the call and document cards and lists serve with no error and no warning on the eight cores, and
  the clone button is rendered with a well formed link;
- 256 PHPUnit runs green, 126 e-invoice generations, 16 end-to-end cycles, all unchanged.
