### PR TITLE
Qual: hand a string to the three functions that ask for one

### DIFF
--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -1775,7 +1775,7 @@ class EInvoicing
 			$reason = $this->getIgnoreReason($object) ?? $langs->trans('EInvoiceIgnoreReasonUserChoice');
 			$resprints .= '<tr class="treinvoicing_collapseseparator">';
 			$resprints .= '<td>' . $form->textwithpicto($langs->trans('EInvoiceIgnoreReasonLabel'), $langs->transnoentitiesnoconv('EInvoiceIgnoreReasonLabelHelp')) . '</td>';
-			$resprints .= '<td>' . dol_escape_htmltag($reason) . '</td>';
+			$resprints .= '<td>' . dol_escape_htmltag((string) $reason) . '</td>';
 			$resprints .= '</tr>';
 			return $resprints;
 		}

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -1921,7 +1921,7 @@ class CIIProtocol extends AbstractProtocol
 					continue;
 				}
 
-				$line[$key] = $this->getXPathValue($xpath, $expr, $node);
+				$line[$key] = $this->getXPathValue($xpath, (string) $expr, $node);
 			}
 
 			// Type normalisation

--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -511,7 +511,7 @@ trait CommonProtocol
 		// Note: the carrier of the specimen is the one the setup of the instance produces, untouched.
 		// A Factur-X specimen is only a conformant PDF/A-3 when PDF_USE_A is set to PDF/A-3b in
 		// "Home - Setup - PDF", which is exactly what the specimen is there to show.
-		$tmpinvoice->generateDocument($tmpinvoice->model_pdf, $outputlangs);
+		$tmpinvoice->generateDocument((string) $tmpinvoice->model_pdf, $outputlangs);
 
 		// For invoice with ->specimen=1, the file is SPECIMEN.pdf so we rename it into ref
 		$dir = $conf->invoice->multidir_output[$conf->entity];


### PR DESCRIPTION
## Problem

Three core functions declare a `string` and are handed a value the core types as
nullable:

- `dol_escape_htmltag($reason)` — `getIgnoreReason()` returns `?string`;
- `Facture::generateDocument($tmpinvoice->model_pdf)` — `model_pdf` is null on an
  invoice whose model was never chosen;
- `CIIProtocol::getXPathValue($xpath, $expr)` — the line template also holds the
  placeholders the loop just handled by key a few lines above.

## Fix

Cast at the call. Nothing changes at runtime, PHP was already doing the same
conversion, but the three calls stop claiming they can pass null.

## Testing

Bench, eight instances, Dolibarr 18.0.10 / 19.0.4 / 20.0.4 / 21.0.4 / 22.0.5 /
23.0.4 / 24.0.1 / 25.0.0 (development), each under the PHP version its core
targets (7.4 to 8.5):

- 24 XML files regenerated byte for byte identical, which covers `getXPathValue`
  and `buildXML`;
- 256 PHPUnit runs, 126 generations, 16 end-to-end cycles, 48 pages.
