### PR TITLE
Qual: the Factur-X reader calls a deprecated zugferd method for nothing

### DIFF
--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -565,7 +565,10 @@ class FacturXProtocol extends CIIProtocol
 					$document->getDocumentPositionProductDetails($prodname, $proddesc, $prodsellerid, $prodbuyerid, $prodglobalidtype, $prodglobalid);
 					$document->getDocumentPositionGrossPrice($grosspriceamount, $grosspricebasisquantity, $grosspricebasisquantityunitcode);
 					$document->getDocumentPositionNetPrice($netpriceamount, $netpricebasisquantity, $netpricebasisquantityunitcode);
-					$document->getDocumentPositionLineSummation($lineTotalAmount, $totalAllowanceChargeAmount);
+					// The two-argument form is deprecated in zugferd and never read the document for the
+					// second one: it set it to 0.0 and called the simple form for the first. Nothing here
+					// reads that second value, so call the form that is kept.
+					$document->getDocumentPositionLineSummationSimple($lineTotalAmount);
 					$document->getDocumentPositionQuantity($billedquantity, $billedquantityunitcode, $chargeFreeQuantity, $chargeFreeQuantityunitcode, $packageQuantity, $packageQuantityunitcode);
 
 					// Get AdditionalReferencedDocument at line level
@@ -596,7 +599,7 @@ class FacturXProtocol extends CIIProtocol
 						'netpricebasisquantity' => $netpricebasisquantity ?? null,
 						'netpricebasisquantityunitcode' => $netpricebasisquantityunitcode ?? null,
 						'lineTotalAmount' => $lineTotalAmount ?? null,
-						'totalAllowanceChargeAmount' => $totalAllowanceChargeAmount ?? null,
+						'totalAllowanceChargeAmount' => 0.0,
 						'billedquantity' => $billedquantity ?? null,
 						'billedquantityunitcode' => $billedquantityunitcode ?? null,
 						'chargeFreeQuantity' => $chargeFreeQuantity ?? null,


### PR DESCRIPTION
## Problem

`FacturXProtocol` reads the line totals with a method zugferd deprecated:

```php
$document->getDocumentPositionLineSummation($lineTotalAmount, $totalAllowanceChargeAmount);
```

Its second argument never came from the document. The library sets it to `0.0`
and delegates the first one:

```php
public function getDocumentPositionLineSummation(?float &$lineTotalAmount, ?float &$totalAllowanceChargeAmount)
{
    $totalAllowanceChargeAmount = 0.0;
    $this->getDocumentPositionLineSummationSimple($lineTotalAmount);
    return $this;
}
```

And nothing in the module reads that second value: `totalAllowanceChargeAmount`
is written into the parsed line and never consumed, on either import path.

## Fix

Call `getDocumentPositionLineSummationSimple()`, which the library keeps, and
hand the parsed line the same `0.0` so the shape of the array does not change.
`getDocumentPositionLineSummationExt()` would read BT-X-98 for real, which is a
different subject: no caller wants it yet.

## Testing

Bench, eight instances, Dolibarr 18.0.10 / 19.0.4 / 20.0.4 / 21.0.4 / 22.0.5 /
23.0.4 / 24.0.1 / 25.0.0 (development), each under the PHP version its core
targets (7.4 to 8.5):

- the same Factur-X document imported before and after gives the **same supplier
  invoice, line by line**, on four cores: a plain one, and one carrying two
  discounted lines and three VAT rates (895.83 / 159.17 / 1055.00, discounts
  15.0007 and 7.5041 preserved);
- 16 end-to-end cycles through the platform, which is what really exercises the
  reception path, plus 256 PHPUnit runs, 126 generations and 48 pages.
