### PR TITLE
FIX [einvoicing] The BASIC profile declares the specification identifier it is registered under

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -2217,7 +2217,10 @@ class CIIProtocol extends AbstractProtocol
 		$profileGuidelines = [
 			'MINIMUM'  => 'urn:factur-x.eu:1p0:minimum', 	// Factur-X profile
 			'BASICWL'  => 'urn:factur-x.eu:1p0:basicwl', 	// Factur-X profile
-			'BASIC'    => 'urn:factur-x.eu:1p0:basic', 		// Factur-X profile (flowProfile = BASIC)
+			// BASIC is a CIUS of EN 16931, where MINIMUM and BASIC WL are below it: its identifier carries
+			// the compliance prefix, and the bare form is registered nowhere. A document declaring the bare
+			// one is refused by a platform that reads BT-24 against the code list.
+			'BASIC'    => 'urn:cen.eu:en16931:2017#compliant#urn:factur-x.eu:1p0:basic', 		// Factur-X profile (flowProfile = BASIC)
 			'EN16931'=> 'urn:cen.eu:en16931:2017', 		// CII Profile (PDP flowProfile => CIUS)
 			'EXTENDED' => 'urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended', // Factur-X profile (flowProfile = Extended-CTC-FR)
 			'EXTENDEDFR' => 'urn:cen.eu:en16931:2017#conformant#urn.cpro.gouv.fr:1p0:extended-ctc-fr', 			// Factur-X and CII profile (Only France) (flowProfile = Extended-CTC-FR)


### PR DESCRIPTION
## The defect

A document generated on the **BASIC** profile declares

```xml
<ram:GuidelineSpecifiedDocumentContextParameter>
  <ram:ID>urn:factur-x.eu:1p0:basic</ram:ID>
</ram:GuidelineSpecifiedDocumentContextParameter>
```

That form is registered nowhere. BASIC is a **CIUS of EN 16931**, so its specification identifier carries the compliance prefix:

```
urn:cen.eu:en16931:2017#compliant#urn:factur-x.eu:1p0:basic
```

MINIMUM and BASIC WL are the ones that keep a bare `urn:factur-x.eu:1p0:*` identifier, because they sit *below* the norm instead of being a subset of it. The module already writes those two correctly, and EN16931, EXTENDED and EXTENDED-CTC-FR correctly too — BASIC is the only entry of `$profileGuidelines` that is out.

## How it surfaced

By generating one specimen per profile the module can emit — the six values of `SUPPORTED_XML_PROFILES` — and running the FNFE rules on each:

```
profile_minimum.xml      SKIP   the FNFE package ships no validator for "urn:factur-x.eu:1p0:minimum"
profile_basicwl.xml      VALID  urn:factur-x.eu:1p0:basicwl
profile_basic.xml        SKIP   unknown specification identifier "urn:factur-x.eu:1p0:basic"
profile_en16931.xml      VALID  urn:cen.eu:en16931:2017
profile_extended.xml     VALID  urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended
profile_extendedfr.xml   VALID  urn:cen.eu:en16931:2017#conformant#urn.cpro.gouv.fr:1p0:extended-ctc-fr
```

MINIMUM is skipped because the FNFE package ships no chain for it — a limit of the rules, not of the document. **BASIC is skipped for another reason entirely**: the identifier it declares is not one the validator, or the code list, knows. A platform reading BT-24 refuses such a document rather than merely failing to validate it.

## Scope

One entry of the profile map. Nothing else changes: the identifier is written by the same code path for every profile, and the five others already carry their registered form.

`phpcs` clean. The generated specimens of the test suite are EN16931, so no committed fixture moves.

## Worth knowing

The corpus the CI validates is EN16931 only — the five specimens and the two committed samples all declare `urn:cen.eu:en16931:2017`. That is why a profile emitted with a wrong identifier could sit there unnoticed. Extending the corpus to one specimen per profile is the follow-up, and it is what found this.
