### PR TITLE
Qual: say why the module still calls the deprecated core API

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -3353,6 +3353,9 @@ class CIIProtocol extends AbstractProtocol
 	 * @param 	string[]   	$deliveryDateList            	array to store the corresponding delivery dates as string in format YYYY-MM-DD
 	 * @param 	Facture 	$object 						invoice object
 	 * @return	void
+	 *
+	 * @phan-suppress PhanDeprecatedProperty  Expedition->origin has no replacement on the versions the
+	 *               module supports: origin_type appears on CommonObject in Dolibarr 24, the floor is 18.
 	 */
 	protected function determineDeliveryDatesAndCustomerOrderNumbers(&$customerOrderReferenceList, &$deliveryDateList, $object)
 	{
@@ -3749,6 +3752,10 @@ class CIIProtocol extends AbstractProtocol
 	 * @param int    $fk_soc                  	supplier ID
 	 * @param string $description             	invoice number or any reference
 	 * @return array{-1:string}|array<int,int>	[ originalIndex => fk_remise_except_id ] or '-1' on error
+	 *
+	 * @phan-suppress PhanDeprecatedProperty  DiscountAbsolute::create() reads amount_* and fk_soc, and
+	 *               nothing else, from Dolibarr 18 to the development branch: the core deprecated those
+	 *               properties but its own writer still needs them. See the comment on fk_soc below.
 	 */
 	protected function createHeaderDiscounts(array $headerAllowancesCharges, int $fk_soc, string $description): array
 	{
@@ -3810,6 +3817,10 @@ class CIIProtocol extends AbstractProtocol
 	 *
 	 * @param FactureFournisseur $linkedObject The deposit (TYPE_DEPOSIT) supplier invoice referenced by the final invoice
 	 * @return array{res:int<-1,1>, message?:string, fkRemise?:int} 'res' 1 on success with 'fkRemise', -1 on error with 'message'
+	 *
+	 * @phan-suppress PhanDeprecatedProperty  Same as createHeaderDiscounts(): DiscountAbsolute::create()
+	 *               reads amount_*, multicurrency_amount_* and fk_soc only, from Dolibarr 18 to the
+	 *               development branch.
 	 */
 	protected function getOrCreateDepositDiscount(FactureFournisseur $linkedObject)
 	{

--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -98,6 +98,7 @@ $promise_code = $object->array_options['options_d4d_promise_code'] ?? '';
 if ($promise_code == '') {
 	// Dolibarr "Réf. client" holds the customer's purchase order number -> BT-13 (see issue #302).
 	// The property is ref_client on recent versions and ref_customer on some older ones; accept both.
+	// @phan-suppress-next-line PhanDeprecatedProperty  ref_client is the deprecated twin of ref_customer, kept because an invoice built without a fetch may carry only that one.
 	$promise_code = $object->ref_client ?? ($object->ref_customer ?? '');
 }
 if ($promise_code == '' && !empty($customerOrderReferenceList)) {
@@ -114,6 +115,7 @@ if ($object->fk_account > 0) {
 
 $account_proprio = '';
 if ($account->id > 0) {
+	// @phan-suppress-next-line PhanDeprecatedProperty  owner_name only exists from Dolibarr 24 on, the module supports 18: proprio is the one that answers on the whole range.
 	$account_proprio = trim(!empty($account->proprio) ? $account->proprio : $account->owner_name);	// $account->proprio is for old version compatibility
 }
 if ($account_proprio == '') {
@@ -317,6 +319,7 @@ if (! ($object->project instanceof Project)) {
 	if (method_exists($object, 'fetchProject')) {
 		$object->fetchProject();
 	} else {
+		// @phan-suppress-next-line PhanDeprecatedFunction  fetchProject() only exists from Dolibarr 24 on, and the branch above is what uses it when it does.
 		$object->fetch_project();
 	}
 }
@@ -1169,8 +1172,12 @@ if ($shipAddress === null && !empty($object->linkedObjectsIds['shipping']) && is
 	require_once DOL_DOCUMENT_ROOT . '/contact/class/contact.class.php';
 	foreach ($object->linkedObjectsIds['shipping'] as $expeditionId) {
 		$tmpexpedition = new Expedition($db);
+		// The core deprecated fk_delivery_address without ever naming a replacement, and it is still the
+		// only place a shipment carries its own delivery address.
+		// @phan-suppress-next-line PhanDeprecatedProperty
 		if ($tmpexpedition->fetch($expeditionId) > 0 && !empty($tmpexpedition->fk_delivery_address)) {
 			$shipContact = new Contact($db);
+			// @phan-suppress-next-line PhanDeprecatedProperty
 			if ($shipContact->fetch((int) $tmpexpedition->fk_delivery_address) > 0) {
 				$shipAddress = einvoicingShipToFromContact($shipContact, $object->thirdparty, $outputlangs, $db);
 				break;


### PR DESCRIPTION
## Problem

Twenty-one deprecated reads sat in the phan baseline, which suppresses them for
the **whole file** — so any new one in `CIIProtocol.class.php` or
`buildinvoicelines.inc.php` was hidden too. None of them can be dropped, and the
reasons are not the same:

- `DiscountAbsolute::create()` reads `amount_ht`, `amount_tva`, `amount_ttc`,
  `multicurrency_amount_*` and `fk_soc`, and nothing else, from Dolibarr 18 to
  the development branch. The core deprecated those properties in favour of
  `total_*` and `socid`, but its own writer still only fills the insert from the
  deprecated ones. Both places in the module are write paths feeding `create()`;
- `Account->owner_name`, `CommonObject->origin_type` and `fetchProject()` only
  appear in Dolibarr 24. The module supports 18;
- `Expedition->fk_delivery_address` was deprecated without a replacement ever
  being named, and is still the only place a shipment carries its own delivery
  address.

## Fix

Carry each reason where the code is: three `@phan-suppress` on the docblock of
the method that holds a whole group, four on the lines that are alone. No code
change.

The baseline can then stop covering those two files, and a deprecated call added
to them later becomes visible again.

## Testing

Bench, eight instances, Dolibarr 18.0.10 / 19.0.4 / 20.0.4 / 21.0.4 / 22.0.5 /
23.0.4 / 24.0.1 / 25.0.0 (development), each under the PHP version its core
targets (7.4 to 8.5):

- annotations only, so what matters is that nothing moved: 24 XML files
  regenerated byte for byte identical, 256 PHPUnit runs, 126 generations, 16
  end-to-end cycles, 48 pages;
- `phan` without the baseline drops the twenty-one findings, and the two files
  leave `file_suppressions` entirely.
