### PR TITLE
Qual: say why the module writes what the analysis reads as suspicious

### DIFF
--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -759,6 +759,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 
 
 		if ($isSupplierInvoiceContext) {
+			'@phan-var-force FactureFournisseur $object';
 			$permissiontoedit = $user->hasRight('fournisseur', 'facture', 'creer');
 			// Who may validate a supplier invoice is decided by the core, in fourn/facture/card.php
 			// ($usercanvalidate): the "create" right is enough, unless advanced permissions are on, where

--- a/einvoicing/class/call.class.php
+++ b/einvoicing/class/call.class.php
@@ -305,9 +305,13 @@ class Call extends CommonObject
 		//foreach($this->lines as $line)
 		//	$line->fetch_optionals();
 
-		// Reset some properties
+		// Reset some properties. unset() rather than an empty value is what the core does in its own
+		// createFromClone(): createCommon() below builds the INSERT from the properties that are set.
+		// @phan-suppress-next-line PhanTypeObjectUnsetDeclaredProperty
 		unset($object->id);
+		// @phan-suppress-next-line PhanTypeObjectUnsetDeclaredProperty
 		unset($object->fk_user_creat);
+		// @phan-suppress-next-line PhanTypeObjectUnsetDeclaredProperty
 		unset($object->import_key);
 
 		// Clear fields

--- a/einvoicing/class/document.class.php
+++ b/einvoicing/class/document.class.php
@@ -324,9 +324,13 @@ class Document extends CommonObject
 		//foreach($this->lines as $line)
 		//	$line->fetch_optionals();
 
-		// Reset some properties
+		// Reset some properties. unset() rather than an empty value is what the core does in its own
+		// createFromClone(): createCommon() below builds the INSERT from the properties that are set.
+		// @phan-suppress-next-line PhanTypeObjectUnsetDeclaredProperty
 		unset($object->id);
+		// @phan-suppress-next-line PhanTypeObjectUnsetDeclaredProperty
 		unset($object->fk_user_creat);
+		// @phan-suppress-next-line PhanTypeObjectUnsetDeclaredProperty
 		unset($object->import_key);
 
 		// Clear fields

--- a/einvoicing/compat/commonhookactions.class.php
+++ b/einvoicing/compat/commonhookactions.class.php
@@ -32,6 +32,9 @@
 if (!class_exists('CommonHookActions', false)) {
 	/**
 	 *	Parent class of all other hook actions classes
+	 *
+	 * @phan-suppress PhanRedefineClass  That is the point of the guard above: the core brings the class
+	 *               from Dolibarr 19 on, this copy only answers for the versions before it.
 	 */
 	abstract class CommonHookActions
 	{


### PR DESCRIPTION
## Problem

Three deliberate patterns were suppressed file-wide by the phan baseline, which
hides anything else of the same kind in those files:

- `createFromClone()` unsets `id`, `fk_user_creat` and `import_key` rather than
  emptying them, because `createCommon()` builds its insert from the properties
  that are set. That is what the core does in its own `createFromClone()`;
- `compat/commonhookactions.class.php` declares a class the core brings from
  Dolibarr 19 on. The `class_exists()` guard is the whole point of the file —
  see the comment above it and issue #630;
- `doActions()` narrows `$object` in the customer invoice branch
  (`'@phan-var-force Facture $object'`) but not in the supplier one, so reading
  `->socid` there looked like a `CommonObject` property.

## Fix

Carry each reason where the code is, and narrow the supplier branch the way the
customer one already is. No behaviour change.

## Testing

Bench, eight instances, Dolibarr 18.0.10 / 19.0.4 / 20.0.4 / 21.0.4 / 22.0.5 /
23.0.4 / 24.0.1 / 25.0.0 (development), each under the PHP version its core
targets (7.4 to 8.5):

- cloning still works from the call card, and the pages serve clean;
- 256 PHPUnit runs, 126 generations, 24 XML files byte for byte unchanged, 16
  end-to-end cycles, 48 pages.
