### PR TITLE
FIX [einvoicing] A referenced document unknown here no longer aborts the synchronization

### DIFF
--- a/einvoicing/ChangeLog.md
+++ b/einvoicing/ChangeLog.md
@@ -4,6 +4,7 @@
 
 ## 1.2.0
 
+FIX: [einvoicing] A document referenced by a received line and unknown here no longer aborts the synchronization
 FIX: #853 [einvoicing] The dates of a received document keep the day they state
 FIX: [einvoicing] The CDAR date test errors on Dolibarr 19 since it landed on main
 FIX: [einvoicing] Enhance status handling

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -1242,61 +1242,12 @@ class CIIProtocol extends AbstractProtocol
 			// Add supplier ID to line for later use in product sync
 			$parsedLine['supplierId'] = $supplierInvoice->socid;
 
-			$is_deposit_line = 0;
-			$fk_remise = 0;
-			// --------------------------------------------------
-			// Loop on linked documents at line level
-			// --------------------------------------------------
-			if (!empty($parsedLine['additionalRefDocs']) && is_array($parsedLine['additionalRefDocs'])) {
-				foreach ($parsedLine['additionalRefDocs'] as $refDoc) {
-					$lineRefDocId = $refDoc['IssuerAssignedID'] ?? null;
-					$lineRefDocType = $refDoc['typeCode'] ?? null;
-					$lineRefDocDate = $refDoc['issueDate'] ?? null;
-
-					$linkedObjectId = SupplierInvoiceHelper::findIdByRef($lineRefDocId, (int) $parsedLine['supplierId']);
-					if ($linkedObjectId < 0) {
-						return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($linkedObjectId, $lineRefDocId, 'linked to line ' . $parsedLine['lineid'])];
-					}
-					if ($linkedObjectId == 0) {
-						return [
-							'res' => -1,
-							'message' => 'Document "' . dol_escape_htmltag((string) $lineRefDocId) . '" linked to line ' . dol_escape_htmltag((string) $parsedLine['lineid']) . ' was not found in Dolibarr. Please verify why this document is missing (deleted, not imported, or not provided by the supplier). To resolve this issue, you must manually create the invoice using the supplier invoice reference "' . dol_escape_htmltag((string) $lineRefDocId) . '".'
-						];
-						// TODO: Add a check before sending a final invoice after deposit to ensure that the deposit invoice has been properly sent to the PDP and successfully received.
-					}
-
-					// Load linked supplier invoice
-					$linkedObject = new FactureFournisseur($db);
-					$resFetchLinkedObject = $linkedObject->fetch($linkedObjectId);
-					if ($resFetchLinkedObject > 0) {
-						/*
-						 * Deposit handling: deposits may be referenced at document level or at line level.
-						 * At line level, we create the discount before creating the invoice line, so it can be linked later.
-						 * If the same deposit appears both at line and document level, line-level handling takes priority to
-						 * avoid duplicates. If it exists only at document level, the discount line is created after all lines.
-						 */
-						if ($linkedObject->type == FactureFournisseur::TYPE_DEPOSIT) {
-							$is_deposit_line = 1;
-
-							$depositDiscountRes = $this->getOrCreateDepositDiscount($linkedObject);
-							if ($depositDiscountRes['res'] < 0) {
-								return $depositDiscountRes;
-							}
-							$fk_remise = $depositDiscountRes['fkRemise'];
-						}
-
-						/*
-						 * --------------------------------------------------
-						 * Other linked document types
-						 * --------------------------------------------------
-						 * Additional logic may be added here for other
-						 * document types such as credit notes, etc.
-						 */
-					} else {
-						return ['res' => -1, 'message' => 'Document : ' . dol_escape_htmltag((string) $lineRefDocId) . ' linked to line ' . dol_escape_htmltag((string) $parsedLine['lineid']) . ' not found in Dolibarr'];
-					}
-				}
+			$linked = $this->resolveLineLinkedDocuments($parsedLine, $return_messages);
+			if ($linked['res'] < 0) {
+				return $linked;
 			}
+			$is_deposit_line = $linked['is_deposit'];
+			$fk_remise = $linked['fk_remise'];
 
 			$productId = 0;
 			$productMatchType = '';
@@ -1608,6 +1559,71 @@ class CIIProtocol extends AbstractProtocol
 		}
 
 		return $netPrice / $baseQuantity;
+	}
+
+	/**
+	 * Resolve the documents a received line references (BT-128, ram:AdditionalReferencedDocument).
+	 *
+	 * The reference is how a deposit gets attached to the line, not a condition for the invoice to be valid,
+	 * and the issuer is free to put anything else there - a contract number was seen in the wild. A reference
+	 * matching no supplier invoice is therefore reported and stepped over instead of failing the import, which
+	 * used to abort the whole synchronization and leave the invoice out. A deposit that really is missing still
+	 * shows up: the invoice then totals less than its document announces, which alignInvoiceTotalsWithDocument()
+	 * catches and flags.
+	 *
+	 * @param	array<string,mixed>		$parsedLine			One line as parseInvoiceLines() returns it
+	 * @param	array<int,string>		$return_messages	Messages of the import, completed here
+	 * @return	array{res:int,message?:string,is_deposit:int,fk_remise:int}	Deposit found on the line, if any
+	 */
+	protected function resolveLineLinkedDocuments(array $parsedLine, array &$return_messages): array
+	{
+		$resolved = ['res' => 1, 'is_deposit' => 0, 'fk_remise' => 0];
+
+		if (empty($parsedLine['additionalRefDocs']) || !is_array($parsedLine['additionalRefDocs'])) {
+			return $resolved;
+		}
+
+		$lineId = (string) ($parsedLine['lineid'] ?? '?');
+
+		foreach ($parsedLine['additionalRefDocs'] as $refDoc) {
+			$lineRefDocId = trim((string) ($refDoc['IssuerAssignedID'] ?? ''));
+			if ($lineRefDocId === '') {
+				continue;
+			}
+
+			$linkedObjectId = SupplierInvoiceHelper::findIdByRef($lineRefDocId, (int) $parsedLine['supplierId']);
+			if ($linkedObjectId < 0) {
+				return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($linkedObjectId, $lineRefDocId, 'linked to line ' . $lineId), 'is_deposit' => 0, 'fk_remise' => 0];
+			}
+			if ($linkedObjectId == 0) {
+				$return_messages[] = 'Document "' . dol_escape_htmltag($lineRefDocId) . '" referenced by line ' . dol_escape_htmltag($lineId) . ' matches no supplier invoice in Dolibarr and was skipped: it is only a reference, so the invoice is imported without it.';
+				continue;
+			}
+
+			$linkedObject = new FactureFournisseur($this->db);
+			if ($linkedObject->fetch($linkedObjectId) <= 0) {
+				return ['res' => -1, 'message' => 'Document : ' . dol_escape_htmltag($lineRefDocId) . ' linked to line ' . dol_escape_htmltag($lineId) . ' not found in Dolibarr', 'is_deposit' => 0, 'fk_remise' => 0];
+			}
+
+			/*
+			 * Deposit handling: deposits may be referenced at document level or at line level.
+			 * At line level, we create the discount before creating the invoice line, so it can be linked later.
+			 * If the same deposit appears both at line and document level, line-level handling takes priority to
+			 * avoid duplicates. If it exists only at document level, the discount line is created after all lines.
+			 */
+			if ($linkedObject->type == FactureFournisseur::TYPE_DEPOSIT) {
+				// TODO: Add a check before sending a final invoice after deposit to ensure that the deposit
+				// invoice has been properly sent to the PDP and successfully received.
+				$depositDiscountRes = $this->getOrCreateDepositDiscount($linkedObject);
+				if ($depositDiscountRes['res'] < 0) {
+					return $depositDiscountRes + ['is_deposit' => 0, 'fk_remise' => 0];
+				}
+				$resolved['is_deposit'] = 1;
+				$resolved['fk_remise'] = $depositDiscountRes['fkRemise'];
+			}
+		}
+
+		return $resolved;
 	}
 
 	/**

--- a/einvoicing/test/phpunit/LineLinkedDocumentTest.php
+++ b/einvoicing/test/phpunit/LineLinkedDocumentTest.php
@@ -1,0 +1,140 @@
+<?php
+/* Copyright (C) 2026 ATM Consulting
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/LineLinkedDocumentTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for the documents a received line references
+ *                  (EN 16931 BT-128, ram:AdditionalReferencedDocument).
+ *                  The reference is a convenience used to attach a deposit, not a condition for
+ *                  the invoice to be valid, and the flow puts whatever it likes there - a contract
+ *                  number among others. One that matches nothing in Dolibarr must be reported and
+ *                  stepped over, not turn a valid invoice into a failure that stops the whole
+ *                  synchronization.
+ *      \remarks    To run this script as CLI: phpunit filename.php
+ */
+
+global $conf, $user, $langs, $db;
+
+$dolibarrHtdocs = getenv('DOLIBARR_HTDOCS');
+if (!$dolibarrHtdocs) {
+	$dolibarrHtdocs = dirname(__FILE__) . '/../../htdocs';
+}
+if (!file_exists($dolibarrHtdocs . '/master.inc.php')) {
+	throw new \RuntimeException('Could not locate master.inc.php under "' . $dolibarrHtdocs . '/". Set the environment variable (export DOLIBARR_HTDOCS=...) to the htdocs directory of the Dolibarr instance to test against.');
+}
+
+require_once $dolibarrHtdocs . '/master.inc.php';
+dol_include_once('einvoicing/class/protocols/CIIProtocol.class.php');
+require_once __DIR__ . '/CommonClassTestCompat.inc.php';
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class LineLinkedDocumentTest extends CommonClassTest
+{
+	/**
+	 * Call the protected CIIProtocol::resolveLineLinkedDocuments() through reflection. Only reads
+	 * are involved on a reference that matches nothing, so nothing is written by these tests.
+	 *
+	 * @param	array	$parsedLine			Parsed line, as parseInvoiceLines() returns it
+	 * @param	array	$return_messages	Messages of the import, completed by the call
+	 * @return	array{res:int,message?:string,is_deposit:int,fk_remise:int}
+	 */
+	private function resolveLinks(array $parsedLine, array &$return_messages): array
+	{
+		$method = new ReflectionMethod(CIIProtocol::class, 'resolveLineLinkedDocuments');
+		$method->setAccessible(true);
+
+		return $method->invokeArgs(new CIIProtocol($GLOBALS['db']), [$parsedLine, &$return_messages]);
+	}
+
+	/**
+	 * A line whose referenced document is unknown here keeps its invoice importable.
+	 *
+	 * @return void
+	 */
+	public function testAnUnknownLinkedDocumentDoesNotAbortTheImport()
+	{
+		$messages = [];
+		$resolved = $this->resolveLinks([
+			'lineid' => 1,
+			'supplierId' => 1,
+			'additionalRefDocs' => [['IssuerAssignedID' => 'CT-2026-0042', 'typeCode' => '916']],
+		], $messages);
+
+		$this->assertGreaterThanOrEqual(0, $resolved['res'], 'An unknown reference must not fail the line');
+		$this->assertSame(0, $resolved['is_deposit'], 'Nothing was resolved, so no deposit was found');
+		$this->assertSame(0, $resolved['fk_remise'], 'and no discount goes with it');
+	}
+
+	/**
+	 * Stepping over a reference has to leave a trace, or the missing link is invisible.
+	 *
+	 * @return void
+	 */
+	public function testTheUnknownReferenceIsReported()
+	{
+		$messages = [];
+		$this->resolveLinks([
+			'lineid' => 7,
+			'supplierId' => 1,
+			'additionalRefDocs' => [['IssuerAssignedID' => 'CT-2026-0042', 'typeCode' => '916']],
+		], $messages);
+
+		$this->assertNotEmpty($messages, 'The skipped reference must be reported');
+		$this->assertStringContainsString('CT-2026-0042', implode("\n", $messages), 'and it must name the reference');
+	}
+
+	/**
+	 * A line referencing nothing must go through untouched, and stay silent.
+	 *
+	 * @return void
+	 */
+	public function testALineWithoutAnyReferenceResolvesToNothing()
+	{
+		$messages = [];
+		$resolved = $this->resolveLinks(['lineid' => 1, 'supplierId' => 1, 'additionalRefDocs' => []], $messages);
+
+		$this->assertSame(1, $resolved['res']);
+		$this->assertSame(0, $resolved['is_deposit']);
+		$this->assertSame([], $messages, 'Nothing to report when nothing is referenced');
+	}
+
+	/**
+	 * An empty reference identifier is not a lookup, so it is stepped over without a word.
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyReferenceIsIgnoredSilently()
+	{
+		$messages = [];
+		$resolved = $this->resolveLinks([
+			'lineid' => 1,
+			'supplierId' => 1,
+			'additionalRefDocs' => [['IssuerAssignedID' => '', 'typeCode' => '130']],
+		], $messages);
+
+		$this->assertSame(1, $resolved['res']);
+		$this->assertSame([], $messages, 'An empty reference has nothing to report');
+	}
+}


### PR DESCRIPTION
## Problem

A received line may reference another document through BT-128 (`ram:AdditionalReferencedDocument`). The import required **every** one of them to match a supplier invoice already present in Dolibarr, whatever the referenced document actually was.

Seen in production: a vendor carried a **contract number** there. `findIdByRef()` returned 0, the import returned an error, and the whole synchronization run stopped on that flow. The invoices created earlier in the same run were reported as synchronized while they were not kept, which is confusing for the operator and leaves the queue stuck on a document that will never resolve.

The type of the referenced document is read right above, into `$lineRefDocType`, and never used — a single occurrence in the module.

## What changes

That reference is how a deposit gets attached to a line. It is not a condition for the invoice to be valid, and an issuer is free to carry an order or a contract number there. A reference matching no supplier invoice is now **reported in the messages of the import and stepped over**, and the invoice is created.

A deposit that really is missing is not silent either: the invoice then totals less than its document announces, which `alignInvoiceTotalsWithDocument()` already catches and flags on the invoice.

Filtering on the type code was the other option. It was not taken: it only covers the type codes we happen to know about, while an unresolved reference should not fail a valid invoice whatever its type.

Unchanged on purpose:

- a lookup that fails technically (`findIdByRef()` < 0) still fails the import;
- a document found but not readable still fails the import;
- deposit handling is untouched.

## Structure

The loop moves out of `createSupplierInvoiceLinesFromSource()` into `resolveLineLinkedDocuments()`, next to the other `resolveLine*` helpers, so the decision can be tested on its own. An existing `// TODO` about deposits was kept, next to the deposit branch where it applies.

## Tests

`test/phpunit/LineLinkedDocumentTest.php`, 4 cases: an unknown reference does not fail the line, it is reported and names the reference, a line referencing nothing stays silent, an empty identifier is skipped without a message.

Written before the fix and watched failing. Full module suite run before and after: same failures either way, minus the four this adds — no regression. `php -l` clean, phpcs clean against `dev/setup/codesniffer/ruleset.xml`.