### PR TITLE
FIX: [einvoicing] Refuse an invoice whose currency is not the accounting one

### DIFF
--- a/einvoicing/lib/buildinvoicelines.inc.php
+++ b/einvoicing/lib/buildinvoicelines.inc.php
@@ -1198,6 +1198,13 @@ if ($shipAddress !== null) {
 
 // Section to control data and throw errors in case of problem, to avoid generating non compliant XML
 // --------------------------------------------------------------------------------------------------
+// The amounts above come from calcul_price_total(), so they are expressed in the accounting currency of
+// the company, while BT-5 announces $object->multicurrency_code. A foreign currency invoice would claim
+// an amount it does not mean, and BR-FR-CO-12 refuses it anyway: BT-5 other than EUR makes the VAT total
+// in accounting currency (BT-6, BT-111) mandatory, and neither is built here.
+if (!empty($object->multicurrency_code) && $object->multicurrency_code != $conf->currency) {
+	throw new Exception('UNSUPPORTEDCURRENCY: The invoice ' . $object->ref . ' is issued in ' . $object->multicurrency_code . ' but the e-invoice can only be built in the accounting currency of your company (' . $conf->currency . ').');
+}
 if (empty($idprof)) {
 	throw new Exception('BADTHIRDPARTYPROFID: The main professional ID of the buyer ' . $buyerParty->name . ' is empty.');
 }


### PR DESCRIPTION
## The defect

The amounts written into the document come from `calcul_price_total()` on `$line->subprice`, so they
are expressed in the **accounting currency of the company**, while BT-5 announces
`$object->multicurrency_code`. An invoice issued in a foreign currency therefore claims an amount it
does not mean: BT-5 says `USD`, BT-112 carries the euro figure. The `multicurrency_total_*` columns
are never read on this path.

`ram:TaxCurrencyCode` (BT-6) is hardcoded to `null` and only one `ram:TaxTotalAmount` is written, so
the document also breaks `BR-FR-CO-12` of the French CTC rules, flagged **fatal**:

> Si la devise de facture (BT-5) est différente de EUR, alors la devise de comptabilité (BT-6) doit
> être présente et égale à EUR, le montant de TVA en devise de comptabilité (BT-111) doit être
> renseigné, et sa devise (BT-111-1) doit être égale à EUR.

Same requirement in `G1.12` of the DGFiP external specifications v3.2 (annex 7), and in `BR-53` of
EN 16931.

## The change

Seven lines in the control block of `buildinvoicelines.inc.php`, next to the professional identifier
checks, refusing the generation with a message that names the invoice and both currencies.

The comparison is against `$conf->currency`, not a hardcoded `EUR`: a company whose accounting is in
another currency is out of scope of the French mandate anyway, and hardcoding `EUR` would break every
instance outside France.

Supporting a foreign currency for real — reading `multicurrency_total_*`, emitting BT-6 and a second
`TaxTotalAmount` in EUR — is a separate piece of work, not this fix.

## Measured

On the eight cores of the bench (18.0.10 → 25.0.0-alpha, each under the PHP version the CI matrix
gives it, 7.4 → 8.5):

| | before | after |
|---|---|---|
| invoice in EUR | XML generated | XML generated, byte for byte |
| invoice in USD | **XML generated silently** | refused: `UNSUPPORTEDCURRENCY: The invoice … is issued in USD but the e-invoice can only be built in the accounting currency of your company (EUR).` |

8/8 cores behave as expected. PHPUnit: 32/32 files green on each of the eight cores (256/256).
`regenerate_einvoicing_fixtures.php` reports the five reference documents unchanged.

The negative control matters here: on `main`, a USD invoice generates without a word — the defect is
reachable from the product, not only from a hand-edited document.

## Note

The message is a plain English string, like the other `BAD*` exceptions of that block, which the
caller already prefixes with the translated `ErrorGeneratingXML`. Introducing a language key for one
of eight sibling messages would make the block inconsistent; happy to change it if you prefer.
