### PR TITLE
FIX #912 [einvoicing] The deposit a line deducts is referenced where a preceding invoice belongs

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -2761,23 +2761,11 @@ class CIIProtocol extends AbstractProtocol
 		$sett->appendChild($sum);
 		$sum->appendChild($doc->createElement('ram:LineTotalAmount', number_format($line['lineTotalAmount'], 2, '.', '')));
 
-		// Ref doc for deposit line
-		if (!empty($line['isDepositLine'])) {
-			$refNode = $doc->createElement('ram:AdditionalReferencedDocument');
-
-			$refNode->appendChild($doc->createElement('ram:IssuerAssignedID', einvoicingXmlText((string) $line['depositInvoiceRef'])));
-			$refNode->appendChild($doc->createElement('ram:TypeCode', '130'));
-
-			if (!empty($line['depositInvoiceDate']) && $profile === 'EXTENDED') {
-				$dateNode = $doc->createElement('ram:FormattedIssueDateTime');
-				$str = $doc->createElement('qdt:DateTimeString', $line['depositInvoiceDate']->format('Ymd'));
-				$str->setAttribute('format', '102');
-				$dateNode->appendChild($str);
-				$refNode->appendChild($dateNode);
-			}
-
-			$sett->appendChild($refNode);
-		}
+		// The deposit this line deducts is referenced at document level, in BG-3, where a preceding
+		// invoice belongs (BT-25 with its date BT-26, type 386) - buildinvoicelines.inc.php fills it in
+		// the same place it marks the line. It used to be written here as well, as a line level
+		// ram:AdditionalReferencedDocument with TypeCode 130: that slot is BT-128, the identifier of what
+		// the line bills - a phone number, a meter - and never a document (issue #912).
 
 		return $el;
 	}


### PR DESCRIPTION
Closes #912.

## The defect

A final invoice deducting a deposit wrote that deposit's reference **twice**:

* at document level, in **BG-3** — `ram:InvoiceReferencedDocument`, BT-25 with its date BT-26, and the type `386` on the profiles that accept it;
* and again on the line, as a `ram:AdditionalReferencedDocument` with `TypeCode 130`.

The second slot is **BT-128, the Invoiced object identifier** — what the line bills, a phone number, a meter, a subscription — and never a document. A conformant reader receiving one of our invoices treats the deposit reference as the identifier of the billed object, and drops the link.

Both writes come from the same block of `buildinvoicelines.inc.php`, so they could never disagree: the line level one is pure duplication in the wrong place.

## On the target proposed in the issue

`TypeCode 916` was suggested as the line level alternative. It is not one: in the FNFE rules (`France_RFE` 1.4.0.04) `916` only ever appears under `ApplicableHeaderTradeAgreement/ram:AdditionalReferencedDocument` — BG-24, the supporting documents, at document level. Swapping 130 for 916 on the line would move the problem rather than solve it.

The French rules do give BT-128 two qualified uses, and one of them carries an invoice number — `BR-FR-MV-07/BT-128`, an invoice number coded `AFL` — but only inside the multi-vendor and mandate frameworks (`BT-23` ∈ S8, B8, M8, S9, B9, M9), and `BR-FR-30` caps `AFL` and `AVV` at one occurrence each. Not a general slot for a deposit.

So the fix is to stop writing the line level reference, not to recode it.

## Measured

Dolibarr 22, a customer deposit invoice turned into a discount and applied to a standard invoice, emitted before and after:

```
                     BT-128 on the line    BG-3 at document level     schematron 1.4.0.04
before                        1                     2                       VALID
after                         0                     2                       VALID
```

BG-3 still carries `DD22B-AC-2609-0001` with its date. The schematron accepts both, which is the point: no rule catches this, only a reader does — it is a conformity of meaning, not a rule violation.

**Round trip**, the same two documents imported back with the referenced deposit present as a supplier invoice:

```
before   imported   deposit discount ht=100.00 ttc=120.00 src=18313
after    imported   deposit discount ht=100.00 ttc=120.00 src=18313
```

Identical. The import resolves a deposit referenced at document level through the same `getOrCreateDepositDiscount()` as one referenced at line level, and creates the deposit line itself — `CIIProtocol` around the `invoiceRefDocs` loop.

## Compatibility

Nothing is needed on the reading side, and nothing changes there. An invoice already issued with the line level `130` keeps its deposit linked: the reader looks the reference up first and links whatever it finds, whatever code it carries. The window the issue asks about closes itself.

PHPUnit, Dolibarr 18 to 25: **256 runs, 256 OK**. `phpcs` clean. No committed fixture moves — none of them carries a deposit line, which is why this went unnoticed.
