### PR TITLE
TEST: [einvoicing] The rules are given documents that carry real dates

### DIFF
--- a/.github/workflows/module_einvoicing_phpunit.yml
+++ b/.github/workflows/module_einvoicing_phpunit.yml
@@ -231,13 +231,17 @@ jobs:
         if: ${{ matrix.validate == 'yes' }}
         # regenerate_einvoicing_fixtures.php is the script a developer runs after a change that
         # alters the XML on purpose - the same entry point, so this validates what that developer
-        # would be committing. It writes over the reference documents, which is why they are copied
-        # out and restored before anything else reads them.
+        # would be committing. It writes over the reference documents, which is why they are restored
+        # before anything else reads them.
+        # What is validated is the documents BEFORE normalization: that step flattens every
+        # DateTimeString to 20000101 to keep the committed fixtures deterministic, which also makes
+        # BR-FR-CO-07, BR-FR-03 and G1.07 true whatever the document says. Everything else is
+        # identical, so nothing is lost by validating the raw ones.
+        env:
+          EINVOICING_RAW_FIXTURES_DIR: ${{ github.workspace }}/generated
         run: |
           set -euo pipefail
           php einvoicing/scripts/regenerate_einvoicing_fixtures.php
-          mkdir -p generated
-          cp einvoicing/test/phpunit/fixtures/einvoicing_samples/*.xml generated/
           git checkout -- einvoicing/test/phpunit/fixtures/einvoicing_samples/
           count=$(ls generated/*.xml | wc -l)
           if [ "$count" -lt 5 ]; then

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -4035,10 +4035,12 @@ class EInvoicing
 	 * @used-by	regenerate_einvoicing_fixtures.php For fixture generation
 	 * @used-by	EInvoicingSamplesTest.php For comparison and regression testing
 	 *
+	 * @param	array<string,string>	$rawxmls	Filled with the same five documents before normalization,
+	 *												for a caller that hands them to a validator
 	 * @return	array<string, string>	Array with keys 'deposit', 'standard', and 'creditnote',
 	 *                                  each containing normalized XML of the respective invoice type
 	 */
-	public static function generateSampleEInvoicesForTests()
+	public static function generateSampleEInvoicesForTests(&$rawxmls = array())
 	{
 		global $conf, $db, $langs;
 		require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
@@ -4133,6 +4135,18 @@ class EInvoicing
 			$conf->global->TAX_MODE_SELL_SERVICE = $savTaxModeSellService;
 			$langs = $savLangs;
 		}
+
+		// The same documents before normalization, for a caller that validates them: normalization
+		// flattens every date to one value, which makes the date rules of the French socle -
+		// BR-FR-CO-07, BR-FR-03, G1.07 - true whatever the document says. Handed back apart, so the
+		// returned array keeps holding five documents and nothing else.
+		$rawxmls = array(
+			'deposit' => $depositXml,
+			'standard' => $standardXml,
+			'replacement' => $replacementXml,
+			'creditnote' => $creditnoteXml,
+			'situation' => $situationXml,
+		);
 
 		return array(
 			'deposit' => self::normalizeSampleInvoiceXml($depositXml),

--- a/einvoicing/scripts/regenerate_einvoicing_fixtures.php
+++ b/einvoicing/scripts/regenerate_einvoicing_fixtures.php
@@ -113,7 +113,8 @@ $files = array(
 );
 
 try {
-	$xmls = EInvoicing::generateSampleEInvoicesForTests();
+	$rawxmls = array();
+	$xmls = EInvoicing::generateSampleEInvoicesForTests($rawxmls);
 
 	foreach ($files as $key => $path) {
 		$previous = file_exists($path) ? file_get_contents($path) : null;
@@ -122,6 +123,19 @@ try {
 		file_put_contents($path, $xmls[$key]);
 
 		print(($changed ? 'UPDATED' : 'unchanged') . ' : ' . $path . PHP_EOL);
+	}
+
+	// EINVOICING_RAW_FIXTURES_DIR asks for the same documents before normalization, which is what a
+	// validator has to be given: the normalization flattens every date to one value and makes the date
+	// rules of the French socle true whatever the document says. Never committed, their dates move.
+	$rawDir = rtrim((string) getenv('EINVOICING_RAW_FIXTURES_DIR'), '/');
+	if ($rawDir !== '') {
+		dol_mkdir($rawDir);
+		foreach ($files as $key => $path) {
+			$rawPath = $rawDir . '/' . basename($path);
+			file_put_contents($rawPath, $rawxmls[$key]);
+			print('raw : ' . $rawPath . PHP_EOL);
+		}
 	}
 
 	print "Done.\n";


### PR DESCRIPTION
## What the job was actually validating

`normalizeSampleInvoiceXml()` rewrites **every** `DateTimeString` to `20000101`, so the committed
fixtures stay byte-stable across runs and cores. That is the right thing to do for the fixtures — but
the conformance job validated exactly those, and the documents it fed the rules had **one single
distinct date**:

```
distinct dates in the normalized fixture : 1
distinct dates in the document as built  : 2
```

With BT-2 = BT-9 = BT-26 = BT-72, four rules of the French socle were true whatever the document said:

| rule | why it could not bite |
|---|---|
| `BR-FR-CO-07` (**fatal**) — the due date is not before the invoice date | BT-9 = BT-2, the comparison is trivially true |
| `BR-FR-03`, `G1.36` — the year is between 2000 and 2099 | exactly on the lower bound |
| `G1.07` — the date is not in the future | year 2000 always passes |

`BR-FR-CO-07` is the one that matters: it is fatal, the FNFE has just corrected it in 1.4.0.04 for
multiple payment terms groups, and the module has a path where BT-9 is built out of nothing
(`new DateTime(dol_print_date($object->date_lim_reglement, …))` answers "now" when the due date is
empty).

## The change

`generateSampleEInvoicesForTests()` hands the same five documents back **before** normalization,
through a reference parameter — so the array it returns still holds five documents and nothing else,
which the three tests that `foreach` over it rely on. `regenerate_einvoicing_fixtures.php` writes them
where `EINVOICING_RAW_FIXTURES_DIR` asks, and nowhere at all when that variable is not set, so a
developer's run is unchanged.

The job validates those instead of the normalized copies. Everything but the dates is identical
between the two, so nothing is lost. Nothing new is committed: raw documents carry the day they were
generated.

## Measured

On the eight cores of the bench (18.0.10 → 25.0.0-alpha, PHP 7.4 → 8.5):

* the five raw documents are `VALID` on the three stages, `--strict`, with real dates
  (`20260910` for BT-2, `20260911` for BT-9);
* `regenerate_einvoicing_fixtures.php` still reports the five reference documents `unchanged`, with
  and without the new variable;
* PHPUnit 32/32 files on each core (256/256).

And the control that says the coverage really moved — the same document with BT-9 pushed one month
before BT-2:

```
raw_duedate_before.xml                   INVALID   urn:cen.eu:en16931:2017
  ctc-fr  BR-FR-Flux2-Schematron-CII.xslt : 67 check(s), 1 failure(s)
      [BR-FR-CO-07_BT-9] (fatal) La date d'échéance (BT-9), si présente, doit être postérieure
      ou égale à la date de facture (BT-2)…
```

That damage is undetectable on a normalized document, and refused on the ones the job now validates.
