### PR TITLE
Qual: drop the numbering machinery neither object can use

### DIFF
--- a/einvoicing/class/call.class.php
+++ b/einvoicing/class/call.class.php
@@ -559,12 +559,9 @@ class Call extends CommonObject
 
 		$this->db->begin();
 
-		// Define new ref
-		if (preg_match('/^[\(]?PROV/i', $this->ref) || empty($this->ref)) { // empty should not happened, but when it occurs, the test save life
-			$num = $this->getNextNumRef();
-		} else {
-			$num = (string) $this->ref;
-		}
+		// The object has no ref column and the module ships no numbering model: fetchCommon() fills
+		// $this->ref with the row id, and the reference the user sees is call_id.
+		$num = (string) $this->ref;
 		$this->newref = $num;
 
 		if (!empty($num)) {
@@ -1073,62 +1070,6 @@ class Call extends CommonObject
 		} else {
 			$this->lines = $result;
 			return $this->lines;
-		}
-	}
-
-	/**
-	 *  Returns the reference to the following non used object depending on the active numbering module.
-	 *
-	 *  @return	string      		Object free reference
-	 */
-	public function getNextNumRef()
-	{
-		global $langs, $conf;
-		$langs->load("einvoicing@einvoicing");
-
-		if (!getDolGlobalString('EINVOICING_MYOBJECT_ADDON')) {
-			$conf->global->EINVOICING_MYOBJECT_ADDON = 'mod_call_standard';
-		}
-
-		if (getDolGlobalString('EINVOICING_MYOBJECT_ADDON')) {
-			$mybool = false;
-
-			$file = getDolGlobalString('EINVOICING_MYOBJECT_ADDON').".php";
-			$classname = getDolGlobalString('EINVOICING_MYOBJECT_ADDON');
-
-			// Include file with class
-			$dirmodels = array_merge(array('/'), (array) $conf->modules_parts['models']);
-			foreach ($dirmodels as $reldir) {
-				$dir = dol_buildpath($reldir."core/modules/einvoicing/");
-
-				// Load file with numbering class (if found)
-				$mybool = $mybool || @include_once $dir.$file;
-			}
-
-			if (!$mybool) {
-				dol_print_error(null, "Failed to include file ".$file);
-				return '';
-			}
-
-			if (class_exists($classname)) {
-				$obj = new $classname();
-				'@phan-var-force ModeleNumRefCall $obj';
-				$numref = $obj->getNextValue($this);
-
-				if ($numref != '' && $numref != '-1') {
-					return $numref;
-				} else {
-					$this->error = $obj->error;
-					//dol_print_error($this->db,get_class($this)."::getNextNumRef ".$obj->error);
-					return "";
-				}
-			} else {
-				print $langs->trans("Error")." ".$langs->trans("ClassNotFound").' '.$classname;
-				return "";
-			}
-		} else {
-			print $langs->trans("ErrorNumberingModuleNotSetup", $this->element);
-			return "";
 		}
 	}
 

--- a/einvoicing/class/document.class.php
+++ b/einvoicing/class/document.class.php
@@ -941,12 +941,9 @@ class Document extends CommonObject
 
 		$this->db->begin();
 
-		// Define new ref
-		if (preg_match('/^[\(]?PROV/i', $this->ref) || empty($this->ref)) { // empty should not happened, but when it occurs, the test save life
-			$num = $this->getNextNumRef();
-		} else {
-			$num = (string) $this->ref;
-		}
+		// The object has no ref column and the module ships no numbering model: fetchCommon() fills
+		// $this->ref with the row id, and the reference the user sees is tracking_idref.
+		$num = (string) $this->ref;
 		$this->newref = $num;
 
 		if (!empty($num)) {
@@ -1448,62 +1445,6 @@ class Document extends CommonObject
 		} else {
 			$this->lines = $result;
 			return $this->lines;
-		}
-	}
-
-	/**
-	 *  Returns the reference to the following non used object depending on the active numbering module.
-	 *
-	 *  @return	string      		Object free reference
-	 */
-	public function getNextNumRef()
-	{
-		global $langs, $conf;
-		$langs->load("einvoicing@einvoicing");
-
-		if (!getDolGlobalString('EINVOICING_MYOBJECT_ADDON')) {
-			$conf->global->EINVOICING_MYOBJECT_ADDON = 'mod_document_standard';
-		}
-
-		if (getDolGlobalString('EINVOICING_MYOBJECT_ADDON')) {
-			$mybool = false;
-
-			$file = getDolGlobalString('EINVOICING_MYOBJECT_ADDON').".php";
-			$classname = getDolGlobalString('EINVOICING_MYOBJECT_ADDON');
-
-			// Include file with class
-			$dirmodels = array_merge(array('/'), (array) $conf->modules_parts['models']);
-			foreach ($dirmodels as $reldir) {
-				$dir = dol_buildpath($reldir."core/modules/einvoicing/");
-
-				// Load file with numbering class (if found)
-				$mybool = $mybool || @include_once $dir.$file;
-			}
-
-			if (!$mybool) {
-				dol_print_error(null, "Failed to include file ".$file);
-				return '';
-			}
-
-			if (class_exists($classname)) {
-				$obj = new $classname();
-				'@phan-var-force ModeleNumRefDocument $obj';
-				$numref = $obj->getNextValue($this);
-
-				if ($numref != '' && $numref != '-1') {
-					return $numref;
-				} else {
-					$this->error = $obj->error;
-					//dol_print_error($this->db,get_class($this)."::getNextNumRef ".$obj->error);
-					return "";
-				}
-			} else {
-				print $langs->trans("Error")." ".$langs->trans("ClassNotFound").' '.$classname;
-				return "";
-			}
-		} else {
-			print $langs->trans("ErrorNumberingModuleNotSetup", $this->element);
-			return "";
 		}
 	}
 

--- a/einvoicing/langs/en_US/einvoicing.lang
+++ b/einvoicing/langs/en_US/einvoicing.lang
@@ -233,7 +233,6 @@ DeleteCall=Delete call
 Failed=Failed
 Skipped=Skipped
 ClassNotFound=Class not found
-ErrorNumberingModuleNotSetup=Numbering module not set up for %s
 ErrorLoadingInvoice=Failed to load the invoice
 PASettings=Access Point Settings (PA, PDP...)
 EInvoicingInfo=As part of the French electronic invoicing law, any invoicing software must allow the sending and receiving of invoices. This is achieved through communication with an approved private partner called a PA (formerly PDP). This module enables bi-directional synchronization between your Dolibarr and a PA. The module is free, but the PA you choose will most likely charge subscription fees (The contract is drawn up directly with the PA %s).


### PR DESCRIPTION
## Problem

`Call::getNextNumRef()` and `Document::getNextNumRef()` ask a numbering model for
a reference at validation. The module ships none — `einvoicing/core/modules/`
holds only the module descriptor — so the method ends on:

```
dol_print_error(null, "Failed to include file mod_document_standard.php")
```

reproduced in CLI on Dolibarr 18.0.10, 23.0.4 and 25.0.0.

It is never reached, and cannot be. Neither table has a `ref` column, so
`fetchCommon()` fills `$this->ref` with the row id (`ref=['12031']`) and
`validate()` always takes the other branch. Checked in HTTP as well:
`action=confirm_validate` on a document goes through with no error and no
warning, and the row moves from status 0 to 1. The reference the user sees is
`call_id` and `tracking_idref`.

The `@phan-var-force ModeleNumRefCall $obj` those methods carried also named a
class that exists nowhere, in this repository or in the core.

## Fix

Remove the two methods, the dead branch in `validate()` that called them, and
the language key that went with them. `validate()` keeps doing what it already
did in practice.

## Testing

Bench, eight instances, Dolibarr 18.0.10 / 19.0.4 / 20.0.4 / 21.0.4 / 22.0.5 /
23.0.4 / 24.0.1 / 25.0.0 (development), each under the PHP version its core
targets (7.4 to 8.5):

- validating a document over HTTP still goes through on four cores: `http=200`,
  no error, no warning, status 0 to 1, and no numbering message anywhere in the
  answer;
- the call and document cards and lists serve clean on the eight cores;
- 256 PHPUnit runs, 126 generations, 24 XML files unchanged, 16 end-to-end
  cycles.
