### PR TITLE
Qual: refresh the phan baseline after the einvoicing clean-up

### DIFF
--- a/dev/tools/phan/baseline.txt
+++ b/dev/tools/phan/baseline.txt
@@ -10,40 +10,31 @@
 return [
     // # Issue statistics:
     // PhanDeprecatedProperty : 20+ occurrences
-    // PhanUndeclaredProperty : 20+ occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 8 occurrences
     // PhanUndeclaredClassMethod : 7 occurrences
     // PhanTypeObjectUnsetDeclaredProperty : 6 occurrences
-    // PhanUndeclaredMethod : 5 occurrences
-    // PhanTypeMismatchArgumentNullable : 5 occurrences
+    // PhanTypeMismatchArgumentNullable : 3 occurrences
     // PhanDeprecatedFunction : 2 occurrences
     // PhanTypeArraySuspiciousNullable : 2 occurrences
     // PhanUndeclaredClassProperty : 2 occurrences
     // PhanParamTooMany : 1 occurrence
-    // PhanPluginDuplicateExpressionAssignmentOperation : 1 occurrence
     // PhanRedefineClass : 1 occurrence
-    // PhanTypeMismatchReturnNullable : 1 occurrence
+    // PhanUndeclaredProperty : 1 occurrence
     // PhanUndeclaredTypeParameter : 1 occurrence
     // PhanUndeclaredTypeReturnType : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'einvoicing/admin/setup.php' => ['PhanUndeclaredMethod', 'PhanUndeclaredProperty'],
-        'einvoicing/call_card.php' => ['PhanUndeclaredProperty'],
-        'einvoicing/class/actions_einvoicing.class.php' => ['PhanUndeclaredMethod', 'PhanUndeclaredProperty'],
+        'einvoicing/class/actions_einvoicing.class.php' => ['PhanUndeclaredProperty'],
         'einvoicing/class/call.class.php' => ['PhanTypeObjectUnsetDeclaredProperty', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty'],
-        'einvoicing/class/document.class.php' => ['PhanTypeObjectUnsetDeclaredProperty', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredProperty'],
+        'einvoicing/class/document.class.php' => ['PhanTypeObjectUnsetDeclaredProperty', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty'],
         'einvoicing/class/einvoicing.class.php' => ['PhanTypeMismatchArgumentNullable'],
-        'einvoicing/class/protocols/CIIProtocol.class.php' => ['PhanDeprecatedProperty', 'PhanParamTooMany', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeMismatchArgumentNullable'],
-        'einvoicing/class/protocols/CommonProtocol.class.php' => ['PhanTypeMismatchArgumentNullable', 'PhanUndeclaredMethod'],
+        'einvoicing/class/protocols/CIIProtocol.class.php' => ['PhanDeprecatedProperty', 'PhanParamTooMany', 'PhanTypeMismatchArgumentNullable'],
+        'einvoicing/class/protocols/CommonProtocol.class.php' => ['PhanTypeMismatchArgumentNullable'],
         'einvoicing/class/protocols/FacturXProtocol.class.php' => ['PhanDeprecatedFunction'],
-        'einvoicing/class/providers/EsalinkPDPProvider.class.php' => ['PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredProperty'],
-        'einvoicing/class/providers/PDPProviderManager.class.php' => ['PhanTypeMismatchReturnNullable'],
-        'einvoicing/class/providers/SuperPDPProvider.class.php' => ['PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredProperty'],
+        'einvoicing/class/providers/EsalinkPDPProvider.class.php' => ['PhanTypeArraySuspiciousNullable'],
+        'einvoicing/class/providers/SuperPDPProvider.class.php' => ['PhanTypeArraySuspiciousNullable'],
         'einvoicing/compat/commonhookactions.class.php' => ['PhanRedefineClass'],
-        'einvoicing/document_card.php' => ['PhanUndeclaredProperty'],
         'einvoicing/lib/buildinvoicelines.inc.php' => ['PhanDeprecatedFunction', 'PhanDeprecatedProperty'],
-        'einvoicing/lib/einvoicing.lib.php' => ['PhanTypeMismatchArgumentNullable'],
         'helloasso/admin/setup.php' => ['PhanUndeclaredClassMethod'],
         'helloasso/lib/helloasso.lib.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
     ],


### PR DESCRIPTION
Regenerated with `--save-baseline` on `main`. `phan` with it: **0**.

88 → 48 findings, so 14 entries no longer suppress anything and five files leave
`file_suppressions`.

## What removed what

| PR | file | issue | was |
| --- | --- | --- | --- |
| #885 | `einvoicing/admin/setup.php` | PhanUndeclaredProperty | 6 |
| #885 | `einvoicing/class/actions_einvoicing.class.php` | PhanUndeclaredProperty | 2 → 1 |
| #885 | `einvoicing/class/providers/EsalinkPDPProvider.class.php` | PhanUndeclaredProperty | 6 |
| #885 | `einvoicing/class/providers/SuperPDPProvider.class.php` | PhanUndeclaredProperty | 6 |
| #886, #888 | `einvoicing/admin/setup.php` | PhanUndeclaredMethod | 3 |
| #887 | `einvoicing/class/actions_einvoicing.class.php` | PhanUndeclaredMethod | 1 |
| #887 | `einvoicing/class/protocols/CommonProtocol.class.php` | PhanUndeclaredMethod | 1 |
| #890 | `einvoicing/class/providers/EsalinkPDPProvider.class.php` | PhanTypeMismatchArgumentProbablyReal | 3 |
| #890 | `einvoicing/class/providers/SuperPDPProvider.class.php` | PhanTypeMismatchArgumentProbablyReal | 4 |
| #891 | `einvoicing/class/providers/PDPProviderManager.class.php` | PhanTypeMismatchReturnNullable | 1 |
| #892 | `einvoicing/lib/einvoicing.lib.php` | PhanTypeMismatchArgumentNullable | 1 |
| #893, #894 | `einvoicing/class/einvoicing.class.php` | PhanTypeMismatchArgumentNullable | 4 → 1 |
| #895 | `einvoicing/call_card.php` | PhanUndeclaredProperty | 1 |
| #895 | `einvoicing/class/document.class.php` | PhanUndeclaredProperty | 2 |
| #895 | `einvoicing/document_card.php` | PhanUndeclaredProperty | 1 |
| already stale in #882 | `einvoicing/class/protocols/CIIProtocol.class.php` | PhanPluginDuplicateExpressionAssignmentOperation | 0 |

The two rows reading `2 → 1` and `4 → 1` keep their entry, with less behind it.

A second refresh will be due once #889, #898, #899, #900, #901, #902 and #903
land: they take the remaining 41 einvoicing findings to 0, leaving only the two
`helloasso` files, whose findings need the generated stub to carry
`OAuth\Common\Storage\TokenInterface`.
