### PR TITLE
FIX einvoicing: duplicate agenda event on every supplier invoice status check

### DIFF
--- a/einvoicing/ajax/checksupplierinvoicestatus.php
+++ b/einvoicing/ajax/checksupplierinvoicestatus.php
@@ -129,7 +129,7 @@ if ($objectID) {
 
 	// Get flowId from linked document log
 	$flowId = '';
-	$sql = "SELECT rowid, flow_id, lc_status, lc_reason_code FROM ".MAIN_DB_PREFIX."einvoicing_lifecycle_msg";
+	$sql = "SELECT rowid, flow_id, lc_status, lc_reason_code, lc_validation_status FROM ".MAIN_DB_PREFIX."einvoicing_lifecycle_msg";
 	$sql .= " WHERE element_type = '".$db->escape($invoice->element)."'";
 	$sql .= " AND element_id = ".(int) $invoice->id;
 	$sql .= " ORDER BY rowid DESC LIMIT 1";
@@ -138,6 +138,7 @@ if ($objectID) {
 	$flowId = 0;
 	$lcStatus = 0;
 	$lcReasonCode = '';
+	$lcValidationStatus = '';
 
 	$resql = $db->query($sql);
 	if ($resql) {
@@ -147,6 +148,8 @@ if ($objectID) {
 			$flowId = $obj->flow_id;
 			$lcStatus = $obj->lc_status;
 			$lcReasonCode = $obj->lc_reason_code;
+			// Validation status known so far, read before updateStatusMessageValidation() overwrites it below.
+			$lcValidationStatus = $obj->lc_validation_status;
 		}
 	} else {
 		print json_encode(['status' => 'error', 'message' => 'Error retrieving flowId for supplier invoice ref '. $invoice->ref]);
@@ -189,8 +192,8 @@ if ($objectID) {
 		$currentLCStatusLabel = $einvoicing->getStatusLabel($obj->lc_status);
 		$currentLCReasonLabel = $langs->trans($einvoicing->getReasonsByStatus($obj->lc_status)[$obj->lc_reason_code]['label'] ?? $obj->lc_reason_code);
 
-		// Log an event in the invoice timeline if status not pending
-		if ($statusvalidationlabel != 'Pending') {
+		// Log an event in the invoice timeline if status not pending and it has changed
+		if ($statusvalidationlabel != 'Pending' && $statusvalidationlabel !== $lcValidationStatus) {
 			$eventLabel = "EINVOICING - ".$langs->trans("CheckStatus");
 			$eventMessage = "EINVOICING - ".$langs->trans("CheckStatus")." (From ajax checksupplierinvoicestatus) - [Dolibarr: " . $currentLCStatusLabel . ', '.$langs->trans("ResultOnAP").': '.$statusvalidationlabel . (!empty($statusvalidationinfo) ? " - " . $statusvalidationinfo : "") . (!empty($lcReasonCode) ? " - Reason: " . $currentLCReasonLabel : "")."]";
 


### PR DESCRIPTION
Fixes #905

### Problem

Checking the status of a supplier invoice logged a new agenda event in its timeline on **every** call, even when the status returned by the PDP had not changed. Five checks on the same invoice produced five identical events.

The previous validation status is persisted in `llx_einvoicing_lifecycle_msg.lc_validation_status` by `EInvoicing::updateStatusMessageValidation()`, but `einvoicing/ajax/checksupplierinvoicestatus.php` never read it back — the `SELECT` omitted the column, leaving `!= 'Pending'` as the only guard before `addEvent()`.

The customer-invoice counterpart `einvoicing/ajax/checkinvoicestatus.php` already implements this guard ("We add an event only if somethiing has changed"), so the supplier side was simply missing the equivalent check.

### Change

- add `lc_validation_status` to the `SELECT`;
- keep it in `$lcValidationStatus`, initialised to `''` alongside the other defaults;
- compare it to the label returned by the platform before logging the event.

The row is read at line 132, before `updateStatusMessageValidation()` overwrites it at line 187, so the value compared is the previous one.

### Behaviour

| Situation | Before | After |
|---|---|---|
| Status unchanged, re-checked | one event per check | no event |
| Status changed | one event | one event |
| `Pending` | no event | no event |
| First check after upgrade (column empty on the existing row) | one event | one event, then silent |

No schema change, no API change, 4 lines touched in a single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
