### PR TITLE
FIX einvoicing: sample invoice test reads a flow id out of a body that has none

### DIFF
--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -667,6 +667,12 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 
 
 		if ($response['status_code'] == 200 || $response['status_code'] == 202) {
+			if (!is_array($response['response']) || empty($response['response']['flowId'])) {
+				// Accepted, but the answer is not the JSON body the platform announces. Everything below
+				// is built on that flow id, so stop here rather than call 'flows/' with nothing.
+				$this->errors[] = "Sample invoice sent but the platform returned no flow id.";
+				return 0;
+			}
 			$flowId = $response['response']['flowId'];
 			$outputLog[] = "Sample invoice sent successfully.";
 

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -1342,6 +1342,12 @@ class SuperPDPProvider extends AbstractPDPProvider
 		$response = $this->callApi("flows", "POSTALREADYFORMATED", $params, $extraHeaders, 'send_sample_invoice');
 
 		if ($response['status_code'] == 200 || $response['status_code'] == 202) {
+			if (!is_array($response['response']) || empty($response['response']['flowId'])) {
+				// Accepted, but the answer is not the JSON body the platform announces. Everything below
+				// is built on that flow id, so stop here rather than call 'flows/' with nothing.
+				$this->errors[] = "Sample invoice sent but the platform returned no flow id.";
+				return 0;
+			}
 			$flowId = $response['response']['flowId'];
 			$outputLog[] = "Sample invoice sent successfully.";
 


### PR DESCRIPTION
## Problem

Both providers take the flow id out of the answer as soon as the platform
replies 200 or 202:

```php
if ($response['status_code'] == 200 || $response['status_code'] == 202) {
    $flowId = $response['response']['flowId'];
```

That body is only an array when the answer parsed as JSON. On an HTML error page
from a gateway, an empty body, or a JSON scalar, it is a string or null — and
**on PHP 8 that read is a TypeError**, not a warning. The line sits outside the
`try` block above it, which catches `Exception` and not `Error`, so the setup
page dies on an uncaught fatal instead of reporting that the platform answered
something unexpected.

Measured on the bench with a provider whose API returns
`200 / "<html>Gateway timeout</html>"`, on the seven PHP versions the supported
cores run:

| PHP | reading that body the old way |
| --- | --- |
| 7.4 | `Warning: Illegal string offset 'flowId'` |
| 8.0 to 8.5 | **TypeError** |

## Fix

Check the body carries the flow id, and stop with an explicit message if not.

## Testing

Bench, eight instances, Dolibarr 18.0.10 / 19.0.4 / 20.0.4 / 21.0.4 / 22.0.5 /
23.0.4 / 24.0.1 / 25.0.0 (development), each under the PHP version its core
targets:

- with the same fake answer, `sendSampleInvoice()` now returns a failure and an
  explanation, and raises no offset warning and no TypeError, on all eight;
- the control in the same run confirms the old read still trips on every one of
  them, so the absence of a warning is the fix and not a blind spot;
- 256 PHPUnit runs, 126 e-invoice generations, 16 end-to-end cycles, 48 pages.
