### PR TITLE
QUAL [einvoicing] The French rules the CI validates against are the current release

### DIFF
--- a/.github/workflows/module_einvoicing_phpunit.yml
+++ b/.github/workflows/module_einvoicing_phpunit.yml
@@ -40,7 +40,7 @@ concurrency:
 
 env:
   # The FNFE package that carries the three validation stages, pinned. https://github.com/fnfempe/France_RFE
-  FNFE_TAG: v1.4.0.03
+  FNFE_TAG: v1.4.0.04
   # Saxon-HE runs the compiled Schematron XSLT of that package.
   SAXON_VERSION: 10.9
 


### PR DESCRIPTION
The workflow pins `FNFE_TAG: v1.4.0.03`, published 04/08/2026. **`v1.4.0.04` came out on 04/09/2026** and is what the platform validates against now.

## What that release carries

Read from its notes, and it lands on what this repository generates:

* **Factur-X EXTENDED — `BR-FXEXT-CO-10`, `-12`, `-13`**: `sum()` rewritten with `xs:decimal()`, so numeric representation stops moving a rounding. That is the family of rules the totals of a generated document are measured on;
* **EXTENDED-CTC-FR CII** — `CII-SR-069` and `CII-SR-072` renamed `CII-FREXT-SR-*`, cardinality of BT-160 and BT-161 back to `0..1`;
* **CDAR — `BR-FR-CDV-13`**: a WARNING when `MDT-129` carries a `schemeID="0002"` identifier. This module writes that CDAR;
* **EN 16931 alignment** — rules `CII-SR-467` to `469` and `471` to `494` added;
* plus fixes on Flux2-CII (`BR-FR-MV-10`, `BR-FR-CO-07`) and Flux2-UBL.

## Measured before pushing

Both packages fetched and run locally through `einvoicing/test/conformance/validate-cii.py`, three stages, Saxon-HE 10.9, on the seven documents this workflow validates — the five generated specimens and the two committed samples:

```
                                    v1.4.0.03      v1.4.0.04
cii_creditnote.xml                  VALID          VALID
cii_deposit.xml                     VALID          VALID
cii_replacement.xml                 VALID          VALID
cii_situation.xml                   VALID          VALID
cii_standard.xml                    VALID          VALID
SPECIMEN-doli_ok.cii.xml            VALID          VALID
SPECIMEN-doli_ko_transfer.cii.xml   VALID          VALID
```

And the control the workflow relies on — a VAT breakdown rate damaged to 19.00 — is refused on `BR-CO-17` by both packages, exit 1.

So this bump changes no verdict today. What changes is what the next generated document is measured against.

## One thing worth knowing while reading this

All seven documents declare `urn:cen.eu:en16931:2017`. The **EXTENDED-CTC-FR** rules this release touches are therefore the ones no document of the corpus exercises, even though the module can emit that profile (`urn.cpro.gouv.fr:1p0:extended-ctc-fr`). Adding a specimen in that profile would close the gap — not done here, since it is a corpus change rather than a version bump.
