### PR TITLE
FIX [einvoicing] The e-invoice tracking tab answers on Dolibarr 18 and 19

### DIFF
--- a/einvoicing/compat/functions.lib.php
+++ b/einvoicing/compat/functions.lib.php
@@ -162,3 +162,75 @@ if (!function_exists('getMultidirTemp')) {
 		return getMultidirOutputCompat($object, $module, $forobject, 'temp');
 	}
 }
+
+if (!function_exists('recordNotFound')) {
+	/**
+	 * Print an error page for a record that does not exist, then end the page.
+	 * Provided as a polyfill for Dolibarr < 20, where this function does not exist yet.
+	 *
+	 * @param	string		$message			Message to show, an "ErrorRecordNotFound" translation when empty
+	 * @param	int<0,1>	$printheader		1 to print the page header
+	 * @param	int<0,1>	$printfooter		1 to print the page footer
+	 * @param	int<0,1>	$showonlymessage	1 to show the message alone, without the hooks
+	 * @param	mixed		$params				Optional parameters passed to the hook
+	 * @return	void							The function ends the execution of the page
+	 *  @since	Dolibarr V20
+	 */
+	function recordNotFound($message = '', $printheader = 1, $printfooter = 1, $showonlymessage = 0, $params = null)
+	{
+		global $conf, $db, $langs, $hookmanager;
+		global $action, $object;
+
+		if (!is_object($langs)) {
+			// The core ships install/inc.php, which defines DOL_DOCUMENT_ROOT as '..'; PHPStan
+			// resolves the constant against it and looks for the file next to the module.
+			// @phpstan-ignore includeOnce.fileNotFound
+			include_once DOL_DOCUMENT_ROOT.'/core/class/translate.class.php';
+			$langs = new Translate('', $conf);
+			$langs->setDefaultLang();
+		}
+
+		$langs->load("errors");
+
+		if ($printheader) {
+			if (function_exists("llxHeader")) {
+				// Kept as the core writes it. llxHeader() is redeclared by every page template,
+				// and the declaration the analysers pick up on the older cores takes no argument.
+				llxHeader(''); // @phpstan-ignore arguments.count
+			} elseif (function_exists("llxHeaderVierge")) {
+				// Same reason, for the public pages: they give llxHeaderVierge() a title.
+				// @phan-suppress-next-line PhanParamTooMany
+				llxHeaderVierge(''); // @phpstan-ignore arguments.count
+			}
+		}
+
+		print '<div class="error">';
+		if (empty($message)) {
+			print $langs->trans("ErrorRecordNotFound");
+		} else {
+			print $langs->trans($message);
+		}
+		print '</div>';
+		print '<br>';
+
+		if (empty($showonlymessage)) {
+			if (empty($hookmanager)) {
+				// Same as the translate.class.php include above.
+				// @phpstan-ignore includeOnce.fileNotFound
+				include_once DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php';
+				$hookmanager = new HookManager($db);
+				// Initialize technical object to manage hooks of page. Note that conf->hooks_modules contains array of hook context
+				$hookmanager->initHooks(array('main'));
+			}
+
+			$parameters = array('message' => $message, 'params' => $params);
+			$hookmanager->executeHooks('getErrorRecordNotFound', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
+			print $hookmanager->resPrint;
+		}
+
+		if ($printfooter && function_exists("llxFooter")) {
+			llxFooter();
+		}
+		exit(0);
+	}
+}

--- a/einvoicing/einvoice_tracking.php
+++ b/einvoicing/einvoice_tracking.php
@@ -68,6 +68,8 @@ if (!$res) {
  */
 require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/invoice.lib.php';
+// recordNotFound() below only exists from Dolibarr 20 on, and this page is served down to 18.
+include_once __DIR__.'/compat/functions.lib.php';
 dol_include_once('/einvoicing/class/einvoicing.class.php');
 dol_include_once('/einvoicing/lib/einvoicing_lifecycle.lib.php');
 


### PR DESCRIPTION
## The bug

Opening the **E-invoice events** tab of an invoice that does not exist ends on the `else` branch of
`einvoice_tracking.php`, which calls `recordNotFound()`. The core only ships that function **from
Dolibarr 20 on** (`htdocs/core/lib/functions.lib.php`), and the module supports Dolibarr 18 and up.

On Dolibarr 18.0.10, `einvoice_tracking.php?id=999999`:

```
PHP Fatal error:  Uncaught Error: Call to undefined function recordNotFound()
in .../einvoicing/einvoice_tracking.php:225
```

The answer is a truncated 22 kB page: it stops in the middle of `<div class="fiche">`, with no
message, no footer and no closing tags — a blank area under the menus for the user.

## The fix

`recordNotFound()` joins the other core helpers the module already carries in `compat/`, copied from
Dolibarr 20 — the release that introduced it — and guarded by `function_exists()`, so from Dolibarr
20 on the core version keeps winning and nothing changes. `einvoice_tracking.php` includes that file
the way `document_list.php` and `document_card.php` already do.

## Tested

On the bench, Dolibarr **18.0.10** and **24.0.0**, module deployed:

| | before | after |
| --- | --- | --- |
| `einvoice_tracking.php?id=999999` on 18.0.10 | HTTP 200, **22 259 bytes, truncated**, fatal in the log | HTTP 200, **31 021 bytes**, `Record not found.`, full page with footer |
| same on 24.0.0 | unchanged | unchanged (core function still the one used) |

The whole PHPUnit suite of the module was run file by file on the seven cores, **Dolibarr 18.0.10 to
24.0.0**, plus `develop`: 32/32 green on each.
