### PR TITLE
Qual: pin the FNFE conformance rules to V1.4.0.04

### DIFF
--- a/.github/workflows/module_einvoicing_phpunit.yml
+++ b/.github/workflows/module_einvoicing_phpunit.yml
@@ -40,7 +40,7 @@ concurrency:
 
 env:
   # The FNFE package that carries the three validation stages, pinned. https://github.com/fnfempe/France_RFE
-  FNFE_TAG: v1.4.0.03
+  FNFE_TAG: v1.4.0.04
   # Saxon-HE runs the compiled Schematron XSLT of that package.
   SAXON_VERSION: 10.9
 

--- a/einvoicing/test/conformance/README.md
+++ b/einvoicing/test/conformance/README.md
@@ -15,7 +15,7 @@ Neither is vendored here: the CI fetches a pinned release, and so do you.
 ## Running it locally
 
 ```sh
-curl -sSL -o france-rfe.tar.gz https://github.com/fnfempe/France_RFE/archive/refs/tags/v1.4.0.03.tar.gz
+curl -sSL -o france-rfe.tar.gz https://github.com/fnfempe/France_RFE/archive/refs/tags/v1.4.0.04.tar.gz
 mkdir -p /tmp/france-rfe && tar xz -C /tmp/france-rfe --strip-components=1 -f france-rfe.tar.gz
 curl -sSL -o /tmp/saxon.jar https://repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/10.9/Saxon-HE-10.9.jar
 


### PR DESCRIPTION
## What

Pin the FNFE `France_RFE` package the conformance job downloads to **V1.4.0.04** (2026-09-04), instead of V1.4.0.03 (2026-08-04). The example command in `einvoicing/test/conformance/README.md` follows.

V1.4.0.04 moves the "fatal" mode of the CTC-FR rules to **1st October 2026**, so it is the set an access point runs from then on.

## What the new package changes

- `number()` → `xs:decimal()` in the sums and comparisons of BR-FXEXT-CO-10/12/13, BR-FR-CO-09, BR-FR-MV-05/09/10 and BR-CO-25 (exact decimal arithmetic instead of doubles);
- the DETAIL/GROUP predicate of BR-FXEXT-\*-01 / BR-FREXT-\*-01 tested the wrong axis and was always true; it now filters as intended;
- CDAR: a new warning (BR-FR-CDV-13/MDT-129-2) asks the issuer identifier to carry a SIREN (`schemeID="0002"`);
- EXTENDED-CTC-FR aligns on EN 16931 rules CII-SR-467 to 494, and renames CII-SR-069/072 to CII-FREXT-SR-\*.

## Measured before bumping

Both tags were run over the same documents, and the verdicts compared file by file:

| corpus | documents | verdict changes |
|---|---|---|
| the five specimens + the two committed samples | 7 | 0 |
| two benches (60 223 and 15 335 XML, reduced to one representative per distinct document shape) | 2 178 | 0 |
| production instances | 38 | 0 |
| Factur-X returned by the platform | 415 | 0 |

The only differences are the number of rules fired (±1), on the two profiles whose XSLT changed. The negative control still refuses the seven damaged documents on BR-CO-17 under the new rules.

Every unit price, quantity and amount the module writes was checked against the decimal caps of the annex of XP Z12-012 (BT-146/BT-148: 6 decimals, BT-129: 4, amounts: 2): 3 549 lines, none over the cap.
