### PR TITLE
FIX: [einvoicing] A text value XML cannot carry no longer breaks the document

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -2130,7 +2130,7 @@ class CIIProtocol extends AbstractProtocol
 	/**
 	 * Build CII XML from invoice data.
 	 *
-	 * Every value taken from the invoice or the company data is passed through htmlspecialchars() before it is
+	 * Every value taken from the invoice or the company data is passed through einvoicingXmlText() before it is
 	 * handed to DOMDocument::createElement(): that method parses its second argument, so a value holding an
 	 * ampersand produces an EMPTY element and silently loses the business term - issue #695.
 	 *
@@ -2190,7 +2190,7 @@ class CIIProtocol extends AbstractProtocol
 		if (!empty($invoiceData['businessProcessId'])) {
 			$bp = $doc->createElement('ram:BusinessProcessSpecifiedDocumentContextParameter');
 			$ctx->appendChild($bp);
-			$bp->appendChild($doc->createElement('ram:ID', htmlspecialchars((string) $invoiceData['businessProcessId'])));
+			$bp->appendChild($doc->createElement('ram:ID', einvoicingXmlText((string) $invoiceData['businessProcessId'])));
 		}
 
 		$profile = !empty($profile) ? strtoupper($profile) : 'EXTENDED';
@@ -2220,8 +2220,8 @@ class CIIProtocol extends AbstractProtocol
 		$exDoc = $doc->createElement('rsm:ExchangedDocument');
 		$root->appendChild($exDoc);
 
-		$exDoc->appendChild($doc->createElement('ram:ID', htmlspecialchars((string) $invoiceData['documentno'])));
-		$exDoc->appendChild($doc->createElement('ram:TypeCode', htmlspecialchars((string) $invoiceData['documenttypecode'])));
+		$exDoc->appendChild($doc->createElement('ram:ID', einvoicingXmlText((string) $invoiceData['documentno'])));
+		$exDoc->appendChild($doc->createElement('ram:TypeCode', einvoicingXmlText((string) $invoiceData['documenttypecode'])));
 
 		// Date
 		$issueDT = $doc->createElement('ram:IssueDateTime');
@@ -2241,30 +2241,30 @@ class CIIProtocol extends AbstractProtocol
 			if (!empty($invoiceData['documentNotePublic'])) {
 				$note = $doc->createElement('ram:IncludedNote');
 				$exDoc->appendChild($note);
-				$note->appendChild($doc->createElement('ram:Content', htmlspecialchars($invoiceData['documentNotePublic'])));
+				$note->appendChild($doc->createElement('ram:Content', einvoicingXmlText($invoiceData['documentNotePublic'])));
 			}
 			if (!empty($invoiceData['documentNotePMT'])) {
 				$note = $doc->createElement('ram:IncludedNote');
 				$exDoc->appendChild($note);
-				$note->appendChild($doc->createElement('ram:Content', htmlspecialchars($invoiceData['documentNotePMT'])));
+				$note->appendChild($doc->createElement('ram:Content', einvoicingXmlText($invoiceData['documentNotePMT'])));
 				$note->appendChild($doc->createElement('ram:SubjectCode', 'PMT'));
 			}
 			if (!empty($invoiceData['documentNotePMD'])) {
 				$note = $doc->createElement('ram:IncludedNote');
 				$exDoc->appendChild($note);
-				$note->appendChild($doc->createElement('ram:Content', htmlspecialchars($invoiceData['documentNotePMD'])));
+				$note->appendChild($doc->createElement('ram:Content', einvoicingXmlText($invoiceData['documentNotePMD'])));
 				$note->appendChild($doc->createElement('ram:SubjectCode', 'PMD'));
 			}
 			if (!empty($invoiceData['documentNoteAAB'])) {
 				$note = $doc->createElement('ram:IncludedNote');
 				$exDoc->appendChild($note);
-				$note->appendChild($doc->createElement('ram:Content', htmlspecialchars($invoiceData['documentNoteAAB'])));
+				$note->appendChild($doc->createElement('ram:Content', einvoicingXmlText($invoiceData['documentNoteAAB'])));
 				$note->appendChild($doc->createElement('ram:SubjectCode', 'AAB'));
 			}
 			if (!empty($invoiceData['documentNoteTXD'])) {
 				$note = $doc->createElement('ram:IncludedNote');
 				$exDoc->appendChild($note);
-				$note->appendChild($doc->createElement('ram:Content', htmlspecialchars($invoiceData['documentNoteTXD'])));
+				$note->appendChild($doc->createElement('ram:Content', einvoicingXmlText($invoiceData['documentNoteTXD'])));
 				$note->appendChild($doc->createElement('ram:SubjectCode', 'TXD'));
 			}
 		}
@@ -2310,7 +2310,7 @@ class CIIProtocol extends AbstractProtocol
 			$comment = $doc->createComment('Buyer reference (BT-10)');
 			$agreement->appendChild($comment);
 
-			$agreement->appendChild($doc->createElement('ram:BuyerReference', htmlspecialchars($invoiceData['buyerReference'])));
+			$agreement->appendChild($doc->createElement('ram:BuyerReference', einvoicingXmlText($invoiceData['buyerReference'])));
 		}
 
 		// Seller
@@ -2334,7 +2334,7 @@ class CIIProtocol extends AbstractProtocol
 
 			$buyerOrderRef = $doc->createElement('ram:BuyerOrderReferencedDocument');
 			$agreement->appendChild($buyerOrderRef);
-			$buyerOrderRef->appendChild($doc->createElement('ram:IssuerAssignedID', htmlspecialchars($invoiceData['orderReference'])));
+			$buyerOrderRef->appendChild($doc->createElement('ram:IssuerAssignedID', einvoicingXmlText($invoiceData['orderReference'])));
 		}
 
 		// Contract reference (BT-12): the contract the invoice is issued under. ram:ContractReferencedDocument
@@ -2346,7 +2346,7 @@ class CIIProtocol extends AbstractProtocol
 
 			$contractRef = $doc->createElement('ram:ContractReferencedDocument');
 			$agreement->appendChild($contractRef);
-			$contractRef->appendChild($doc->createElement('ram:IssuerAssignedID', htmlspecialchars($invoiceData['contractReference'])));
+			$contractRef->appendChild($doc->createElement('ram:IssuerAssignedID', einvoicingXmlText($invoiceData['contractReference'])));
 		}
 
 		// Additional order references: when an invoice covers several purchase orders, the first is emitted as BT-13
@@ -2361,7 +2361,7 @@ class CIIProtocol extends AbstractProtocol
 					continue;
 				}
 				$addRef = $doc->createElement('ram:AdditionalReferencedDocument');
-				$addRef->appendChild($doc->createElement('ram:IssuerAssignedID', htmlspecialchars($additionalOrderRef)));
+				$addRef->appendChild($doc->createElement('ram:IssuerAssignedID', einvoicingXmlText($additionalOrderRef)));
 				$addRef->appendChild($doc->createElement('ram:TypeCode', '130'));
 				$agreement->appendChild($addRef);
 			}
@@ -2378,9 +2378,9 @@ class CIIProtocol extends AbstractProtocol
 
 			$procuringProject = $doc->createElement('ram:SpecifiedProcuringProject');
 			$agreement->appendChild($procuringProject);
-			$procuringProject->appendChild($doc->createElement('ram:ID', htmlspecialchars((string) $project->ref)));
+			$procuringProject->appendChild($doc->createElement('ram:ID', einvoicingXmlText((string) $project->ref)));
 			$projectName = trim((string) $project->title);
-			$procuringProject->appendChild($doc->createElement('ram:Name', htmlspecialchars($projectName !== '' ? $projectName : (string) $project->ref)));
+			$procuringProject->appendChild($doc->createElement('ram:Name', einvoicingXmlText($projectName !== '' ? $projectName : (string) $project->ref)));
 		}
 
 
@@ -2459,11 +2459,11 @@ class CIIProtocol extends AbstractProtocol
 				$pm = $doc->createElement('ram:SpecifiedTradeSettlementPaymentMeans');
 				$settlement->appendChild($pm);
 
-				$pm->appendChild($doc->createElement('ram:TypeCode', htmlspecialchars((string) $invoiceData['paymentMeansCode'])));		// A code for payment type BT-81 (BG-16)
+				$pm->appendChild($doc->createElement('ram:TypeCode', einvoicingXmlText((string) $invoiceData['paymentMeansCode'])));		// A code for payment type BT-81 (BG-16)
 				// BT-82 and BT-85 below are optional: emit them only when they carry something,
 				// an empty element being refused by PEPPOL-EN16931-R008 (issue #695).
 				if ($this->isEn16931Profile($profile) && !empty($invoiceData['paymentMeansText'])) {
-					$pm->appendChild($doc->createElement('ram:Information', htmlspecialchars((string) $invoiceData['paymentMeansText'])));	// A label for payment type BT-82
+					$pm->appendChild($doc->createElement('ram:Information', einvoicingXmlText((string) $invoiceData['paymentMeansText'])));	// A label for payment type BT-82
 				}
 
 				$acc = $doc->createElement('ram:PayeePartyCreditorFinancialAccount');
@@ -2471,7 +2471,7 @@ class CIIProtocol extends AbstractProtocol
 
 				// CII XSD order for CreditorFinancialAccountType: IBANID, AccountName, ProprietaryID
 				if (!empty($invoiceData['iban'])) {
-					$acc->appendChild($doc->createElement('ram:IBANID', htmlspecialchars((string) $invoiceData['iban'])));					// BT-84
+					$acc->appendChild($doc->createElement('ram:IBANID', einvoicingXmlText((string) $invoiceData['iban'])));					// BT-84
 				} else {
 					// If no IBAN provided
 					if ($invoiceData['paymentMeansCode'] == 30) {	// If payment by credit transfer
@@ -2483,15 +2483,15 @@ class CIIProtocol extends AbstractProtocol
 					}
 				}
 				if ($this->isEn16931Profile($profile) && !empty($invoiceData['accountName'])) {
-					$acc->appendChild($doc->createElement('ram:AccountName', htmlspecialchars((string) $invoiceData['accountName'])));		// BT-85
+					$acc->appendChild($doc->createElement('ram:AccountName', einvoicingXmlText((string) $invoiceData['accountName'])));		// BT-85
 				}
 				if (empty($invoiceData['iban']) && !empty($invoiceData['accountRef'])) {	// If IBAN unknown we can fallback on the private ref.
-					$acc->appendChild($doc->createElement('ram:ProprietaryID', htmlspecialchars((string) $invoiceData['accountRef'])));	// BT-84-0
+					$acc->appendChild($doc->createElement('ram:ProprietaryID', einvoicingXmlText((string) $invoiceData['accountRef'])));	// BT-84-0
 				}
 				if (!empty($invoiceData['bic']) && $this->isEn16931Profile($profile)) {
 					$inst = $doc->createElement('ram:PayeeSpecifiedCreditorFinancialInstitution');
 					$pm->appendChild($inst);
-					$inst->appendChild($doc->createElement('ram:BICID', htmlspecialchars((string) $invoiceData['bic'])));					// BT-86
+					$inst->appendChild($doc->createElement('ram:BICID', einvoicingXmlText((string) $invoiceData['bic'])));					// BT-86
 				}
 			}
 
@@ -2545,7 +2545,7 @@ class CIIProtocol extends AbstractProtocol
 			$terms = $doc->createElement('ram:SpecifiedTradePaymentTerms');
 			$settlement->appendChild($terms);
 
-			$terms->appendChild($doc->createElement('ram:Description', htmlspecialchars((string) $invoiceData['paymentTermsText'])));
+			$terms->appendChild($doc->createElement('ram:Description', einvoicingXmlText((string) $invoiceData['paymentTermsText'])));
 
 			// Due date is optional (e.g. immediate payment); guard against a null date to avoid a fatal on ->format().
 			if (!empty($invoiceData['paymentDueDate'])) {
@@ -2594,13 +2594,13 @@ class CIIProtocol extends AbstractProtocol
 				foreach ($invoiceData['invoiceRefDocs'] as $refDoc) {
 					$refNode = $doc->createElement('ram:InvoiceReferencedDocument');
 
-					$refNode->appendChild($doc->createElement('ram:IssuerAssignedID', htmlspecialchars((string) $refDoc['ref'])));
+					$refNode->appendChild($doc->createElement('ram:IssuerAssignedID', einvoicingXmlText((string) $refDoc['ref'])));
 
 					// The document type (BT-X-...) is a fatal error under EN 16931, where CII-DT-018 only
 					// tolerates a TypeCode on an AdditionalReferencedDocument. The EXTENDED and
 					// EXTENDED-CTC-FR profiles reinstate it (CII-EXT-DT-018).
 					if ($this->isExtendedProfile($profile)) {
-						$refNode->appendChild($doc->createElement('ram:TypeCode', htmlspecialchars((string) $refDoc['type'])));
+						$refNode->appendChild($doc->createElement('ram:TypeCode', einvoicingXmlText((string) $refDoc['type'])));
 					}
 
 					// The issue date of the preceding invoice (BT-26) is part of BG-3 in EN 16931, where
@@ -2648,19 +2648,19 @@ class CIIProtocol extends AbstractProtocol
 		// ID
 		$docLine = $doc->createElement('ram:AssociatedDocumentLineDocument');
 		$el->appendChild($docLine);
-		$docLine->appendChild($doc->createElement('ram:LineID', htmlspecialchars((string) $line['lineid'])));
+		$docLine->appendChild($doc->createElement('ram:LineID', einvoicingXmlText((string) $line['lineid'])));
 
 		// Product
 		$prod = $doc->createElement('ram:SpecifiedTradeProduct');
 		$el->appendChild($prod);
 		if (!empty($line['prodsellerid'])) {
 			$prod->appendChild(
-				$doc->createElement('ram:SellerAssignedID', htmlspecialchars((string) $line['prodsellerid']))
+				$doc->createElement('ram:SellerAssignedID', einvoicingXmlText((string) $line['prodsellerid']))
 			);
 		}
-		$prod->appendChild($doc->createElement('ram:Name', htmlspecialchars($line['prodname'])));
+		$prod->appendChild($doc->createElement('ram:Name', einvoicingXmlText($line['prodname'])));
 		if (!empty($line['proddesc'])) {
-			$prod->appendChild($doc->createElement('ram:Description', htmlspecialchars($line['proddesc'])));
+			$prod->appendChild($doc->createElement('ram:Description', einvoicingXmlText($line['proddesc'])));
 		}
 
 		// Price
@@ -2714,13 +2714,13 @@ class CIIProtocol extends AbstractProtocol
 		$lineExemptionReason = (string) ($line['ExemptionReason'] ?? '');
 		$lineExemptionReasonCode = (string) ($line['ExemptionReasonCode'] ?? '');
 		if ($lineExemptionReason !== '') {
-			$tax->appendChild($doc->createElement('ram:ExemptionReason', htmlspecialchars($lineExemptionReason)));
+			$tax->appendChild($doc->createElement('ram:ExemptionReason', einvoicingXmlText($lineExemptionReason)));
 		}
-		$tax->appendChild($doc->createElement('ram:CategoryCode', htmlspecialchars((string) $line['categoryCode'])));
+		$tax->appendChild($doc->createElement('ram:CategoryCode', einvoicingXmlText((string) $line['categoryCode'])));
 		if ($lineExemptionReasonCode !== '') {
-			$tax->appendChild($doc->createElement('ram:ExemptionReasonCode', htmlspecialchars((string) $lineExemptionReasonCode)));
+			$tax->appendChild($doc->createElement('ram:ExemptionReasonCode', einvoicingXmlText((string) $lineExemptionReasonCode)));
 		}
-		$tax->appendChild($doc->createElement('ram:RateApplicablePercent', htmlspecialchars((string) $line['rateApplicablePercent'])));
+		$tax->appendChild($doc->createElement('ram:RateApplicablePercent', einvoicingXmlText((string) $line['rateApplicablePercent'])));
 
 		// Billing period for the line (BG-26 / BT-134 / BT-135). Must be placed after ApplicableTradeTax
 		// and before SpecifiedTradeAllowanceCharge (discount below) per the CII D22B schema sequence.
@@ -2750,7 +2750,7 @@ class CIIProtocol extends AbstractProtocol
 		if (!empty($line['isDepositLine'])) {
 			$refNode = $doc->createElement('ram:AdditionalReferencedDocument');
 
-			$refNode->appendChild($doc->createElement('ram:IssuerAssignedID', htmlspecialchars((string) $line['depositInvoiceRef'])));
+			$refNode->appendChild($doc->createElement('ram:IssuerAssignedID', einvoicingXmlText((string) $line['depositInvoiceRef'])));
 			$refNode->appendChild($doc->createElement('ram:TypeCode', '130'));
 
 			if (!empty($line['depositInvoiceDate']) && $profile === 'EXTENDED') {
@@ -2798,7 +2798,7 @@ class CIIProtocol extends AbstractProtocol
 		if (!$this->isMinimumProfile($profile)) {
 			if (!empty($data[$prefix . 'GlobalIds'])) {
 				foreach ($data[$prefix . 'GlobalIds'] as $globalId) {
-					$g = $doc->createElement('ram:GlobalID', htmlspecialchars((string) $globalId['value']));
+					$g = $doc->createElement('ram:GlobalID', einvoicingXmlText((string) $globalId['value']));
 					$g->setAttribute('schemeID', $globalId['schemeID']);
 					$node->appendChild($g);
 				}
@@ -2806,7 +2806,7 @@ class CIIProtocol extends AbstractProtocol
 				// The ram:ID variant of the same term. Nothing to write when the party identifier is
 				// deliberately not declared: BT-29 and BT-46 are optional, and an empty element would
 				// be refused by PEPPOL-EN16931-R008.
-				$node->appendChild($doc->createElement('ram:ID', htmlspecialchars((string) $data[$prefix . 'ids'])));
+				$node->appendChild($doc->createElement('ram:ID', einvoicingXmlText((string) $data[$prefix . 'ids'])));
 			}
 
 			// Routing code of the buyer (BT-46 under scheme 0224), where BR-FR-CPRO-11 and BR-FR-CPRO-13 read
@@ -2814,19 +2814,19 @@ class CIIProtocol extends AbstractProtocol
 			// profiles accept (FX-SCH-A-000164 caps that element at one occurrence below them), and it belongs
 			// to the buyer alone: on the deliver-to party the identifier is BT-71, a location (issue #678).
 			if ($type === 'buyer' && !$minimal && $this->isExtendedProfile($profile) && !empty($data['buyerRoutingCode'])) {
-				$routing = $doc->createElement('ram:GlobalID', htmlspecialchars($data['buyerRoutingCode']));
+				$routing = $doc->createElement('ram:GlobalID', einvoicingXmlText($data['buyerRoutingCode']));
 				$routing->setAttribute('schemeID', EInvoicing::SCHEME_FR_ROUTING_CODE);
 				$node->appendChild($routing);
 			}
 		}
 
-		$node->appendChild($doc->createElement('ram:Name', htmlspecialchars($data[$prefix . 'name'])));
+		$node->appendChild($doc->createElement('ram:Name', einvoicingXmlText($data[$prefix . 'name'])));
 
 		// Legal org
 		if (!$minimal) {
 			$legal = $doc->createElement('ram:SpecifiedLegalOrganization');
 			$node->appendChild($legal);
-			$id = $doc->createElement('ram:ID', htmlspecialchars((string) $data[$prefix . 'LegalOrgId']));
+			$id = $doc->createElement('ram:ID', einvoicingXmlText((string) $data[$prefix . 'LegalOrgId']));
 			$id->setAttribute('schemeID', $data[$prefix . 'LegalOrgScheme']);
 			$legal->appendChild($id);
 			// LegalOrganizationType is reduced to ram:ID by the MINIMUM schema.
@@ -2835,7 +2835,7 @@ class CIIProtocol extends AbstractProtocol
 			// nothing at all: an empty element would be refused by PEPPOL-EN16931-R008 (issue #695).
 			if (!$this->isMinimumProfile($profile) && !empty($data[$prefix . 'TradingName'])) {
 				$legal->appendChild(
-					$doc->createElement('ram:TradingBusinessName', htmlspecialchars((string) $data[$prefix . 'TradingName']))
+					$doc->createElement('ram:TradingBusinessName', einvoicingXmlText((string) $data[$prefix . 'TradingName']))
 				);
 			}
 		}
@@ -2855,17 +2855,17 @@ class CIIProtocol extends AbstractProtocol
 			$node->appendChild($contact);
 
 			if (!empty($data[$prefix . 'contactpersonname'])) {
-				$contact->appendChild($doc->createElement('ram:PersonName', htmlspecialchars($data[$prefix . 'contactpersonname'])));
+				$contact->appendChild($doc->createElement('ram:PersonName', einvoicingXmlText($data[$prefix . 'contactpersonname'])));
 			}
 
 			if (!empty($data[$prefix . 'contactdepartmentname'])) {
-				$contact->appendChild($doc->createElement('ram:DepartmentName', htmlspecialchars($data[$prefix . 'contactdepartmentname'])));
+				$contact->appendChild($doc->createElement('ram:DepartmentName', einvoicingXmlText($data[$prefix . 'contactdepartmentname'])));
 			}
 
 			if (!empty($data[$prefix . 'contactphoneno'])) {
 				$phone = $doc->createElement('ram:TelephoneUniversalCommunication');
 				$contact->appendChild($phone);
-				$phone->appendChild($doc->createElement('ram:CompleteNumber', htmlspecialchars((string) $data[$prefix . 'contactphoneno'])));
+				$phone->appendChild($doc->createElement('ram:CompleteNumber', einvoicingXmlText((string) $data[$prefix . 'contactphoneno'])));
 			}
 
 			// No ram:FaxUniversalCommunication here on purpose, see the comment above. The
@@ -2875,7 +2875,7 @@ class CIIProtocol extends AbstractProtocol
 			if (!empty($data[$prefix . 'contactemailaddr'])) {
 				$email = $doc->createElement('ram:EmailURIUniversalCommunication');
 				$contact->appendChild($email);
-				$email->appendChild($doc->createElement('ram:URIID', htmlspecialchars((string) $data[$prefix . 'contactemailaddr'])));
+				$email->appendChild($doc->createElement('ram:URIID', einvoicingXmlText((string) $data[$prefix . 'contactemailaddr'])));
 			}
 		}
 
@@ -2886,28 +2886,28 @@ class CIIProtocol extends AbstractProtocol
 
 		// TradeAddressType is reduced to the country code by the MINIMUM schema
 		if (!$this->isMinimumProfile($profile)) {
-			$addr->appendChild($doc->createElement('ram:PostcodeCode', htmlspecialchars((string) $data[$prefix . 'postcode'])));
+			$addr->appendChild($doc->createElement('ram:PostcodeCode', einvoicingXmlText((string) $data[$prefix . 'postcode'])));
 			// The three address lines the norm has: BT-35/36/162 for the seller, BT-50/51/163 for the
 			// buyer. XSD order inside TradeAddressType is PostcodeCode, LineOne, LineTwo, LineThree,
 			// CityName, CountryID - the elements are written in that order and nowhere else.
 			if (!empty($data[$prefix . 'lineone'])) {
-				$addr->appendChild($doc->createElement('ram:LineOne', htmlspecialchars($data[$prefix . 'lineone'])));
+				$addr->appendChild($doc->createElement('ram:LineOne', einvoicingXmlText($data[$prefix . 'lineone'])));
 			}
 			if (!empty($data[$prefix . 'linetwo'])) {
-				$addr->appendChild($doc->createElement('ram:LineTwo', htmlspecialchars($data[$prefix . 'linetwo'])));
+				$addr->appendChild($doc->createElement('ram:LineTwo', einvoicingXmlText($data[$prefix . 'linetwo'])));
 			}
 			if (!empty($data[$prefix . 'linethree'])) {
-				$addr->appendChild($doc->createElement('ram:LineThree', htmlspecialchars($data[$prefix . 'linethree'])));
+				$addr->appendChild($doc->createElement('ram:LineThree', einvoicingXmlText($data[$prefix . 'linethree'])));
 			}
-			$addr->appendChild($doc->createElement('ram:CityName', htmlspecialchars($data[$prefix . 'city'])));
+			$addr->appendChild($doc->createElement('ram:CityName', einvoicingXmlText($data[$prefix . 'city'])));
 		}
-		$addr->appendChild($doc->createElement('ram:CountryID', htmlspecialchars((string) $data[$prefix . 'country'])));
+		$addr->appendChild($doc->createElement('ram:CountryID', einvoicingXmlText((string) $data[$prefix . 'country'])));
 
 		// URIUniversalCommunication. Not declared by the MINIMUM schema.
 		if (!$minimal && !$this->isMinimumProfile($profile) && !empty($data[$prefix . 'CommunicationUriScheme']) && !empty($data[$prefix . 'CommunicationUri'])) {
 			$uri = $doc->createElement('ram:URIUniversalCommunication');
 			$node->appendChild($uri);
-			$uriid = $doc->createElement('ram:URIID', htmlspecialchars((string) $data[$prefix . 'CommunicationUri']));			// Example 315143296_1939
+			$uriid = $doc->createElement('ram:URIID', einvoicingXmlText((string) $data[$prefix . 'CommunicationUri']));			// Example 315143296_1939
 			$uriid->setAttribute('schemeID', $data[$prefix . 'CommunicationUriScheme']);			// Example 0225
 			$uri->appendChild($uriid);
 		}
@@ -2932,7 +2932,7 @@ class CIIProtocol extends AbstractProtocol
 
 			foreach ($registrations as $registration) {
 				$tax = $doc->createElement('ram:SpecifiedTaxRegistration');
-				$id = $doc->createElement('ram:ID', htmlspecialchars((string) $registration['value']));
+				$id = $doc->createElement('ram:ID', einvoicingXmlText((string) $registration['value']));
 				$id->setAttribute('schemeID', $registration['type']);
 				$tax->appendChild($id);
 				$node->appendChild($tax);
@@ -2977,7 +2977,7 @@ class CIIProtocol extends AbstractProtocol
 
 		// BT-70 Deliver-to party name (optional).
 		if (!empty($ship['name'])) {
-			$node->appendChild($doc->createElement('ram:Name', htmlspecialchars($ship['name'])));
+			$node->appendChild($doc->createElement('ram:Name', einvoicingXmlText($ship['name'])));
 		}
 
 		// BG-15 Deliver-to address.
@@ -2986,7 +2986,7 @@ class CIIProtocol extends AbstractProtocol
 
 		// CII XSD order for PostalTradeAddress: PostcodeCode BEFORE LineOne (counter-intuitive).
 		if (!empty($ship['zip'])) {
-			$addr->appendChild($doc->createElement('ram:PostcodeCode', htmlspecialchars((string) $ship['zip'])));
+			$addr->appendChild($doc->createElement('ram:PostcodeCode', einvoicingXmlText((string) $ship['zip'])));
 		}
 		// BT-75/76/165: the deliver-to address has three lines too. The caller splits the free text
 		// field Dolibarr stores; a single-line address keeps landing on LineOne alone.
@@ -2997,14 +2997,14 @@ class CIIProtocol extends AbstractProtocol
 		);
 		foreach (array('ram:LineOne', 'ram:LineTwo', 'ram:LineThree') as $rank => $element) {
 			if (!empty($shiplines[$rank])) {
-				$addr->appendChild($doc->createElement($element, htmlspecialchars($shiplines[$rank])));
+				$addr->appendChild($doc->createElement($element, einvoicingXmlText($shiplines[$rank])));
 			}
 		}
 		if (!empty($ship['town'])) {
-			$addr->appendChild($doc->createElement('ram:CityName', htmlspecialchars($ship['town'])));
+			$addr->appendChild($doc->createElement('ram:CityName', einvoicingXmlText($ship['town'])));
 		}
 		// CountryID is mandatory whenever the address block exists (BR-57). Guaranteed non-empty here.
-		$addr->appendChild($doc->createElement('ram:CountryID', htmlspecialchars((string) $ship['country'])));
+		$addr->appendChild($doc->createElement('ram:CountryID', einvoicingXmlText((string) $ship['country'])));
 
 		return $node;
 	}
@@ -3062,19 +3062,19 @@ class CIIProtocol extends AbstractProtocol
 		$tax->appendChild($doc->createElement('ram:TypeCode', 'VAT'));
 
 		if ($vals['ExemptionReason']) {
-			$tax->appendChild($doc->createElement('ram:ExemptionReason', htmlspecialchars((string) $vals['ExemptionReason'])));
+			$tax->appendChild($doc->createElement('ram:ExemptionReason', einvoicingXmlText((string) $vals['ExemptionReason'])));
 		}
 
 		$tax->appendChild($doc->createElement('ram:BasisAmount', number_format($vals['totalHT'], 2, '.', '')));
 
-		$tax->appendChild($doc->createElement('ram:CategoryCode', htmlspecialchars((string) $vals['categoryVAT'])));
+		$tax->appendChild($doc->createElement('ram:CategoryCode', einvoicingXmlText((string) $vals['categoryVAT'])));
 
 		if ($vals['ExemptionReasonCode']) {
-			$tax->appendChild($doc->createElement('ram:ExemptionReasonCode', htmlspecialchars((string) $vals['ExemptionReasonCode'])));
+			$tax->appendChild($doc->createElement('ram:ExemptionReasonCode', einvoicingXmlText((string) $vals['ExemptionReasonCode'])));
 		}
 
 		if (!empty($dueDateTypeCode)) {		// BT-8, placed before the rate per the CII D22B sequence
-			$tax->appendChild($doc->createElement('ram:DueDateTypeCode', htmlspecialchars((string) $dueDateTypeCode)));
+			$tax->appendChild($doc->createElement('ram:DueDateTypeCode', einvoicingXmlText((string) $dueDateTypeCode)));
 		}
 
 		// BT-119 comes from the group itself, never from the key it is filed under: that key identifies
@@ -3139,12 +3139,12 @@ class CIIProtocol extends AbstractProtocol
 
 		// reasonCode
 		if ($reasonCode !== null) {
-			$node->appendChild($doc->createElement('ram:ReasonCode', htmlspecialchars((string) $reasonCode)));
+			$node->appendChild($doc->createElement('ram:ReasonCode', einvoicingXmlText((string) $reasonCode)));
 		}
 
 		// Reason
 		if ($reason !== null) {
-			$node->appendChild($doc->createElement('ram:Reason', htmlspecialchars((string) $reason)));
+			$node->appendChild($doc->createElement('ram:Reason', einvoicingXmlText((string) $reason)));
 		}
 
 		// Tax (important Factur-X). Document level only: on a line the VAT of the discount is already
@@ -3153,7 +3153,7 @@ class CIIProtocol extends AbstractProtocol
 			$taxNode = $doc->createElement('ram:CategoryTradeTax');
 
 			$taxNode->appendChild($doc->createElement('ram:TypeCode', 'VAT'));
-			$taxNode->appendChild($doc->createElement('ram:CategoryCode', htmlspecialchars((string) $taxCategory)));
+			$taxNode->appendChild($doc->createElement('ram:CategoryCode', einvoicingXmlText((string) $taxCategory)));
 			$taxNode->appendChild($doc->createElement('ram:RateApplicablePercent', number_format($taxRate, 2, '.', '')));
 
 			$node->appendChild($taxNode);

--- a/einvoicing/class/utils/CdarHandler.class.php
+++ b/einvoicing/class/utils/CdarHandler.class.php
@@ -195,7 +195,7 @@ class CdarHandler
 	/**
 	 * generate
 	 *
-	 * Values coming from the data are escaped with htmlspecialchars() before they reach
+	 * Values coming from the data are escaped with einvoicingXmlText() before they reach
 	 * DOMDocument::createElement(), which parses its second argument: an ampersand in a free text
 	 * (a rejection reason, a party name) would otherwise produce an empty element and lose the
 	 * information - same defect as issue #695 on the invoice side.
@@ -911,7 +911,7 @@ class CdarHandler
 		$context->appendChild($process);
 
 		$guideline = $dom->createElement('ram:GuidelineSpecifiedDocumentContextParameter');
-		$guideline->appendChild($dom->createElement('ram:ID', htmlspecialchars((string) $guidelineID)));
+		$guideline->appendChild($dom->createElement('ram:ID', einvoicingXmlText((string) $guidelineID)));
 		$context->appendChild($guideline);
 		$root->appendChild($context);
 	}
@@ -929,7 +929,7 @@ class CdarHandler
 	private function addDateTimeElement($dom, $parent, $elementName, $value, $format)
 	{
 		$element = $dom->createElement($elementName);
-		$dateTimeStr = $dom->createElement('udt:DateTimeString', htmlspecialchars((string) $value));
+		$dateTimeStr = $dom->createElement('udt:DateTimeString', einvoicingXmlText((string) $value));
 		$dateTimeStr->setAttribute('format', $format);
 		$element->appendChild($dateTimeStr);
 		$parent->appendChild($element);
@@ -949,18 +949,18 @@ class CdarHandler
 		$party = $dom->createElement($elementName);
 
 		if (isset($data['GlobalID'])) {
-			$globalID = $dom->createElement('ram:GlobalID', htmlspecialchars((string) $data['GlobalID']));
+			$globalID = $dom->createElement('ram:GlobalID', einvoicingXmlText((string) $data['GlobalID']));
 			if (!empty($data['SchemeID'])) {
 				$globalID->setAttribute('schemeID', $data['SchemeID']);
 			}
 			$party->appendChild($globalID);
 		}
 
-		$party->appendChild($dom->createElement('ram:RoleCode', htmlspecialchars((string) $data['RoleCode'])));
+		$party->appendChild($dom->createElement('ram:RoleCode', einvoicingXmlText((string) $data['RoleCode'])));
 
 		if (isset($data['URIID'])) {
 			$uriComm = $dom->createElement('ram:URIUniversalCommunication');
-			$uriID = $dom->createElement('ram:URIID', htmlspecialchars((string) $data['URIID']));
+			$uriID = $dom->createElement('ram:URIID', einvoicingXmlText((string) $data['URIID']));
 			$uriID->setAttribute('schemeID', $data['URISchemeID']);
 			$uriComm->appendChild($uriID);
 			$party->appendChild($uriComm);
@@ -1091,8 +1091,8 @@ class CdarHandler
 	private function addExchangedDocument($dom, $root, $doc)
 	{
 		$exchanged = $dom->createElement('rsm:ExchangedDocument');
-		$exchanged->appendChild($dom->createElement('ram:ID', htmlspecialchars((string) $doc['ID'])));
-		$exchanged->appendChild($dom->createElement('ram:Name', htmlspecialchars((string) $doc['Name'])));
+		$exchanged->appendChild($dom->createElement('ram:ID', einvoicingXmlText((string) $doc['ID'])));
+		$exchanged->appendChild($dom->createElement('ram:Name', einvoicingXmlText((string) $doc['Name'])));
 
 		$this->addDateTimeElement($dom, $exchanged, 'ram:IssueDateTime', $doc['IssueDateTime'], self::FORMAT_DATETIME);
 
@@ -1120,7 +1120,7 @@ class CdarHandler
 		$multipleRef->appendChild($indicator);
 		$ack->appendChild($multipleRef);
 
-		$ack->appendChild($dom->createElement('ram:TypeCode', htmlspecialchars((string) $doc['TypeCode'])));
+		$ack->appendChild($dom->createElement('ram:TypeCode', einvoicingXmlText((string) $doc['TypeCode'])));
 		$this->addDateTimeElement($dom, $ack, 'ram:IssueDateTime', $doc['IssueDateTime'], self::FORMAT_DATETIME);
 		$this->addReferencedDocument($dom, $ack, $doc['ReferenceReferencedDocument']);
 
@@ -1138,24 +1138,24 @@ class CdarHandler
 	private function addReferencedDocument($dom, $parent, $doc)
 	{
 		$ref = $dom->createElement('ram:ReferenceReferencedDocument');
-		$ref->appendChild($dom->createElement('ram:IssuerAssignedID', htmlspecialchars((string) $doc['IssuerAssignedID'])));
-		$ref->appendChild($dom->createElement('ram:StatusCode', htmlspecialchars((string) $doc['StatusCode'])));
-		$ref->appendChild($dom->createElement('ram:TypeCode', htmlspecialchars((string) $doc['TypeCode'])));
+		$ref->appendChild($dom->createElement('ram:IssuerAssignedID', einvoicingXmlText((string) $doc['IssuerAssignedID'])));
+		$ref->appendChild($dom->createElement('ram:StatusCode', einvoicingXmlText((string) $doc['StatusCode'])));
+		$ref->appendChild($dom->createElement('ram:TypeCode', einvoicingXmlText((string) $doc['TypeCode'])));
 
 		// MDT-97. Its place in the CDAR XSD sequence (ReferencedDocumentType) is after ReceiptDateTime /
 		// AttachmentBinaryObject and before FormattedIssueDateTime - the order the platforms use too.
 		if (!empty($doc['ReferenceTypeCode'])) {
-			$ref->appendChild($dom->createElement('ram:ReferenceTypeCode', htmlspecialchars((string) $doc['ReferenceTypeCode'])));
+			$ref->appendChild($dom->createElement('ram:ReferenceTypeCode', einvoicingXmlText((string) $doc['ReferenceTypeCode'])));
 		}
 
 		$formattedDateTime = $dom->createElement('ram:FormattedIssueDateTime');
-		$dateTimeStr = $dom->createElement('qdt:DateTimeString', htmlspecialchars((string) $doc['FormattedIssueDateTime']));
+		$dateTimeStr = $dom->createElement('qdt:DateTimeString', einvoicingXmlText((string) $doc['FormattedIssueDateTime']));
 		$dateTimeStr->setAttribute('format', self::FORMAT_DATE);
 		$formattedDateTime->appendChild($dateTimeStr);
 		$ref->appendChild($formattedDateTime);
 
-		$ref->appendChild($dom->createElement('ram:ProcessConditionCode', htmlspecialchars((string) $doc['ProcessConditionCode'])));
-		$ref->appendChild($dom->createElement('ram:ProcessCondition', htmlspecialchars((string) $doc['ProcessCondition'])));
+		$ref->appendChild($dom->createElement('ram:ProcessConditionCode', einvoicingXmlText((string) $doc['ProcessConditionCode'])));
+		$ref->appendChild($dom->createElement('ram:ProcessCondition', einvoicingXmlText((string) $doc['ProcessCondition'])));
 
 		$this->addTradeParty($dom, $ref, 'ram:IssuerTradeParty', $doc['IssuerTradeParty']);
 		$parent->appendChild($ref);
@@ -1165,13 +1165,13 @@ class CdarHandler
 
 			if (!empty($doc['SpecifiedDocumentStatus']['ReasonCode'])) {
 				$status->appendChild(
-					$dom->createElement('ram:ReasonCode', htmlspecialchars((string) $doc['SpecifiedDocumentStatus']['ReasonCode']))
+					$dom->createElement('ram:ReasonCode', einvoicingXmlText((string) $doc['SpecifiedDocumentStatus']['ReasonCode']))
 				);
 			}
 
 			if (!empty($doc['SpecifiedDocumentStatus']['Reason'])) {
 				$status->appendChild(
-					$dom->createElement('ram:Reason', htmlspecialchars((string) $doc['SpecifiedDocumentStatus']['Reason']))
+					$dom->createElement('ram:Reason', einvoicingXmlText((string) $doc['SpecifiedDocumentStatus']['Reason']))
 				);
 			}
 
@@ -1189,10 +1189,10 @@ class CdarHandler
 			if (!empty($doc['SpecifiedDocumentStatus']['SpecifiedDocumentCharacteristic'])) {
 				foreach ($doc['SpecifiedDocumentStatus']['SpecifiedDocumentCharacteristic'] as $characteristic) {
 					$characteristicElement = $dom->createElement('ram:SpecifiedDocumentCharacteristic');
-					$characteristicElement->appendChild($dom->createElement('ram:TypeCode', htmlspecialchars((string) $characteristic['TypeCode'])));
+					$characteristicElement->appendChild($dom->createElement('ram:TypeCode', einvoicingXmlText((string) $characteristic['TypeCode'])));
 
 					if (isset($characteristic['ValueAmount'])) {
-						$amountElement = $dom->createElement('ram:ValueAmount', htmlspecialchars((string) $characteristic['ValueAmount']));
+						$amountElement = $dom->createElement('ram:ValueAmount', einvoicingXmlText((string) $characteristic['ValueAmount']));
 						if (!empty($characteristic['CurrencyID'])) {
 							$amountElement->setAttribute('currencyID', $characteristic['CurrencyID']);
 						}
@@ -1204,7 +1204,7 @@ class CdarHandler
 					}
 
 					if (isset($characteristic['ValuePercent'])) {
-						$characteristicElement->appendChild($dom->createElement('ram:ValuePercent', htmlspecialchars((string) $characteristic['ValuePercent'])));
+						$characteristicElement->appendChild($dom->createElement('ram:ValuePercent', einvoicingXmlText((string) $characteristic['ValuePercent'])));
 					}
 
 					$status->appendChild($characteristicElement);

--- a/einvoicing/lib/einvoicing.lib.php
+++ b/einvoicing/lib/einvoicing.lib.php
@@ -215,6 +215,32 @@ function thirdpartyidprof($object)
 }
 
 /**
+ * Escape a value for a text node or an attribute of a generated XML document.
+ *
+ * Two ways a text value breaks the document, neither of which htmlspecialchars() handles alone:
+ * an invalid UTF-8 sequence, which it answers with an EMPTY STRING below PHP 8.1 where ENT_SUBSTITUTE
+ * is not a default (one latin-1 byte in a company name, and BR-06 refuses the empty element), and a
+ * control character forbidden by XML 1.0 (a vertical tab pasted from a PDF), which it copies through
+ * and which leaves a file no parser reads - the platform answers HTTP 400 on it.
+ *
+ * @param  mixed	$value	Value to escape. null is accepted and gives ''.
+ * @return string			Value escaped for DOMDocument::createElement() and setAttribute()
+ */
+function einvoicingXmlText($value)
+{
+	$value = (string) $value;
+
+	// Tab, LF and CR are the three control characters XML 1.0 allows. No /u here: the pattern is
+	// byte based on purpose, so it also holds on the invalid UTF-8 the escape below repairs.
+	$stripped = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F]/', '', $value);
+	if ($stripped !== null) {
+		$value = $stripped;
+	}
+
+	return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
+/**
  * Remove every space of an identifier, whatever kind of space it is.
  *
  * A value copied from a web page or a PDF often carries a non-breaking (U+00A0), thin or zero-width


### PR DESCRIPTION
## The defect

Two ways a text value read from the database reaches the generated document broken. Both are silent, and both leave a file the Access Point answers **HTTP 400** on.

**1. An invalid UTF-8 byte empties the element.** `htmlspecialchars()` returns an **empty string** on any invalid UTF-8 sequence unless `ENT_SUBSTITUTE` is passed — and that flag only became a default in **PHP 8.1**. The generation path called it 84 times without flags, so on the cores the module supports below 8.1, one latin-1 byte in a company name, an address or an item label reached the document as an empty element, with no error and no log line:

```
$s = "Soci\xE9t\xE9 Dupont";  echo htmlspecialchars($s);
php7.4 => EMPTY STRING          php8.1 => [Soci<?>t<?> Dupont]
php8.0 => EMPTY STRING          php8.5 => [Soci<?>t<?> Dupont]
```

On `main`, Dolibarr 19 / PHP 8.0, with that byte in the company name:

```
ram:Name du vendeur : ELEMENT VIDE (<ram:Name/>)

profile FACTUR-X_EN16931.xslt : 101 check(s), 2 failure(s)
    [PEPPOL-EN16931-R008] (warning) Document MUST not contain empty elements.
    [BR-06] An Invoice shall contain the Seller name (BT-27).
```

The same third party record produces a valid document on a core running 8.1 or above, so the defect depends on the PHP of the instance — "it works here" is literally true, which makes it expensive to diagnose from a support ticket.

**2. A control character forbidden by XML 1.0 is copied through.** A vertical tab pasted from a PDF (`0x0B`), a `0x1F` in an item reference — `htmlspecialchars()` does not touch them whatever the flags (they are valid UTF-8, simply forbidden by the XML specification), `DOMDocument` writes them as is without a warning, and the file that comes out is not XML any more. Measured on the seven PHP of the CI matrix:

```
php7.4.33 libxml=2.9.14 : 0x0B PRESENT in the file, read back = FAILURE
php8.0.30 … php8.5.10   : same, on all seven
```

```
PCDATA invalid Char value 11
```

## The change

One helper next to `removeAllSpaces()` in `einvoicing/lib/einvoicing.lib.php`, already included by both `CommonProtocol` and `CdarHandler`:

```php
function einvoicingXmlText($value)
{
	$value = (string) $value;

	// Tab, LF and CR are the three control characters XML 1.0 allows. No /u here: the pattern is
	// byte based on purpose, so it also holds on the invalid UTF-8 the escape below repairs.
	$stripped = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F]/', '', $value);
	if ($stripped !== null) {
		$value = $stripped;
	}

	return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
}
```

and the 84 escapes of the generation path routed through it — 63 in `CIIProtocol`, 21 in `CdarHandler`. Both flags exist since PHP 5.4, so the form holds on the whole supported range.

`ENT_QUOTES` only adds the apostrophe, which `DOMDocument` parses back like the four others: the document is unchanged for a valid value.

After this, no value written into a document is escaped by a bare `htmlspecialchars()` any more. The calls left in the module escape **HTML** output and are out of scope: a page title in `admin/setup.php`, a masked token in the three provider setup pages, a `<span>` of the invoice card, the XML preview highlighter (`lib/xmlhighlight.lib.php`) and the documentation generator. The other writes of the generation path carry no free text — a literal (`VAT`, `PMT`, `130`), a number, a date, or a namespace URI — and `setAttribute()` escapes its value on its own, unlike the second argument of `createElement()`, which is the one that needed a helper.

## Measured

On the eight cores of the bench (18.0.10 → 25.0.0-alpha, PHP 7.4 → 8.5):

| | before | after |
|---|---|---|
| valid company name | document generated | **byte for byte identical** — `regenerate_einvoicing_fixtures.php` reports the five reference documents `unchanged` |
| one latin-1 byte in the name, PHP ≤ 8.0 | `<ram:Name/>`, document refused on BR-06 | `[Société Burger Queen]`, name kept |
| one latin-1 byte in the name, PHP ≥ 8.1 | name kept | name kept |
| `0x0B` / `0x1F` reaching the escape | byte written to the file, document unreadable, on all seven PHP | removed, document well formed, the value kept otherwise |

An invoice carrying the poisoned value on its **fourteen** text terms at once (seller and buyer names, addresses, towns, contact, note, customer reference, bank holder, line description, item label and reference, discount reason) comes out well formed, with no empty element, on 18.0.10 / 20 / 23 / 24. A value that holds no forbidden character round trips exactly as before the change (`exact=11/14` on the `&`, `<`, `'` string, identical before and after).

PHPUnit: 32/32 files green on each of the eight cores (256/256).

## Note

No PHPUnit test is included in this branch, per the repository rule. A case pinning the behaviour on an invalid byte and on a control character is ready and easy to add if you want it.
