### PR TITLE
FIX: [einvoicing] A received 0225 identifier is stored by its shape, not by its scheme

### DIFF
--- a/einvoicing/class/protocols/CommonProtocol.class.php
+++ b/einvoicing/class/protocols/CommonProtocol.class.php
@@ -583,7 +583,7 @@ trait CommonProtocol
 				if (!empty($globalId)) {
 					// Map scheme to idprof field (0002 = SIREN)
 					// TODO Use function idprof() ?
-					$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode);
+					$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode, $globalId);
 					if (!empty($idprofField)) {
 						$result = 0;
 						// Fetch thirdparty by corresponding idprof field
@@ -766,7 +766,7 @@ trait CommonProtocol
 					if (!empty($sellerInfo['sellerGlobalIds']) && is_array($sellerInfo['sellerGlobalIds'])) {
 						foreach ($sellerInfo['sellerGlobalIds'] as $idScheme => $globalId) {
 							if (!empty($globalId)) {
-								$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode);
+								$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode, $globalId);
 								if (!empty($idprofField)) {
 									$thirdparty->$idprofField = removeAllSpaces($globalId);
 								}
@@ -814,7 +814,7 @@ trait CommonProtocol
 					if (!empty($sellerInfo['sellerGlobalIds']) && is_array($sellerInfo['sellerGlobalIds'])) {
 						foreach ($sellerInfo['sellerGlobalIds'] as $idScheme => $globalId) {
 							if (!empty($globalId)) {
-								$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode);
+								$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode, $globalId);
 								if (!empty($idprofField) && empty($thirdparty->$idprofField)) {
 									$thirdparty->$idprofField = removeAllSpaces($globalId);
 								}
@@ -900,7 +900,7 @@ trait CommonProtocol
 			if (!empty($sellerInfo['sellerGlobalIds']) && is_array($sellerInfo['sellerGlobalIds'])) {
 				foreach ($sellerInfo['sellerGlobalIds'] as $idScheme => $globalId) {
 					if (!empty($globalId)) {
-						$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode);
+						$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode, $globalId);
 						if (!empty($idprofField)) {
 							$thirdparty->$idprofField = removeAllSpaces($globalId);
 						}
@@ -962,7 +962,7 @@ trait CommonProtocol
 			if (!empty($sellerInfo['sellerGlobalIds']) && is_array($sellerInfo['sellerGlobalIds'])) {
 				foreach ($sellerInfo['sellerGlobalIds'] as $idScheme => $globalId) {
 					if (!empty($globalId)) {
-						$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode);
+						$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode, $globalId);
 						if (!empty($idprofField)) {
 							$createParams[$idprofField] = $globalId;
 						}
@@ -1016,7 +1016,7 @@ trait CommonProtocol
 			if (!empty($sellerInfo['sellerGlobalIds']) && is_array($sellerInfo['sellerGlobalIds'])) {
 				foreach ($sellerInfo['sellerGlobalIds'] as $idScheme => $globalId) {
 					if (!empty($globalId)) {
-						$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode);
+						$idprofField = $this->_mapGlobalIdSchemeToIdprof($idScheme, $sellerCountryCode, $globalId);
 						if (!empty($idprofField)) {
 							$errorDetails[$idprofField] = $langs->trans($idprofField).': ' . $globalId;
 							$actiondata[$idprofField] = $globalId;
@@ -1410,15 +1410,33 @@ trait CommonProtocol
 	/**
 	 * Map global ID scheme to Dolibarr idprof field
 	 *
+	 * 0002 and 0009 name the register they come from, 0225 does not: it is the French e-invoicing
+	 * ADDRESS scheme, whose value is a SIREN, a SIRET, or either of them suffixed with a routing code
+	 * (rules G1.83, G1.93 and G1.115 of the French specification). Its shape is therefore what decides
+	 * where it is stored, and a suffixed one is stored nowhere: it identifies a mailbox, not a company.
+	 * 0231 (the SIREN of a VAT group) and 0088 (a GLN) are left out on purpose - neither is the
+	 * registration identifier of the party the document names.
+	 *
 	 * @param 	string 	$scheme 		Global ID scheme code
 	 * @param	string	$countrycode	Country code
-	 * @return 	string 					Corresponding idprof field name
+	 * @param	string	$value			Identifier carried under that scheme, read when the scheme alone does not decide
+	 * @return 	string 					Corresponding idprof field name, empty when the identifier is not one
 	 */
-	private function _mapGlobalIdSchemeToIdprof($scheme, $countrycode = '')
+	private function _mapGlobalIdSchemeToIdprof($scheme, $countrycode = '', $value = '')
 	{
+		if ($scheme === '0225') {
+			$digits = preg_replace('/\D/', '', (string) $value);
+			if ($digits !== (string) $value) {
+				return '';
+			}
+			if (dol_strlen($digits) == 9) {
+				return 'idprof1';	// SIREN
+			}
+			return (dol_strlen($digits) == 14) ? 'idprof2' : '';	// SIRET
+		}
+
 		$map = [
 			'0002' => 'idprof1',	// SIREN
-			'0225' => 'idprof1',	// SIREN
 			'0009' => 'idprof2',	// SIRET
 		];
 


### PR DESCRIPTION
## The defect

`_mapGlobalIdSchemeToIdprof()` routed a received identifier on its scheme alone:

```php
$map = [
    '0002' => 'idprof1',    // SIREN
    '0225' => 'idprof1',    // SIREN   <- not always
    '0009' => 'idprof2',    // SIRET
];
```

`0002` and `0009` name the register they come from. **`0225` does not** — it is the French
e-invoicing *address* scheme, and the French specification describes three shapes for its value: a
SIREN (`G1.83`), a SIRET (directory line at establishment level), or either of them suffixed with a
routing code (`G1.93`, `G1.115`).

So a supplier addressed at establishment level was created with a "SIREN" of fourteen characters. The
value is then written by the six paths that read this mapping, including the one that pre-fills the
third party creation form. Dolibarr shows such a record as invalid (`isValidSiren()`), and every later
emission towards that third party fails on `G1.89` / `BR-FR-32`.

The module does not hit this on its own documents — it emits `0225` carrying a SIREN — which is why it
went unnoticed. An issuer following XP Z12-012 does.

## The change

The shape decides, since the scheme does not:

| value under `0225` | stored as |
|---|---|
| 9 digits | `idprof1` (SIREN) |
| 14 digits | `idprof2` (SIRET) |
| suffixed with a routing code, or any other length | nowhere — it identifies a mailbox, not a company |

`0231` (the SIREN of a VAT group) and `0088` (a GLN) stay out of the table on purpose, and the docblock
now says why rather than leaving it to be inferred from their absence: neither is the registration
identifier of the party the document names, and storing a group SIREN as the member's would be worse
than storing nothing.

The six call sites now hand over the value they are already looping on.

## Measured

The routing table walked over ten shapes, on the eight cores of the bench (18.0.10 → 25.0.0-alpha,
PHP 7.4 → 8.5), 8/8 as expected:

```
0002 424761419        -> idprof1   SIREN under its own scheme
0009 42476141900012   -> idprof2   SIRET under its own scheme
0225 424761419        -> idprof1   directory line at legal entity level
0225 42476141900012   -> idprof2   directory line at establishment level
0225 424761419_1939   -> (none)    address suffixed with a routing code
0225 4247614          -> (none)    neither nine nor fourteen digits
0231 424761419        -> (none)    SIREN of the VAT group, not of the member
0088 3401234567890    -> (none)    GLN, no field for it in Dolibarr
0060 123456789        -> (none)    DUNS
```

PHPUnit: 32/32 files green on each of the eight cores (256/256), the import tests included.
