### PR TITLE
NEW [dev] PHPStan on the einvoicing module, next to phan

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -44,6 +44,7 @@
 /test               export-ignore
 /.github            export-ignore
 /.phan              export-ignore
+phpstan.neon.dist   export-ignore
 /.tx                export-ignore
 .buildpath          export-ignore
 .codeclimate.yml    export-ignore

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,116 @@
+---
+# PHPStan on the module code, against the Dolibarr cores the module supports.
+#
+# The core is checked out only so PHPStan knows its classes and functions; nothing of the core is
+# analysed and no database is needed. Running the same analysis on several cores is what catches a
+# call written against a recent core reaching a page an older one still serves.
+#
+# This job does not replace phan.yml: the two tools report different things and both must pass.
+name: phpstan
+
+permissions:
+  contents: read
+
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'einvoicing/**'
+      - '!einvoicing/**.md'
+      - 'dev/tools/phpstan/**'
+      - 'phpstan.neon.dist'
+      - '.github/workflows/phpstan.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'einvoicing/**'
+      - '!einvoicing/**.md'
+      - 'dev/tools/phpstan/**'
+      - 'phpstan.neon.dist'
+      - '.github/workflows/phpstan.yml'
+
+  workflow_dispatch:
+
+concurrency:
+  group: phpstan-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # The version the Dolibarr core runs in its own CI, and the one dev/tools/phpstan/phpstan.sh pins.
+  PHPSTAN_VERSION: 2.1.12
+
+jobs:
+  # Which cores to analyse against. A pull request answers on the two ends of the supported range,
+  # where the drift between core versions shows; what lands on main is analysed on all of them.
+  cores:
+    name: Cores to analyse against
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.pick.outputs.matrix }}
+    steps:
+      - id: pick
+        run: |
+          all='["18.0.0","19.0.0","20.0.0","21.0.0","22.0.0","23.0.0","24.0.0"]'
+          review='["18.0.0","24.0.0"]'
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "matrix=$review" >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix=$all" >> "$GITHUB_OUTPUT"
+          fi
+
+  phpstan:
+    name: PHPStan on Dolibarr ${{ matrix.dolibarr }}
+    needs: cores
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dolibarr: ${{ fromJSON(needs.cores.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Checkout Dolibarr ${{ matrix.dolibarr }}
+        uses: actions/checkout@v6
+        with:
+          repository: Dolibarr/dolibarr
+          ref: ${{ matrix.dolibarr }}
+          path: dolibarr
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          # PHPStan runs on one PHP and is told which range to analyse for by phpstan.neon.dist,
+          # so the PHP of the job has nothing to do with the PHP of the core.
+          php-version: '8.3'
+          coverage: none # disable xdebug, pcov
+          tools: cs2pr:1.8.6
+          extensions: mbstring, intl, dom, simplexml, zip, curl
+
+      # The pinned phar and the analysis cache. The cache is per core: PHPStan stores what it read
+      # of the checkout it was pointed at.
+      - name: Restore the PHPStan cache
+        uses: actions/cache@v4
+        with:
+          path: .run-phpstan
+          key: phpstan-${{ env.PHPSTAN_VERSION }}-${{ matrix.dolibarr }}-${{ github.sha }}
+          restore-keys: |
+            phpstan-${{ env.PHPSTAN_VERSION }}-${{ matrix.dolibarr }}-
+
+      - name: Run PHPStan
+        env:
+          DOLIBARR_HTDOCS: ${{ github.workspace }}/dolibarr/htdocs
+        run: |
+          ./dev/tools/phpstan/phpstan.sh --no-progress --error-format=checkstyle -o _phpstan.xml
+
+      - name: Add results to PR
+        if: ${{ always() }}
+        run: cs2pr --prepend-filename --prepend-source --graceful-warnings _phpstan.xml
+
+      - name: Provide the PHPStan report as artifact
+        uses: actions/upload-artifact@v7
+        if: ${{ always() }}
+        with:
+          name: phpstan-${{ matrix.dolibarr }}
+          path: ${{ github.workspace }}/_phpstan.xml
+          retention-days: 2

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -101,7 +101,9 @@ jobs:
         env:
           DOLIBARR_HTDOCS: ${{ github.workspace }}/dolibarr/htdocs
         run: |
-          ./dev/tools/phpstan/phpstan.sh --no-progress --error-format=checkstyle -o _phpstan.xml
+          # PHPStan writes its report on stdout; the progress and the banner of the runner script
+          # go to stderr, so the redirection carries the checkstyle document alone.
+          ./dev/tools/phpstan/phpstan.sh --no-progress --error-format=checkstyle > _phpstan.xml
 
       - name: Add results to PR
         if: ${{ always() }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 # ignore .htaccess files
 .htaccess
 /.run-phpstan
+# Local PHPStan overrides; phpstan.neon.dist is the one that is versioned
+/phpstan.neon
 
 # Mistral Vibe
 .vibe

--- a/dev/tools/phan/config.php
+++ b/dev/tools/phan/config.php
@@ -13,7 +13,9 @@ define('PHAN_DIR', __DIR__);
 function directory_list()
 {
 	$baseDir = __DIR__ . '/../../..';
-	$excluded = ['tests', '.github', 'dev', '.git'];
+	// .run-phpstan holds the PHPStan phar and its cache, which is made of generated PHP files.
+	// The directory is git ignored, so it only ever exists on a developer machine.
+	$excluded = ['tests', '.github', 'dev', '.git', '.run-phpstan'];
 	$directories = array_filter(scandir($baseDir), function ($dir) use ($baseDir, $excluded) {
 		return is_dir($baseDir . '/' . $dir) && !in_array($dir, $excluded) && $dir !== '.' && $dir !== '..';
 	});

--- a/dev/tools/phpstan/README.md
+++ b/dev/tools/phpstan/README.md
@@ -1,0 +1,108 @@
+# PHPStan
+
+PHPStan analyses the module code of this repository. It does not replace [phan](../phan/README.md),
+which stays the check the `dolibarr-community-modules` ecosystem expects: the two tools report
+different things and both have to pass.
+
+## What it analyses, and against what
+
+Only the module is analysed. The Dolibarr core is **indexed, not analysed**: `scanDirectories` in
+`../../../phpstan.neon.dist` points at a core checkout so PHPStan knows its classes, methods,
+properties and functions, and reports nothing about them.
+
+Which checkout does not matter for correctness, but it does matter for what is found: the module
+supports Dolibarr 18 to 24, whose cores do not offer the same API. Analysing against several of
+them is what catches a call written for a recent core on a page an older one still serves —
+`recordNotFound()`, which arrived in Dolibarr 20, was found that way.
+
+`bootstrap.php` defines the handful of constants (`DOL_DOCUMENT_ROOT` and friends) that a module
+resolves its `require_once` against. It deliberately does not load `master.inc.php` or
+`main.inc.php`: those open a database, start a session and read a `conf.php` that does not exist
+here, and PHPStan needs none of it to know the symbols.
+
+`DOL_VERSION` is left undefined on purpose, and listed in `dynamicConstantNames`. A module that
+supports seven cores guards its calls with version tests; pinning the constant to the version of
+the checkout under analysis would let PHPStan call every one of those guards dead code.
+
+## Running it
+
+```bash
+# with a core checkout in one of the usual places (../dolibarr, ~/git/dolibarr)
+dev/tools/phpstan/phpstan.sh
+
+# or say where it is
+DOLIBARR_HTDOCS=/path/to/dolibarr/htdocs dev/tools/phpstan/phpstan.sh
+
+# one file, or any other PHPStan argument
+dev/tools/phpstan/phpstan.sh einvoicing/class/document.class.php
+```
+
+The script pins PHPStan 2.1.12, the version the Dolibarr core runs in its own CI, and caches the
+phar and the analysis cache in `.run-phpstan/`, which git ignores. Nothing to install.
+
+## Level: the posture of the core, copied
+
+`phpstan.neon.dist` carries the settings block of the core's own `phpstan.neon.dist`, as is: level
+10, `customRulesetUsed: true`, and the families of checks the hand written PHPDoc of Dolibarr cannot
+honour turned off - `checkNullables`, `checkUnionTypes`, `reportMaybes`, `treatPhpDocTypesAsCertain`
+and the rest. Reading that as a plain level 10 would be wrong; reading it as lax would be wrong too.
+Measured on this module, against Dolibarr 24:
+
+| posture | reports |
+| --- | --- |
+| strict level 5 | 295 |
+| **the core's block, level 10** | **352** |
+| strict level 6 | 450 |
+
+Two reasons for taking the core's dials rather than picking our own. A contributor who knows the CI
+of Dolibarr finds here exactly what he knows. And what the core judges worth reporting is what is
+reported here, no more and no less - the argument holds by itself in review.
+
+## The two baselines
+
+`phpstan.neon.dist` loads both, always:
+
+| file | what it holds |
+| --- | --- |
+| `baseline.neon` | what the newest supported core reports (299 entries) |
+| `baseline-legacy.neon` | what the older cores add on top of that (350 entries) |
+
+For scale: the core carries 1 527 entries for its own 1,4 million lines.
+
+Together they make every core of the matrix green, so a new error on any of them is reported. They
+are the entry price of introducing the tool on an existing code base, not a place to park new
+findings: **an error a change introduces is fixed, or documented where it happens with a
+`@phpstan-ignore` carrying the reason — never by a line added to a baseline.** That is the same
+rule the phan baseline follows.
+
+Refresh them after a batch of fixes lands, never inside one — two branches editing a baseline
+conflict on every line:
+
+```bash
+DOLIBARR_GIT=~/git/dolibarr dev/tools/phpstan/refresh-baseline.sh
+```
+
+## What is ignored, and why
+
+Everything in `ignoreErrors` in `phpstan.neon.dist` carries its reason next to it. In short:
+
+- the `main.inc.php` / `master.inc.php` ladder every external module page and script opens with: it
+  resolves at runtime from inside an instance, never from this repository;
+- the string expressions phan reads its inline type assertions from;
+- `ActionsMulticompany` and `DaoMulticompany`, of the separate non free Multicompany module, reached
+  only behind `isModEnabled('multicompany')`;
+- the private and protected calls in `lib/buildinvoicelines.inc.php`, which is included from inside
+  a method and runs with that `$this` — phan is told the same thing by the `@phan-file-suppress`
+  the file already carries;
+- the core file of a version gate whose other branch is the module's own backport;
+- the case of the TCPDF setters, which the bundled library renamed between Dolibarr 18 and 24, so
+  no spelling satisfies both.
+
+Where a type can be written instead, it is written: each `'@phan-var-force X $y'` assertion the
+module already carried now has a `/** @var X $y */` next to it, which is the form PHPStan reads.
+
+## CI
+
+`.github/workflows/phpstan.yml`. A pull request is analysed against the two ends of the supported
+range, what lands on `main` against all seven cores. No database, no instance: a checkout of the
+core and the phar.

--- a/dev/tools/phpstan/baseline-legacy.neon
+++ b/dev/tools/phpstan/baseline-legacy.neon
@@ -1,0 +1,2096 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Function llxHeader invoked with 10 parameters, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/admin/about.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/admin\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/admin/about.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/functions2\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/admin/about.php
+
+		-
+			message: '#^Function llxHeader invoked with 10 parameters, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/admin/setup.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/class/html\.formsetup\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/admin/setup.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/admin\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/admin/setup.php
+
+		-
+			message: '#^Function llxHeader invoked with 10 parameters, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/admin/setup_devtools.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_setmoduleoptions\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/admin/setup_devtools.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./compta/facture/class/facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/admin/setup_devtools.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/class/html\.formsetup\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/admin/setup_devtools.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/admin\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/admin/setup_devtools.php
+
+		-
+			message: '#^Function llxHeader invoked with 10 parameters, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/admin/setup_options.php
+
+		-
+			message: '#^Parameter \#3 \$value of function dolibarr_set_const expects string, int given\.$#'
+			identifier: argument.type
+			count: 2
+			path: ../../../einvoicing/admin/setup_options.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_setmoduleoptions\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/admin/setup_options.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/class/html\.formsetup\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/admin/setup_options.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/admin\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/admin/setup_options.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./compta/facture/class/facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/ajax/checkdirectory.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./compta/facture/class/facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/ajax/checkinvoicestatus.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./fourn/class/fournisseur\.facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/ajax/checksupplierinvoicestatus.php
+
+		-
+			message: '#^Function llxHeader invoked with 10 parameters, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/call_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_addupdatedelete\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_builddoc\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_dellink\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_fetchobject\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_printing\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_sendmails\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/card_presend\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/commonfields_add\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/commonfields_edit\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/commonfields_view\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/extrafields_add\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/extrafields_edit\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/extrafields_view\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_card.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/class/html\.formcompany\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_card.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/class/html\.formfile\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_card.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/class/html\.formprojet\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_card.php
+
+		-
+			message: '#^Property Call\:\:\$entity \(int\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/call_card.php
+
+		-
+			message: '#^Function llxHeader invoked with 10 parameters, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Parameter \#11 \$disablesortlink of function getTitleFieldOfList expects string, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_changeselectedfields\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_massactions\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/extrafields_list_array_fields\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/extrafields_list_print_fields\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/extrafields_list_search_input\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/extrafields_list_search_param\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/extrafields_list_search_sql\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/extrafields_list_search_title\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/list_print_total\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/massactions_pre\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/class/html\.formcompany\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/lib/company\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/lib/date\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/class/html\.formadmin\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/class/html\.formfile\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Parameter \#3 \$newmask of function dol_move expects int, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/actions_einvoicing.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./compta/facture/class/facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/actions_einvoicing.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./fourn/class/fournisseur\.facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/actions_einvoicing.class.php
+
+		-
+			message: '#^Property Societe\:\:\$name \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/class/actions_einvoicing.class.php
+
+		-
+			message: '#^Method CommonObject\:\:fetchCommon\(\) invoked with 4 parameters, 1\-3 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Method CommonObject\:\:fetchLinesCommon\(\) invoked with 2 parameters, 0\-1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^PHPDoc type int\<0, 1\>\|string of property Call\:\:\$ismultientitymanaged is not covariant with PHPDoc type int of overridden property CommonObject\:\:\$ismultientitymanaged\.$#'
+			identifier: property.phpDocType
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^PHPDoc type int\<0, 1\>\|string\|null of property CallLine\:\:\$ismultientitymanaged is not covariant with PHPDoc type int of overridden property CommonObject\:\:\$ismultientitymanaged\.$#'
+			identifier: property.phpDocType
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Parameter \#1 \$db of function dol_print_error expects DoliDB\|string, null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Parameter \#2 \$notrigger of method CommonObject\:\:createCommon\(\) expects bool, int\<0, 1\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Parameter \#2 \$notrigger of method CommonObject\:\:deleteCommon\(\) expects bool, int\<0, 1\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Parameter \#2 \$notrigger of method CommonObject\:\:updateCommon\(\) expects bool, int\<0, 1\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Parameter \#3 \$notrigger of method CommonObject\:\:deleteLineCommon\(\) expects bool, int\<0, 1\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/class/commonobject\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/class/commonobjectline\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/files\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 2
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$fields type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$fk_user_creat has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$fk_user_modif has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$status \(int\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$tms has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property CallLine\:\:\$fk_parent_attribute has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property CallLine\:\:\$parent_element has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property CommonObject\:\:\$date_modification \(int\|string\) does not accept null\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property CommonObject\:\:\$oldref \(CommonObject\) does not accept string\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Method CommonObject\:\:fetchCommon\(\) invoked with 4 parameters, 1\-3 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Method CommonObject\:\:fetchLinesCommon\(\) invoked with 2 parameters, 0\-1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^PHPDoc type int\<0, 1\>\|string of property Document\:\:\$ismultientitymanaged is not covariant with PHPDoc type int of overridden property CommonObject\:\:\$ismultientitymanaged\.$#'
+			identifier: property.phpDocType
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^PHPDoc type int\<0, 1\>\|string\|null of property DocumentLine\:\:\$ismultientitymanaged is not covariant with PHPDoc type int of overridden property CommonObject\:\:\$ismultientitymanaged\.$#'
+			identifier: property.phpDocType
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Parameter \#1 \$db of function dol_print_error expects DoliDB\|string, null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Parameter \#2 \$notrigger of method CommonObject\:\:createCommon\(\) expects bool, int\<0, 1\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Parameter \#2 \$notrigger of method CommonObject\:\:deleteCommon\(\) expects bool, int\<0, 1\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Parameter \#2 \$notrigger of method CommonObject\:\:updateCommon\(\) expects bool, int\<0, 1\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Parameter \#3 \$notrigger of method CommonObject\:\:deleteLineCommon\(\) expects bool, int\<0, 1\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/class/commonobject\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/class/commonobjectline\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/files\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 3
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./fourn/class/fournisseur\.facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property CommonObject\:\:\$date_modification \(int\|string\) does not accept null\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property CommonObject\:\:\$oldref \(CommonObject\) does not accept string\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$fields type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$fk_user_creat has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$fk_user_modif has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$status \(int\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$tms has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property DocumentLine\:\:\$fk_parent_attribute has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property DocumentLine\:\:\$parent_element has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Function getURLContent invoked with 12 parameters, 1\-8 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/class/einvoicing.class.php
+
+		-
+			message: '#^Parameter \#1 \$stringtoescape of function dol_escape_js expects string, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/einvoicing.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./compta/facture/class/facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/einvoicing.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/files\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/einvoicing.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/geturl\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/einvoicing.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./societe/class/societe\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 2
+			path: ../../../einvoicing/class/einvoicing.class.php
+
+		-
+			message: '#^Property CommonObject\:\:\$thirdparty \(Societe\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 5
+			path: ../../../einvoicing/class/einvoicing.class.php
+
+		-
+			message: '#^Property FactureLigne\:\:\$desc \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/class/einvoicing.class.php
+
+		-
+			message: '#^Property Societe\:\:\$town \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/class/einvoicing.class.php
+
+		-
+			message: '#^Property Societe\:\:\$zip \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/class/einvoicing.class.php
+
+		-
+			message: '#^Parameter \#3 \$newmask of function dol_copy expects int, string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: ../../../einvoicing/class/protocols/AbstractProtocol.class.php
+
+		-
+			message: '#^Property CommonObject\:\:\$total_ttc \(float\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/class/protocols/AbstractProtocol.class.php
+
+		-
+			message: '#^Call to function method_exists\(\) with Societe and ''findNearest'' will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Function dol_move invoked with 7 parameters, 2\-6 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:_syncOrCreateThirdpartyFromEInvoiceSeller\(\) should return array\{res\: int, message\: string, actioncode\: string\|null, actionurl\: string\|null, action\: string\|null\} but returns array\{res\: mixed, message\: non\-falsy\-string\}\.$#'
+			identifier: return.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Parameter \#1 \$vatrate of method CIIProtocol\:\:checkIfVatRateIsValid\(\) expects string, float given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Parameter \#11 \$seller of function calcul_price_total expects Societe, null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Parameter \#3 \$newmask of function dol_move expects int, string given\.$#'
+			identifier: argument.type
+			count: 4
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./blockedlog/lib/blockedlog\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/lib/price\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./commande/class/commande\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./compta/bank/class/account\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./compta/facture/class/facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 2
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./contact/class/contact\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/class/discount\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/class/extrafields\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/class/translate\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/company\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/date\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/files\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 2
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/pdf\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./expedition/class/expedition\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./fourn/class/fournisseur\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./fourn/class/fournisseur\.commande\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./fourn/class/fournisseur\.facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 2
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./fourn/class/fournisseur\.product\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./product/class/product\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./societe/class/societe\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 2
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Property CommonObject\:\:\$multicurrency_tx \(string\) does not accept int\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Property CommonObject\:\:\$thirdparty \(Societe\) in empty\(\) is not falsy\.$#'
+			identifier: empty.property
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Call to function method_exists\(\) with Societe and ''findNearest'' will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Method FacturXProtocol\:\:_syncOrCreateThirdpartyFromEInvoiceSeller\(\) should return array\{res\: int, message\: string, actioncode\: string\|null, actionurl\: string\|null, action\: string\|null\} but returns array\{res\: mixed, message\: non\-falsy\-string\}\.$#'
+			identifier: return.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Parameter \#1 \$vatrate of method FacturXProtocol\:\:checkIfVatRateIsValid\(\) expects string, float given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Parameter \#11 \$seller of function calcul_price_total expects Societe, null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Parameter \#3 \$newmask of function dol_move expects int, string given\.$#'
+			identifier: argument.type
+			count: 3
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Parameter \#5 \$excludefilter of function dol_dir_list expects array\|null, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Parameter \#7 \$sortorder of function dol_dir_list expects string, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/lib/price\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./compta/facture/class/facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 2
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./contact/class/contact\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/class/extrafields\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/company\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/files\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/pdf\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 2
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./fourn/class/fournisseur\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./fourn/class/fournisseur\.commande\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./fourn/class/fournisseur\.facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./fourn/class/fournisseur\.product\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./societe/class/societe\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 2
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Property CommonObject\:\:\$multicurrency_tx \(string\) does not accept int\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Property CommonObject\:\:\$thirdparty \(Societe\) in empty\(\) is not falsy\.$#'
+			identifier: empty.property
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Parameter \#3 \$value of function dolibarr_set_const expects string, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/providers/AbstractPDPProvider.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./comm/action/class/actioncomm\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/providers/AbstractPDPProvider.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/admin\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 2
+			path: ../../../einvoicing/class/providers/AbstractPDPProvider.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./fourn/class/fournisseur\.facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/providers/AbstractPDPProvider.class.php
+
+		-
+			message: '#^Function getURLContent invoked with 12 parameters, 1\-8 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/class/providers/EsalinkPDPProvider.class.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./compta/facture/class/facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/providers/EsalinkPDPProvider.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./compta/facture/class/facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 3
+			path: ../../../einvoicing/class/providers/EsalinkPDPProvider.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/class/html\.form\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/providers/EsalinkPDPProvider.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/admin\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/providers/EsalinkPDPProvider.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/geturl\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/providers/EsalinkPDPProvider.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./fourn/class/fournisseur\.facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/providers/EsalinkPDPProvider.class.php
+
+		-
+			message: '#^Property CommonObject\:\:\$entity \(int\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/class/providers/EsalinkPDPProvider.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/class/hookmanager\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/providers/PDPProviderManager.class.php
+
+		-
+			message: '#^Function getURLContent invoked with 12 parameters, 1\-8 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./compta/facture/class/facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/lib/admin\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./compta/facture/class/facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 3
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/class/html\.form\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/admin\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/geturl\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 2
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./fourn/class/fournisseur\.facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Property CommonObject\:\:\$entity \(int\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/files\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/utils/FacturxTcpdfMerger.class.php
+
+		-
+			message: '#^Parameter \#1 \$qty of function calcul_price_total expects int, float given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/utils/PriceHelper.class.php
+
+		-
+			message: '#^Parameter \#13 \$progress of function calcul_price_total expects int, float given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/utils/PriceHelper.class.php
+
+		-
+			message: '#^Parameter \#12 \$localtaxes_array of static method PriceHelper\:\:calculatePriceTotal\(\) expects array\{string, int\|string, string, int\|string, string, string\}\|array\{string, int\|string, string, string\}, array\{float, float, float, float\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/utils/SupplierInvoiceHelper.class.php
+
+		-
+			message: '#^Property FactureFournisseur\:\:\$multicurrency_code \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/class/utils/SupplierInvoiceHelper.class.php
+
+		-
+			message: '#^Property SupplierInvoiceLine\:\:\$situation_percent \(int\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/class/utils/SupplierInvoiceHelper.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/files\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/class/utils/SupportExport.class.php
+
+		-
+			message: '#^Access to an undefined property modEInvoicing\:\:\$editor_squarred_logo\.$#'
+			identifier: property.notFound
+			count: 1
+			path: ../../../einvoicing/core/modules/modEInvoicing.class.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/class/extrafields\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/core/modules/modEInvoicing.class.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/modules/DolibarrModules\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/core/modules/modEInvoicing.class.php
+
+		-
+			message: '#^Property DolibarrModules\:\:\$depends \(array\<string\>\) does not accept array\<string, array\<int, string\>\>\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: ../../../einvoicing/core/modules/modEInvoicing.class.php
+
+		-
+			message: '#^Property DolibarrModules\:\:\$hidden \(bool\) does not accept int\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: ../../../einvoicing/core/modules/modEInvoicing.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./compta/facture/class/facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/triggers/dolibarrtriggers\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
+
+		-
+			message: '#^Function llxHeader invoked with 10 parameters, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/document_agenda.php
+
+		-
+			message: '#^Parameter \#5 \$objcon of function show_actions_done expects Contact, null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/document_agenda.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_fetchobject\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_agenda.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./contact/class/contact\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_agenda.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/lib/company\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_agenda.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/lib/functions2\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_agenda.php
+
+		-
+			message: '#^Function llxHeader invoked with 10 parameters, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_addupdatedelete\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_builddoc\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_dellink\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_fetchobject\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_printing\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_sendmails\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/ajaxrow\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/card_presend\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/commonfields_add\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/commonfields_edit\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/commonfields_view\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/extrafields_add\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/extrafields_edit\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/extrafields_view\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/class/html\.formactions\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/class/html\.formcompany\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/class/html\.formfile\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/class/html\.formprojet\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/lib/files\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Property Document\:\:\$entity \(int\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Property Document\:\:\$status \(int\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Function llxHeader invoked with 10 parameters, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/document_contact.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_fetchobject\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_contact.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./contact/class/contact\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_contact.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/class/html\.formcompany\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_contact.php
+
+		-
+			message: '#^Function llxHeader invoked with 10 parameters, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/document_document.php
+
+		-
+			message: '#^Parameter \#5 \$excludefilter of function dol_dir_list expects array\|null, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/document_document.php
+
+		-
+			message: '#^Parameter \#7 \$sortorder of function dol_dir_list expects string, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/document_document.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_fetchobject\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_document.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_linkedfiles\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_document.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/document_actions_post_headers\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_document.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/class/html\.formfile\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_document.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/lib/company\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_document.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/lib/files\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_document.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/lib/images\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_document.php
+
+		-
+			message: '#^Function info_admin invoked with 7 parameters, 1\-6 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Function llxHeader invoked with 10 parameters, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Parameter \#11 \$disablesortlink of function getTitleFieldOfList expects string, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_changeselectedfields\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_massactions\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/extrafields_list_array_fields\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/extrafields_list_print_fields\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/extrafields_list_search_input\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/extrafields_list_search_param\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/extrafields_list_search_sql\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/extrafields_list_search_title\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/list_print_total\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/massactions_pre\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/class/html\.form\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/class/html\.formcompany\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/lib/company\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/lib/date\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./compta/facture/class/facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/class/html\.formadmin\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/class/html\.formfile\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./fourn/class/fournisseur\.facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./societe/class/societe\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Function llxHeader invoked with 10 parameters, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/document_note.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_fetchobject\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_note.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/actions_setnotes\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_note.php
+
+		-
+			message: '#^Path in include\(\) "\.\./core/tpl/notes\.tpl\.php" is not a file or it does not exist\.$#'
+			identifier: include.fileNotFound
+			count: 1
+			path: ../../../einvoicing/document_note.php
+
+		-
+			message: '#^Function llxHeader invoked with 2 parameters, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/einvoice_tracking.php
+
+		-
+			message: '#^Function recordNotFound not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: ../../../einvoicing/einvoice_tracking.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./compta/facture/class/facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/einvoice_tracking.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/invoice\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/einvoice_tracking.php
+
+		-
+			message: '#^Function llxHeader invoked with 10 parameters, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/einvoicingindex.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/class/html\.formfile\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/einvoicingindex.php
+
+		-
+			message: '#^Parameter \#1 \$qty of function calcul_price_total expects int, float given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./compta/facture/class/facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./contact/class/contact\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 2
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/price\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./expedition/class/expedition\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./societe/class/societe\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property CommonObject\:\:\$country_code \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property CommonObject\:\:\$user \(User\) does not accept null\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property Facture\:\:\$ref_customer \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property Facture\:\:\$total_ht \(float\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property FactureLigne\:\:\$remise_percent \(float\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 2
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property FactureLigne\:\:\$situation_percent \(int\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property Societe\:\:\$address \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property Societe\:\:\$default_lang \(string\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property Societe\:\:\$name_alias \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property Societe\:\:\$town \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property Societe\:\:\$tva_intra \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 2
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property Societe\:\:\$zip \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Function getMultidirOutput invoked with 4 parameters, 1\-2 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/lib/einvoicing.lib.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./compta/facture/class/facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/lib/einvoicing.lib.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./societe/class/societe\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/lib/einvoicing.lib.php
+
+		-
+			message: '#^Property Societe\:\:\$idprof1 \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/lib/einvoicing.lib.php
+
+		-
+			message: '#^Property Societe\:\:\$tva_intra \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/lib/einvoicing.lib.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/files\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/lib/einvoicing_call.lib.php
+
+		-
+			message: '#^Parameter \#5 \$excludefilter of function dol_dir_list expects array\|null, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/lib/einvoicing_document.lib.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/class/link\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/lib/einvoicing_document.lib.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/files\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/lib/einvoicing_document.lib.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./fourn/class/fournisseur\.product\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/lib/einvoicing_vendorref.lib.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./societe/class/societe\.class\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/lib/einvoicing_vendorref.lib.php
+
+		-
+			message: '#^Function llxHeader invoked with 10 parameters, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/product_mapping.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/class/html\.form\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/product_mapping.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./fourn/class/fournisseur\.product\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/product_mapping.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./product/class/product\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/product_mapping.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./societe/class/societe\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/product_mapping.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/public/proxy_oauthcallback.php
+
+		-
+			message: '#^Path in require_once\(\) "\.\./core/lib/geturl\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/public/proxy_oauthcallback.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/lib/company\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/scripts/testconnect.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/lib/date\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/scripts/testconnect.php
+
+		-
+			message: '#^Function llxHeader invoked with 10 parameters, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/vendorref_list.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/class/html\.form\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/vendorref_list.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./core/lib/date\.lib\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/vendorref_list.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./fourn/class/fournisseur\.product\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/vendorref_list.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./product/class/product\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/vendorref_list.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./societe/class/societe\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/vendorref_list.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./user/class/user\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/vendorref_list.php
+
+		-
+			message: '#^Function llxHeader invoked with 10 parameters, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/xmlpreview.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./compta/facture/class/facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/xmlpreview.php
+
+		-
+			message: '#^Path in include_once\(\) "\.\./fourn/class/fournisseur\.facture\.class\.php" is not a file or it does not exist\.$#'
+			identifier: includeOnce.fileNotFound
+			count: 1
+			path: ../../../einvoicing/xmlpreview.php
+		-
+			message: '#^Parameter \#7 \$moreinfo of function dol_move expects int, array\<string, int\|string\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Property CommonObject\:\:\$multicurrency_code \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/class/utils/SupplierInvoiceHelper.class.php
+		-
+			message: '#^Parameter \#4 \$url of function dolGetButtonAction expects array\<int, array\{lang\: string, enabled\: bool, perm\: bool, label\: string, url\: string\}\>\|string, array\{0\: array\{lang\: ''einvoicing'', enabled\: true, perm\: \-1\|bool, label\: mixed, text\?\: mixed, url\: non\-falsy\-string\}, 1\?\: array\{lang\: ''einvoicing'', enabled\: 1\|true, perm\: \-1\|bool, label\: mixed, text\?\: mixed, url\: non\-falsy\-string\}, 2\?\: array\{lang\: ''einvoicing'', enabled\: 1, perm\: \-1\|bool, label\: mixed, text\: mixed, url\: non\-falsy\-string\}\|array\{lang\: ''einvoicing'', enabled\: true, perm\: bool, label\: mixed, url\: non\-falsy\-string\}, 3\?\: array\{lang\: ''einvoicing'', enabled\: 1, perm\: \-1\|bool, label\: mixed, text\: mixed, url\: non\-falsy\-string\}\} given\.$#'
+			identifier: argument.type
+			count: 2
+			path: ../../../einvoicing/class/actions_einvoicing.class.php
+
+		-
+			message: '#^PHPDoc type int\<0, 1\>\|string\|null of property CallLine\:\:\$ismultientitymanaged is not covariant with PHPDoc type int\<0, 1\>\|string of overridden property CommonObject\:\:\$ismultientitymanaged\.$#'
+			identifier: property.phpDocType
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$status \(array\<int, string\>\|int\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^PHPDoc type int\<0, 1\>\|string\|null of property DocumentLine\:\:\$ismultientitymanaged is not covariant with PHPDoc type int\<0, 1\>\|string of overridden property CommonObject\:\:\$ismultientitymanaged\.$#'
+			identifier: property.phpDocType
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$status \(array\<int, string\>\|int\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Parameter \#11 \$seller of function calcul_price_total expects Societe\|string, null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Parameter \#11 \$seller of function calcul_price_total expects Societe\|string, null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Property Document\:\:\$status \(array\<int, string\>\|int\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/document_card.php
+		-
+			message: '#^Parameter \#4 \$url of function dolGetButtonAction expects array\<int, array\{lang\: string, enabled\: bool, perm\: bool, label\: string, url\: string, urlroot\?\: string, isDropDown\?\: int\<0, 1\>\}\>\|string, array\{0\: array\{lang\: ''einvoicing'', enabled\: true, perm\: \-1\|bool, label\: mixed, text\?\: mixed, url\: non\-falsy\-string\}, 1\?\: array\{lang\: ''einvoicing'', enabled\: 1\|true, perm\: \-1\|bool, label\: mixed, text\?\: mixed, url\: non\-falsy\-string\}, 2\?\: array\{lang\: ''einvoicing'', enabled\: 1, perm\: \-1\|bool, label\: mixed, text\: mixed, url\: non\-falsy\-string\}\|array\{lang\: ''einvoicing'', enabled\: true, perm\: bool, label\: mixed, url\: non\-falsy\-string\}, 3\?\: array\{lang\: ''einvoicing'', enabled\: 1, perm\: \-1\|bool, label\: mixed, text\: mixed, url\: non\-falsy\-string\}\} given\.$#'
+			identifier: argument.type
+			count: 2
+			path: ../../../einvoicing/class/actions_einvoicing.class.php
+
+		-
+			message: '#^Property Call\:\:\$fields \(array\<string, array\{type\: string, label\: string, enabled\: int\<0, 2\>\|string, position\: int, notnull\?\: int, visible\: int\<\-6, 5\>\|string, alwayseditable\?\: int\<0, 1\>, noteditable\?\: int\<0, 1\>, \.\.\.\}\>\) does not accept default value of type array\{rowid\: array\{type\: ''integer'', label\: ''TechnicalID'', enabled\: ''1'', position\: 1, notnull\: 1, visible\: ''1'', noteditable\: ''1'', index\: ''1'', \.\.\.\}, call_id\: array\{type\: ''varchar\(50\)'', label\: ''Ref'', enabled\: ''1'', position\: 10, notnull\: 1, visible\: ''1'', index\: ''1'', csslist\: ''tdoverflowmax150''\}, provider\: array\{type\: ''varchar\(50\)'', label\: ''provider'', enabled\: ''1'', position\: 20, notnull\: 1, visible\: ''1'', comment\: ''PDP Name''\}, call_type\: array\{type\: ''varchar\(50\)'', label\: ''Type'', enabled\: ''1'', position\: 25, notnull\: 1, visible\: ''1'', comment\: ''Call type \(SyncDocs…'', csslist\: ''tdoverflowmax125''\}, method\: array\{type\: ''varchar\(10\)'', label\: ''Method'', enabled\: ''1'', position\: 30, notnull\: 0, visible\: ''1'', comment\: ''\-\- HTTP method \(GET…''\}, endpoint\: array\{type\: ''varchar\(255\)'', label\: ''Endpoint'', enabled\: ''1'', position\: 35, notnull\: 1, visible\: ''\-1'', comment\: ''\-\- URL or endpoint…''\}, request_id\: array\{type\: ''varchar\(36\)'', label\: ''RequestId'', langs\: ''einvoicing…'', enabled\: ''1'', position\: 36, notnull\: 0, visible\: ''\-1'', comment\: ''\-\- Request\-Id…''\}, skippedflow\: array\{type\: ''integer'', label\: ''SkippedFlows'', enabled\: ''1'', position\: 130, notnull\: 1, visible\: ''1'', comment\: ''Skipped flows…''\}, \.\.\.\}\.$#'
+			identifier: property.defaultValue
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Document\:\:\$fields \(array\<string, array\{type\: string, label\: string, enabled\: int\<0, 2\>\|string, position\: int, notnull\?\: int, visible\: int\<\-6, 5\>\|string, alwayseditable\?\: int\<0, 1\>, noteditable\?\: int\<0, 1\>, \.\.\.\}\>\) does not accept default value of type array\{rowid\: array\{type\: ''integer'', label\: ''ID'', enabled\: ''1'', position\: 1, notnull\: 1, visible\: ''1'', noteditable\: ''1'', index\: ''1'', \.\.\.\}, provider\: array\{type\: ''varchar\(50\)'', label\: ''AccessPoint'', langfile\: ''einvoicing…'', enabled\: ''1'', position\: 5, notnull\: 1, visible\: ''\-1'', comment\: ''EInvoice Platform…''\}, flow_id\: array\{type\: ''varchar\(255\)'', label\: ''flow_id'', enabled\: ''1'', position\: 10, notnull\: 0, visible\: ''1'', comment\: ''EInvoice flow UUID'', csslist\: ''tdoverflowmax100''\}, call_id\: array\{type\: ''varchar\(50\)'', label\: ''TransactionID'', enabled\: ''1'', position\: 20, notnull\: 0, visible\: ''1'', comment\: ''Reference to the…'', csslist\: ''tdoverflowmax100''\}, flow_type\: array\{type\: ''varchar\(255\)'', label\: ''flow_type'', enabled\: ''1'', position\: 40, notnull\: 0, visible\: ''1'', comment\: ''Flow type \(\\''sync\\'', …''\}, flow_direction\: array\{type\: ''varchar\(10\)'', label\: ''flow_direction'', enabled\: ''1'', position\: 50, notnull\: 0, visible\: ''1'', comment\: ''In or Out'', csslist\: ''center''\}, flow_syntax\: array\{type\: ''varchar\(50\)'', label\: ''flow_syntax'', enabled\: ''1'', position\: 60, notnull\: 0, visible\: ''\-1'', comment\: ''Document syntax …''\}, flow_profile\: array\{type\: ''varchar\(50\)'', label\: ''flow_profile'', enabled\: ''1'', position\: 70, notnull\: 0, visible\: ''\-1'', comment\: ''Profile used \(Basic…''\}, \.\.\.\}\.$#'
+			identifier: property.defaultValue
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Parameter \#12 \$localtaxes_array of function calcul_price_total expects array\{string, int\|string, string, int\|string, string, string\}\|array\{string, int\|string, string, string\}, array\{\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Parameter \#12 \$localtaxes_array of function calcul_price_total expects array\{string, int\|string, string, int\|string, string, string\}\|array\{string, int\|string, string, string\}, array\{\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Parameter \#12 \$localtaxes_array of function calcul_price_total expects array\{string, int\|string, string, int\|string, string, string\}\|array\{string, int\|string, string, string\}, array\{int\<0, 6\>, float, int\<0, 6\>, float\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+		-
+			message: '#^Property Call\:\:\$fields \(array\<string, array\{type\: string, label\: string, langfile\?\: string, enabled\: int\<0, 2\>\|string, position\: int, notnull\?\: int, visible\: int\<\-6, 6\>\|string, alwayseditable\?\: int\<0, 1\>, \.\.\.\}\>\) does not accept default value of type array\{rowid\: array\{type\: ''integer'', label\: ''TechnicalID'', enabled\: ''1'', position\: 1, notnull\: 1, visible\: ''1'', noteditable\: ''1'', index\: ''1'', \.\.\.\}, call_id\: array\{type\: ''varchar\(50\)'', label\: ''Ref'', enabled\: ''1'', position\: 10, notnull\: 1, visible\: ''1'', index\: ''1'', csslist\: ''tdoverflowmax150''\}, provider\: array\{type\: ''varchar\(50\)'', label\: ''provider'', enabled\: ''1'', position\: 20, notnull\: 1, visible\: ''1'', comment\: ''PDP Name''\}, call_type\: array\{type\: ''varchar\(50\)'', label\: ''Type'', enabled\: ''1'', position\: 25, notnull\: 1, visible\: ''1'', comment\: ''Call type \(SyncDocs…'', csslist\: ''tdoverflowmax125''\}, method\: array\{type\: ''varchar\(10\)'', label\: ''Method'', enabled\: ''1'', position\: 30, notnull\: 0, visible\: ''1'', comment\: ''\-\- HTTP method \(GET…''\}, endpoint\: array\{type\: ''varchar\(255\)'', label\: ''Endpoint'', enabled\: ''1'', position\: 35, notnull\: 1, visible\: ''\-1'', comment\: ''\-\- URL or endpoint…''\}, request_id\: array\{type\: ''varchar\(36\)'', label\: ''RequestId'', langs\: ''einvoicing…'', enabled\: ''1'', position\: 36, notnull\: 0, visible\: ''\-1'', comment\: ''\-\- Request\-Id…''\}, skippedflow\: array\{type\: ''integer'', label\: ''SkippedFlows'', enabled\: ''1'', position\: 130, notnull\: 1, visible\: ''1'', comment\: ''Skipped flows…''\}, \.\.\.\}\.$#'
+			identifier: property.defaultValue
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Document\:\:\$fields \(array\<string, array\{type\: string, label\: string, langfile\?\: string, enabled\: int\<0, 2\>\|string, position\: int, notnull\?\: int, visible\: int\<\-6, 6\>\|string, alwayseditable\?\: int\<0, 1\>, \.\.\.\}\>\) does not accept default value of type array\{rowid\: array\{type\: ''integer'', label\: ''ID'', enabled\: ''1'', position\: 1, notnull\: 1, visible\: ''1'', noteditable\: ''1'', index\: ''1'', \.\.\.\}, provider\: array\{type\: ''varchar\(50\)'', label\: ''AccessPoint'', langfile\: ''einvoicing…'', enabled\: ''1'', position\: 5, notnull\: 1, visible\: ''\-1'', comment\: ''EInvoice Platform…''\}, flow_id\: array\{type\: ''varchar\(255\)'', label\: ''flow_id'', enabled\: ''1'', position\: 10, notnull\: 0, visible\: ''1'', comment\: ''EInvoice flow UUID'', csslist\: ''tdoverflowmax100''\}, call_id\: array\{type\: ''varchar\(50\)'', label\: ''TransactionID'', enabled\: ''1'', position\: 20, notnull\: 0, visible\: ''1'', comment\: ''Reference to the…'', csslist\: ''tdoverflowmax100''\}, flow_type\: array\{type\: ''varchar\(255\)'', label\: ''flow_type'', enabled\: ''1'', position\: 40, notnull\: 0, visible\: ''1'', comment\: ''Flow type \(\\''sync\\'', …''\}, flow_direction\: array\{type\: ''varchar\(10\)'', label\: ''flow_direction'', enabled\: ''1'', position\: 50, notnull\: 0, visible\: ''1'', comment\: ''In or Out'', csslist\: ''center''\}, flow_syntax\: array\{type\: ''varchar\(50\)'', label\: ''flow_syntax'', enabled\: ''1'', position\: 60, notnull\: 0, visible\: ''\-1'', comment\: ''Document syntax …''\}, flow_profile\: array\{type\: ''varchar\(50\)'', label\: ''flow_profile'', enabled\: ''1'', position\: 70, notnull\: 0, visible\: ''\-1'', comment\: ''Profile used \(Basic…''\}, \.\.\.\}\.$#'
+			identifier: property.defaultValue
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Function getURLContent invoked with 12 parameters, 1\-10 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/class/einvoicing.class.php
+
+		-
+			message: '#^Function getURLContent invoked with 12 parameters, 1\-10 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/class/providers/EsalinkPDPProvider.class.php
+
+		-
+			message: '#^Function getURLContent invoked with 12 parameters, 1\-10 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+		-
+			message: '#^Strict comparison using \=\=\= between array\{type\: string, label\: string, langfile\?\: string, enabled\: int\<0, 2\>\|string, position\: int, notnull\?\: int, visible\: int\<\-6, 6\>\|string, alwayseditable\?\: int\<0, 1\>\|string, \.\.\.\} and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Parameter \#4 \$url of function dolGetButtonAction expects array\<int, array\{lang\: string, enabled\: bool, perm\: bool\|int, label\: string, url\: string, urlroot\?\: string, isDropDown\?\: int\<0, 1\>\}\>\|string, array\{0\: array\{lang\: ''einvoicing'', enabled\: true, perm\: \-1\|bool, label\: mixed, text\?\: mixed, url\: non\-falsy\-string\}, 1\?\: array\{lang\: ''einvoicing'', enabled\: 1\|true, perm\: \-1\|bool, label\: mixed, text\?\: mixed, url\: non\-falsy\-string\}, 2\?\: array\{lang\: ''einvoicing'', enabled\: 1, perm\: \-1\|bool, label\: mixed, text\: mixed, url\: non\-falsy\-string\}\|array\{lang\: ''einvoicing'', enabled\: true, perm\: bool, label\: mixed, url\: non\-falsy\-string\}, 3\?\: array\{lang\: ''einvoicing'', enabled\: 1, perm\: \-1\|bool, label\: mixed, text\: mixed, url\: non\-falsy\-string\}\} given\.$#'
+			identifier: argument.type
+			count: 2
+			path: ../../../einvoicing/class/actions_einvoicing.class.php
+
+		-
+			message: '#^Property Call\:\:\$fields \(array\<string, array\{type\: string, label\: string, langfile\?\: string, enabled\: int\<0, 2\>\|string, position\: int, notnull\?\: int, visible\: int\<\-6, 6\>\|string, alwayseditable\?\: int\<0, 1\>\|string, \.\.\.\}\>\) does not accept default value of type array\{rowid\: array\{type\: ''integer'', label\: ''TechnicalID'', enabled\: ''1'', position\: 1, notnull\: 1, visible\: ''1'', noteditable\: ''1'', index\: ''1'', \.\.\.\}, call_id\: array\{type\: ''varchar\(50\)'', label\: ''Ref'', enabled\: ''1'', position\: 10, notnull\: 1, visible\: ''1'', index\: ''1'', csslist\: ''tdoverflowmax150''\}, provider\: array\{type\: ''varchar\(50\)'', label\: ''provider'', enabled\: ''1'', position\: 20, notnull\: 1, visible\: ''1'', comment\: ''PDP Name''\}, call_type\: array\{type\: ''varchar\(50\)'', label\: ''Type'', enabled\: ''1'', position\: 25, notnull\: 1, visible\: ''1'', comment\: ''Call type \(SyncDocs…'', csslist\: ''tdoverflowmax125''\}, method\: array\{type\: ''varchar\(10\)'', label\: ''Method'', enabled\: ''1'', position\: 30, notnull\: 0, visible\: ''1'', comment\: ''\-\- HTTP method \(GET…''\}, endpoint\: array\{type\: ''varchar\(255\)'', label\: ''Endpoint'', enabled\: ''1'', position\: 35, notnull\: 1, visible\: ''\-1'', comment\: ''\-\- URL or endpoint…''\}, request_id\: array\{type\: ''varchar\(36\)'', label\: ''RequestId'', langs\: ''einvoicing…'', enabled\: ''1'', position\: 36, notnull\: 0, visible\: ''\-1'', comment\: ''\-\- Request\-Id…''\}, skippedflow\: array\{type\: ''integer'', label\: ''SkippedFlows'', enabled\: ''1'', position\: 130, notnull\: 1, visible\: ''1'', comment\: ''Skipped flows…''\}, \.\.\.\}\.$#'
+			identifier: property.defaultValue
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Document\:\:\$fields \(array\<string, array\{type\: string, label\: string, langfile\?\: string, enabled\: int\<0, 2\>\|string, position\: int, notnull\?\: int, visible\: int\<\-6, 6\>\|string, alwayseditable\?\: int\<0, 1\>\|string, \.\.\.\}\>\) does not accept default value of type array\{rowid\: array\{type\: ''integer'', label\: ''ID'', enabled\: ''1'', position\: 1, notnull\: 1, visible\: ''1'', noteditable\: ''1'', index\: ''1'', \.\.\.\}, provider\: array\{type\: ''varchar\(50\)'', label\: ''AccessPoint'', langfile\: ''einvoicing…'', enabled\: ''1'', position\: 5, notnull\: 1, visible\: ''\-1'', comment\: ''EInvoice Platform…''\}, flow_id\: array\{type\: ''varchar\(255\)'', label\: ''flow_id'', enabled\: ''1'', position\: 10, notnull\: 0, visible\: ''1'', comment\: ''EInvoice flow UUID'', csslist\: ''tdoverflowmax100''\}, call_id\: array\{type\: ''varchar\(50\)'', label\: ''TransactionID'', enabled\: ''1'', position\: 20, notnull\: 0, visible\: ''1'', comment\: ''Reference to the…'', csslist\: ''tdoverflowmax100''\}, flow_type\: array\{type\: ''varchar\(255\)'', label\: ''flow_type'', enabled\: ''1'', position\: 40, notnull\: 0, visible\: ''1'', comment\: ''Flow type \(\\''sync\\'', …''\}, flow_direction\: array\{type\: ''varchar\(10\)'', label\: ''flow_direction'', enabled\: ''1'', position\: 50, notnull\: 0, visible\: ''1'', comment\: ''In or Out'', csslist\: ''center''\}, flow_syntax\: array\{type\: ''varchar\(50\)'', label\: ''flow_syntax'', enabled\: ''1'', position\: 60, notnull\: 0, visible\: ''\-1'', comment\: ''Document syntax …''\}, flow_profile\: array\{type\: ''varchar\(50\)'', label\: ''flow_profile'', enabled\: ''1'', position\: 70, notnull\: 0, visible\: ''\-1'', comment\: ''Profile used \(Basic…''\}, \.\.\.\}\.$#'
+			identifier: property.defaultValue
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Function getURLContent invoked with 12 parameters, 1\-11 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/class/einvoicing.class.php
+
+		-
+			message: '#^Function getHashUniqueIdOfRegistration invoked with 1 parameter, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Function getURLContent invoked with 12 parameters, 1\-11 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/class/providers/EsalinkPDPProvider.class.php
+
+		-
+			message: '#^Function getURLContent invoked with 12 parameters, 1\-11 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between array\{type\: string, label\: string, langfile\?\: string, enabled\: int\<0, 2\>\|string, position\: int, notnull\?\: int, visible\: int\<\-6, 6\>\|string, alwayseditable\?\: int\<0, 1\>\|string, \.\.\.\} and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: ../../../einvoicing/document_list.php

--- a/dev/tools/phpstan/baseline.neon
+++ b/dev/tools/phpstan/baseline.neon
@@ -1,0 +1,1795 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/admin/about.php
+
+		-
+			message: '#^Call to function is_object\(\) with FormSetup will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: ../../../einvoicing/admin/setup.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/admin/setup.php
+
+		-
+			message: '#^Variable \$formSetup in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 2
+			path: ../../../einvoicing/admin/setup.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/admin/setup_devtools.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/admin/setup_options.php
+
+		-
+			message: '#^Property FormSetupItem\:\:\$fieldAttr \(array\{name\?\: string, id\?\: string, value\?\: mixed, class\?\: string, disabled\?\: int\<0, 1\>\|null, type\?\: string, size\?\: int, placeholder\?\: string, \.\.\.\}\) does not accept array\{name\?\: string, id\?\: string, value\?\: mixed, class\?\: string, disabled\?\: int\<0, 1\>\|null, type\?\: string, size\?\: int, placeholder\?\: string, \.\.\.\}\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: ../../../einvoicing/admin/setup_options.php
+
+		-
+			message: '#^Function einvoicing_directory_html\(\) has parameter \$r with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/ajax/checkdirectory.php
+
+		-
+			message: '#^Function einvoicing_directory_provenance\(\) has parameter \$r with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/ajax/checkdirectory.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/ajax/checkdirectory.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/ajax/checkinvoicestatus.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/ajax/checksupplierinvoicestatus.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/ajax/document.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/call_card.php
+
+		-
+			message: '#^Empty array passed to foreach\.$#'
+			identifier: foreach.emptyArray
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between array\{type\: string, label\: string, enabled\: int\<0, 2\>\|string, position\: int, visible\: int\<\-6, 6\>\|string, langfile\?\: string, notnull\?\: int\<\-1, 1\>, noteditable\?\: int\<0, 1\>, \.\.\.\} and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Variable \$permissiontoread in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: ../../../einvoicing/call_list.php
+
+		-
+			message: '#^Method ActionsEInvoicing\:\:afterODTCreation\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/actions_einvoicing.class.php
+
+		-
+			message: '#^Method ActionsEInvoicing\:\:afterPDFCreation\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/actions_einvoicing.class.php
+
+		-
+			message: '#^Method ActionsEInvoicing\:\:formConfirm\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/actions_einvoicing.class.php
+
+		-
+			message: '#^Parameter \#4 \$url of function dolGetButtonAction expects array\<int, array\{lang\: string, enabled\: bool, perm\: bool\|int, label\: string, text\?\: string, url\: string, urlroot\?\: string, isDropDown\?\: int\<0, 1\>\}\>\|string, array\{0\: array\{lang\: ''einvoicing'', enabled\: true, perm\: \-1\|bool, label\: mixed, text\?\: mixed, url\: non\-falsy\-string\}, 1\?\: array\{lang\: ''einvoicing'', enabled\: 1\|true, perm\: \-1\|bool, label\: mixed, text\?\: mixed, url\: non\-falsy\-string\}, 2\?\: array\{lang\: ''einvoicing'', enabled\: 1, perm\: \-1\|bool, label\: mixed, text\: mixed, url\: non\-falsy\-string\}\|array\{lang\: ''einvoicing'', enabled\: true, perm\: bool, label\: mixed, url\: non\-falsy\-string\}, 3\?\: array\{lang\: ''einvoicing'', enabled\: 1, perm\: \-1\|bool, label\: mixed, text\: mixed, url\: non\-falsy\-string\}\} given\.$#'
+			identifier: argument.type
+			count: 2
+			path: ../../../einvoicing/class/actions_einvoicing.class.php
+
+		-
+			message: '#^Property CommonObject\:\:\$element \(string\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 2
+			path: ../../../einvoicing/class/actions_einvoicing.class.php
+
+		-
+			message: '#^Call to function method_exists\(\) with \$this\(Call\) and ''getLibStatut'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Call to function method_exists\(\) with \$this\(Call\) and ''getNomUrl'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Call to function property_exists\(\) with \$this\(Call\) and ''thirdparty'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Call to function property_exists\(\) with Call and ''date_creation'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Call to function property_exists\(\) with Call and ''date_modification'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Call to function property_exists\(\) with Call and ''ref'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Call to function property_exists\(\) with Call and ''status'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Left side of && is always false\.$#'
+			identifier: booleanAnd.leftAlwaysFalse
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$batchlimit has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$call_id has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$call_type has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$endpoint has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$fields \(array\<string, array\{type\: string, label\: string, enabled\: int\<0, 2\>\|string, position\: int, visible\: int\<\-6, 6\>\|string, langfile\?\: string, notnull\?\: int\<\-1, 1\>, noteditable\?\: int\<0, 1\>, \.\.\.\}\>\) does not accept default value of type array\{rowid\: array\{type\: ''integer'', label\: ''TechnicalID'', enabled\: ''1'', position\: 1, notnull\: 1, visible\: ''1'', noteditable\: ''1'', index\: ''1'', \.\.\.\}, call_id\: array\{type\: ''varchar\(50\)'', label\: ''Ref'', enabled\: ''1'', position\: 10, notnull\: 1, visible\: ''1'', index\: ''1'', csslist\: ''tdoverflowmax150''\}, provider\: array\{type\: ''varchar\(50\)'', label\: ''provider'', enabled\: ''1'', position\: 20, notnull\: 1, visible\: ''1'', comment\: ''PDP Name''\}, call_type\: array\{type\: ''varchar\(50\)'', label\: ''Type'', enabled\: ''1'', position\: 25, notnull\: 1, visible\: ''1'', comment\: ''Call type \(SyncDocs…'', csslist\: ''tdoverflowmax125''\}, method\: array\{type\: ''varchar\(10\)'', label\: ''Method'', enabled\: ''1'', position\: 30, notnull\: 0, visible\: ''1'', comment\: ''\-\- HTTP method \(GET…''\}, endpoint\: array\{type\: ''varchar\(255\)'', label\: ''Endpoint'', enabled\: ''1'', position\: 35, notnull\: 1, visible\: ''\-1'', comment\: ''\-\- URL or endpoint…''\}, request_id\: array\{type\: ''varchar\(36\)'', label\: ''RequestId'', langs\: ''einvoicing…'', enabled\: ''1'', position\: 36, notnull\: 0, visible\: ''\-1'', comment\: ''\-\- Request\-Id…''\}, skippedflow\: array\{type\: ''integer'', label\: ''SkippedFlows'', enabled\: ''1'', position\: 130, notnull\: 1, visible\: ''1'', comment\: ''Skipped flows…''\}, \.\.\.\}\.$#'
+			identifier: property.defaultValue
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$method has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$processing_result has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$provider has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$request_body has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$request_id has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$response has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$rowid has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$skippedflow has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$successflow has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Property Call\:\:\$totalflow has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/call.class.php
+
+		-
+			message: '#^Call to function method_exists\(\) with \$this\(Document\) and ''getLibStatut'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Call to function method_exists\(\) with \$this\(Document\) and ''getNomUrl'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Call to function property_exists\(\) with \$this\(Document\) and ''ref'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Call to function property_exists\(\) with \$this\(Document\) and ''thirdparty'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Call to function property_exists\(\) with Document and ''date_creation'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Call to function property_exists\(\) with Document and ''date_modification'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Call to function property_exists\(\) with Document and ''ref'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Call to function property_exists\(\) with Document and ''status'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Left side of && is always false\.$#'
+			identifier: booleanAnd.leftAlwaysFalse
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$ack_info has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$ack_reason_code has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$ack_status has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$call_id has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$cdar_lifecycle_code has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$cdar_lifecycle_label has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$cdar_reason_code has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$cdar_reason_desc has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$cdar_reason_detail has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$document_body has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$fields \(array\<string, array\{type\: string, label\: string, enabled\: int\<0, 2\>\|string, position\: int, visible\: int\<\-6, 6\>\|string, langfile\?\: string, notnull\?\: int\<\-1, 1\>, noteditable\?\: int\<0, 1\>, \.\.\.\}\>\) does not accept default value of type array\{rowid\: array\{type\: ''integer'', label\: ''ID'', enabled\: ''1'', position\: 1, notnull\: 1, visible\: ''1'', noteditable\: ''1'', index\: ''1'', \.\.\.\}, provider\: array\{type\: ''varchar\(50\)'', label\: ''AccessPoint'', langfile\: ''einvoicing…'', enabled\: ''1'', position\: 5, notnull\: 1, visible\: ''\-1'', comment\: ''EInvoice Platform…''\}, flow_id\: array\{type\: ''varchar\(255\)'', label\: ''flow_id'', enabled\: ''1'', position\: 10, notnull\: 0, visible\: ''1'', comment\: ''EInvoice flow UUID'', csslist\: ''tdoverflowmax100''\}, call_id\: array\{type\: ''varchar\(50\)'', label\: ''TransactionID'', enabled\: ''1'', position\: 20, notnull\: 0, visible\: ''1'', comment\: ''Reference to the…'', csslist\: ''tdoverflowmax100''\}, flow_type\: array\{type\: ''varchar\(255\)'', label\: ''flow_type'', enabled\: ''1'', position\: 40, notnull\: 0, visible\: ''1'', comment\: ''Flow type \(\\''sync\\'', …''\}, flow_direction\: array\{type\: ''varchar\(10\)'', label\: ''flow_direction'', enabled\: ''1'', position\: 50, notnull\: 0, visible\: ''1'', comment\: ''In or Out'', csslist\: ''center''\}, flow_syntax\: array\{type\: ''varchar\(50\)'', label\: ''flow_syntax'', enabled\: ''1'', position\: 60, notnull\: 0, visible\: ''\-1'', comment\: ''Document syntax …''\}, flow_profile\: array\{type\: ''varchar\(50\)'', label\: ''flow_profile'', enabled\: ''1'', position\: 70, notnull\: 0, visible\: ''\-1'', comment\: ''Profile used \(Basic…''\}, \.\.\.\}\.$#'
+			identifier: property.defaultValue
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$fk_element_id has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$fk_element_type has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$flow_direction has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$flow_id has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$flow_profile has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$flow_syntax has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$flow_type has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$flow_uiid has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$processing_rule has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$provider has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$response_for_debug has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$rowid has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$submittedat has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$tracking_idref has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$updatedat has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Property Document\:\:\$xml_data has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/document.class.php
+
+		-
+			message: '#^Loose comparison using \=\= between \-1 and 2 will always evaluate to false\.$#'
+			identifier: equal.alwaysFalse
+			count: 3
+			path: ../../../einvoicing/class/einvoicing.class.php
+
+		-
+			message: '#^Offset ''ADR_ERR''\|''ART_ERR''\|''AUTRE''\|''CALCUL_ERR''\|''CMD_ERR''\|''CODE_ROUTAGE_ERR''\|''CONTRAT_TERM''\|''COORD_BANC_ERR''\|''DEST_ERR''\|''DOUBLE_FACT''\|''DOUBLON''\|''EMMET_INC''\|''JUSTIF_ABS''\|''LIVR_INCOMP''\|''MODPAI_ERR''\|''MONTANTTOTAL_ERR''\|''NON_CONFORME''\|''PU_ERR''\|''QTE_ERR''\|''QUALITE_ERR''\|''REF_CT_ABSENT''\|''REF_ERR''\|''REM_ERR''\|''ROUTAGE_ERR''\|''SIRET_ERR''\|''TRANSAC_INC''\|''TX_TVA_ERR'' on array\{NON_TRANSMISE\: array\{label\: ''ReasonRecipientNotC…'', desc\: ''This reason is used…''\}, JUSTIF_ABS\: array\{label\: ''ReasonMissingOrInsu…'', desc\: ''This reason should…''\}, ROUTAGE_ERR\: array\{label\: ''ReasonRoutingError'', desc\: ''This reason code…''\}, AUTRE\: array\{label\: ''ReasonOther'', desc\: ''Ce motif nécessite…''\}, COORD_BANC_ERR\: array\{label\: ''ReasonBankCoordinat…'', desc\: ''Les références…''\}, TX_TVA_ERR\: array\{label\: ''ReasonIncorrectVATR…'', desc\: ''Un taux de TVA…''\}, MONTANTTOTAL_ERR\: array\{label\: ''ReasonIncorrectTota…'', desc\: ''One of the invoice…''\}, CALCUL_ERR\: array\{label\: ''ReasonInvoiceCalcul…'', desc\: ''Soit détecté au…''\}, \.\.\.\} in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
+			count: 1
+			path: ../../../einvoicing/class/einvoicing.class.php
+
+		-
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(string\)\: bool\)\|null, ''strlen'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/einvoicing.class.php
+
+		-
+			message: '#^Property CommonInvoiceLine\:\:\$product_label \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/class/einvoicing.class.php
+
+		-
+			message: '#^Property CommonObjectLine\:\:\$desc \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/class/einvoicing.class.php
+
+		-
+			message: '#^Property Societe\:\:\$tva_assuj \(int\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/class/einvoicing.class.php
+
+		-
+			message: '#^Variable \$baseErrors in empty\(\) always exists and is always falsy\.$#'
+			identifier: empty.variable
+			count: 2
+			path: ../../../einvoicing/class/einvoicing.class.php
+
+		-
+			message: '#^Method AbstractProtocol\:\:parseInvoiceHeader\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/AbstractProtocol.class.php
+
+		-
+			message: '#^Property AbstractProtocol\:\:\$errors type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/AbstractProtocol.class.php
+
+		-
+			message: '#^Property AbstractProtocol\:\:\$warnings type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/AbstractProtocol.class.php
+
+		-
+			message: '#^Property CommonInvoice\:\:\$total_ttc \(float\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/class/protocols/AbstractProtocol.class.php
+
+		-
+			message: '#^Call to function method_exists\(\) with Societe and ''findNearest'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Expression "''…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 2
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Left side of && is always true\.$#'
+			identifier: booleanAnd.leftAlwaysTrue
+			count: 3
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Loose comparison using \=\= between 1 and 2 will always evaluate to false\.$#'
+			identifier: equal.alwaysFalse
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Loose comparison using \=\= between float and 0\.0 will always evaluate to true\.$#'
+			identifier: equal.alwaysTrue
+			count: 2
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:_applyPaymentInfoToSupplierInvoice\(\) has parameter \$parsedHeader with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:_detectProductTypeFromEinvoiceLine\(\) has parameter \$line with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:_findOrCreateProductFromEinvoiceLine\(\) has parameter \$lineData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:_findOrCreateProductFromEinvoiceLine\(\) should return array\{res\: int, message\: string, actioncode\: string\|null, action\: string\|null, actionurl\: string\|null, actiondata\: array\<string, mixed\>, allactiondata\: array\<string, array\<string, mixed\>\>\} but returns array\{res\: \-1, message\: non\-falsy\-string\}\.$#'
+			identifier: return.type
+			count: 2
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:_findOrCreateProductFromEinvoiceLine\(\) should return array\{res\: int, message\: string, actioncode\: string\|null, action\: string\|null, actionurl\: string\|null, actiondata\: array\<string, mixed\>, allactiondata\: array\<string, array\<string, mixed\>\>\} but returns array\{res\: 0, message\: ''Product not found,…''\}\.$#'
+			identifier: return.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:_findOrCreateProductFromEinvoiceLine\(\) should return array\{res\: int, message\: string, actioncode\: string\|null, action\: string\|null, actionurl\: string\|null, actiondata\: array\<string, mixed\>, allactiondata\: array\<string, array\<string, mixed\>\>\} but returns array\{res\: int, message\: ''Product…''\}\.$#'
+			identifier: return.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:_findOrCreateProductFromEinvoiceLine\(\) should return array\{res\: int, message\: string, actioncode\: string\|null, action\: string\|null, actionurl\: string\|null, actiondata\: array\<string, mixed\>, allactiondata\: array\<string, array\<string, mixed\>\>\} but returns array\{res\: int\<1, max\>, message\: string, matchtype\?\: string\}\.$#'
+			identifier: return.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:_syncOrCreateThirdpartyFromEInvoiceSeller\(\) has parameter \$sellerInfo with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:_syncOrCreateThirdpartyFromEInvoiceSeller\(\) should return array\{res\: int, message\: string, actioncode\: string\|null, actionurl\: string\|null, action\: string\|null\} but returns array\{res\: \-1, message\: non\-falsy\-string, actioncode\: ''DUPLICATE…'', action\: ''Merge the 2…'', actiondata\: array\{thirdpartyid1\: mixed, thirdpartyid2\: mixed\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:_syncOrCreateThirdpartyFromEInvoiceSeller\(\) should return array\{res\: int, message\: string, actioncode\: string\|null, actionurl\: string\|null, action\: string\|null\} but returns array\{res\: \-1, message\: non\-falsy\-string\}\.$#'
+			identifier: return.type
+			count: 2
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:_syncOrCreateThirdpartyFromEInvoiceSeller\(\) should return array\{res\: int, message\: string, actioncode\: string\|null, actionurl\: string\|null, action\: string\|null\} but returns array\{res\: int, message\: non\-falsy\-string\}\.$#'
+			identifier: return.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:_syncOrCreateThirdpartyFromEInvoiceSeller\(\) should return array\{res\: int, message\: string, actioncode\: string\|null, actionurl\: string\|null, action\: string\|null\} but returns array\{res\: int\<1, max\>, message\: non\-falsy\-string\}\.$#'
+			identifier: return.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:addHeaderDiscount\(\) has parameter \$discount with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:addLineDiscount\(\) has parameter \$discount with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:buildLineItem\(\) has parameter \$line with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:buildParty\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:buildShipToTradeParty\(\) has parameter \$bill with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:buildShipToTradeParty\(\) has parameter \$ship with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:buildTaxNode\(\) has parameter \$vals with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:buildXML\(\) has parameter \$invoiceData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:buildXML\(\) has parameter \$linesData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:buildXML\(\) invoked with 4 parameters, 2\-3 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:createSupplierInvoiceLinesFromSource\(\) has parameter \$parsedLines with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:createSupplierInvoiceLinesFromSource\(\) has parameter \$remise_already_used_line_level_ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:createSupplierInvoiceLinesFromSource\(\) has parameter \$return_messages with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:createSupplierInvoiceLinesFromSource\(\) has parameter \$supplierPriceEntries with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:createSupplierInvoiceLinesFromSource\(\) should return array\{res\: int, message\?\: string, actioncode\?\: string\|null, actionurl\?\: string\|null, action\?\: string\|null, actiondata\?\: string\|null\} but returns array\{res\: \-1, message\: non\-falsy\-string, actioncode\: string, actionurl\: string, action\: string\|null, actiondata\: array\<string, mixed\>\}\.$#'
+			identifier: return.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:findProductFromEinvoiceLine\(\) has parameter \$lineData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:getCategoryRate\(\) should return array\<string, string\> but returns array\<string, string\|null\>\.$#'
+			identifier: return.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:getXPathValues\(\) is unused\.$#'
+			identifier: method.unused
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:parseInvoiceHeader\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Method CIIProtocol\:\:resolveLineDiscountPercent\(\) has parameter \$lineAllowances with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Multiple PHPDoc @var tags above single variable assignment are not supported\.$#'
+			identifier: varTag.multipleTags
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^PHPDoc tag @var for variable \$invoiceData has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 6
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^PHPDoc tag @var for variable \$linesData has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 4
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Property CIIProtocol\:\:\$lineTemplate type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Property CommonObjectLine\:\:\$desc \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Property FactureFournisseur\:\:\$lines \(array\<CommonInvoiceLine\>\) does not accept array\<SupplierInvoiceLine\>\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Property SupplierInvoiceLine\:\:\$subprice \(float\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Result of \|\| is always true\.$#'
+			identifier: booleanOr.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between mixed~\(0\|0\.0\|''''\|''0''\|array\{\}\|false\|null\) and '''' will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 3
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Variable \$createParams in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: ../../../einvoicing/class/protocols/CIIProtocol.class.php
+
+		-
+			message: '#^Call to function is_subclass_of\(\) with ''FPDF'' and ''TCPDF'' will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Call to function method_exists\(\) with Societe and ''findNearest'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Instanceof between DateTime and DateTime will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 2
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Left side of && is always true\.$#'
+			identifier: booleanAnd.leftAlwaysTrue
+			count: 3
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Loose comparison using \=\= between 1 and 2 will always evaluate to false\.$#'
+			identifier: equal.alwaysFalse
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Method FacturXProtocol\:\:_applyPaymentInfoToSupplierInvoice\(\) has parameter \$parsedHeader with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Method FacturXProtocol\:\:_detectProductTypeFromEinvoiceLine\(\) has parameter \$line with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Method FacturXProtocol\:\:_findOrCreateProductFromEinvoiceLine\(\) has parameter \$lineData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Method FacturXProtocol\:\:_findOrCreateProductFromEinvoiceLine\(\) should return array\{res\: int, message\: string, actioncode\: string\|null, action\: string\|null, actionurl\: string\|null, actiondata\: array\<string, mixed\>, allactiondata\: array\<string, array\<string, mixed\>\>\} but returns array\{res\: \-1, message\: non\-falsy\-string\}\.$#'
+			identifier: return.type
+			count: 2
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Method FacturXProtocol\:\:_findOrCreateProductFromEinvoiceLine\(\) should return array\{res\: int, message\: string, actioncode\: string\|null, action\: string\|null, actionurl\: string\|null, actiondata\: array\<string, mixed\>, allactiondata\: array\<string, array\<string, mixed\>\>\} but returns array\{res\: 0, message\: ''Product not found,…''\}\.$#'
+			identifier: return.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Method FacturXProtocol\:\:_findOrCreateProductFromEinvoiceLine\(\) should return array\{res\: int, message\: string, actioncode\: string\|null, action\: string\|null, actionurl\: string\|null, actiondata\: array\<string, mixed\>, allactiondata\: array\<string, array\<string, mixed\>\>\} but returns array\{res\: int, message\: ''Product…''\}\.$#'
+			identifier: return.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Method FacturXProtocol\:\:_findOrCreateProductFromEinvoiceLine\(\) should return array\{res\: int, message\: string, actioncode\: string\|null, action\: string\|null, actionurl\: string\|null, actiondata\: array\<string, mixed\>, allactiondata\: array\<string, array\<string, mixed\>\>\} but returns array\{res\: int\<1, max\>, message\: string, matchtype\?\: string\}\.$#'
+			identifier: return.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Method FacturXProtocol\:\:_syncOrCreateThirdpartyFromEInvoiceSeller\(\) has parameter \$sellerInfo with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Method FacturXProtocol\:\:_syncOrCreateThirdpartyFromEInvoiceSeller\(\) should return array\{res\: int, message\: string, actioncode\: string\|null, actionurl\: string\|null, action\: string\|null\} but returns array\{res\: \-1, message\: non\-falsy\-string, actioncode\: ''DUPLICATE…'', action\: ''Merge the 2…'', actiondata\: array\{thirdpartyid1\: mixed, thirdpartyid2\: mixed\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Method FacturXProtocol\:\:_syncOrCreateThirdpartyFromEInvoiceSeller\(\) should return array\{res\: int, message\: string, actioncode\: string\|null, actionurl\: string\|null, action\: string\|null\} but returns array\{res\: \-1, message\: non\-falsy\-string\}\.$#'
+			identifier: return.type
+			count: 2
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Method FacturXProtocol\:\:_syncOrCreateThirdpartyFromEInvoiceSeller\(\) should return array\{res\: int, message\: string, actioncode\: string\|null, actionurl\: string\|null, action\: string\|null\} but returns array\{res\: int, message\: non\-falsy\-string\}\.$#'
+			identifier: return.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Method FacturXProtocol\:\:_syncOrCreateThirdpartyFromEInvoiceSeller\(\) should return array\{res\: int, message\: string, actioncode\: string\|null, actionurl\: string\|null, action\: string\|null\} but returns array\{res\: int\<1, max\>, message\: non\-falsy\-string\}\.$#'
+			identifier: return.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Method FacturXProtocol\:\:findProductFromEinvoiceLine\(\) has parameter \$lineData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Method FacturXProtocol\:\:getCategoryRate\(\) should return array\<string, string\> but returns array\<string, string\|null\>\.$#'
+			identifier: return.type
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between mixed~\(0\|0\.0\|''''\|''0''\|array\{\}\|false\|null\) and '''' will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 3
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Variable \$createParams in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Variable \$documentDeliveryDate on left side of \?\? always exists and is always null\.$#'
+			identifier: nullCoalesce.variable
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Variable \$documentdate on left side of \?\? always exists and is always null\.$#'
+			identifier: nullCoalesce.variable
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Variable \$xmlfile in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: ../../../einvoicing/class/protocols/FacturXProtocol.class.php
+
+		-
+			message: '#^Method ProtocolManager\:\:getProtocolsList\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/protocols/ProtocolManager.class.php
+
+		-
+			message: '#^Call to function is_array\(\) with array\<int\|string, array\<mixed\>\|string\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/class/providers/AbstractPDPProvider.class.php
+
+		-
+			message: '#^Call to function method_exists\(\) with \$this\(AbstractPDPProvider\) and ''callApi'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/class/providers/AbstractPDPProvider.class.php
+
+		-
+			message: '#^Method AbstractPDPProvider\:\:checkHealth\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/AbstractPDPProvider.class.php
+
+		-
+			message: '#^Method AbstractPDPProvider\:\:getConf\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/AbstractPDPProvider.class.php
+
+		-
+			message: '#^Method AbstractPDPProvider\:\:initFormSetup\(\) has parameter \$TFieldProfiles with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/AbstractPDPProvider.class.php
+
+		-
+			message: '#^Method AbstractPDPProvider\:\:initFormSetup\(\) has parameter \$TFieldProtocols with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/AbstractPDPProvider.class.php
+
+		-
+			message: '#^Method AbstractPDPProvider\:\:initFormSetup\(\) has parameter \$providersConfig with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/AbstractPDPProvider.class.php
+
+		-
+			message: '#^Method AbstractPDPProvider\:\:sendSampleInvoice\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/AbstractPDPProvider.class.php
+
+		-
+			message: '#^Method AbstractPDPProvider\:\:validateEInvoiceFile\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/AbstractPDPProvider.class.php
+
+		-
+			message: '#^Property AbstractPDPProvider\:\:\$EINVOICING_LAST_IMPORT_KEY has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/providers/AbstractPDPProvider.class.php
+
+		-
+			message: '#^Property AbstractPDPProvider\:\:\$config type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/AbstractPDPProvider.class.php
+
+		-
+			message: '#^Property AbstractPDPProvider\:\:\$errors type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/AbstractPDPProvider.class.php
+
+		-
+			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
+			identifier: catch.neverThrown
+			count: 3
+			path: ../../../einvoicing/class/providers/EsalinkPDPProvider.class.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/class/providers/EsalinkPDPProvider.class.php
+
+		-
+			message: '#^Left side of && is always true\.$#'
+			identifier: booleanAnd.leftAlwaysTrue
+			count: 1
+			path: ../../../einvoicing/class/providers/EsalinkPDPProvider.class.php
+
+		-
+			message: '#^Method EsalinkPDPProvider\:\:checkHealth\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/EsalinkPDPProvider.class.php
+
+		-
+			message: '#^Method EsalinkPDPProvider\:\:initFormSetup\(\) has parameter \$TFieldProfiles with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/EsalinkPDPProvider.class.php
+
+		-
+			message: '#^Method EsalinkPDPProvider\:\:initFormSetup\(\) has parameter \$TFieldProtocols with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/EsalinkPDPProvider.class.php
+
+		-
+			message: '#^Method EsalinkPDPProvider\:\:initFormSetup\(\) has parameter \$providersConfig with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/EsalinkPDPProvider.class.php
+
+		-
+			message: '#^Method EsalinkPDPProvider\:\:validateEInvoiceFile\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/EsalinkPDPProvider.class.php
+
+		-
+			message: '#^Property AbstractPDPProvider\:\:\$exchangeProtocol \(AbstractProtocol\) in empty\(\) is not falsy\.$#'
+			identifier: empty.property
+			count: 1
+			path: ../../../einvoicing/class/providers/EsalinkPDPProvider.class.php
+
+		-
+			message: '#^Call to function is_null\(\) with null will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
+			identifier: catch.neverThrown
+			count: 3
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Left side of && is always true\.$#'
+			identifier: booleanAnd.leftAlwaysTrue
+			count: 1
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Method SuperPDPProvider\:\:checkHealth\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Method SuperPDPProvider\:\:initFormSetup\(\) has parameter \$TFieldProfiles with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Method SuperPDPProvider\:\:initFormSetup\(\) has parameter \$TFieldProtocols with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Method SuperPDPProvider\:\:initFormSetup\(\) has parameter \$providersConfig with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Method SuperPDPProvider\:\:validateEInvoiceFile\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Property AbstractPDPProvider\:\:\$exchangeProtocol \(AbstractProtocol\) in empty\(\) is not falsy\.$#'
+			identifier: empty.property
+			count: 1
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between mixed~''error'' and ''error'' will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: ../../../einvoicing/class/providers/SuperPDPProvider.class.php
+
+		-
+			message: '#^Method TestPDPProvider\:\:initFormSetup\(\) has parameter \$TFieldProfiles with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/TestPDPProvider.class.php
+
+		-
+			message: '#^Method TestPDPProvider\:\:initFormSetup\(\) has parameter \$TFieldProtocols with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/TestPDPProvider.class.php
+
+		-
+			message: '#^Method TestPDPProvider\:\:initFormSetup\(\) has parameter \$providersConfig with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/TestPDPProvider.class.php
+
+		-
+			message: '#^Method TestPDPProvider\:\:sendSampleInvoice\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/providers/TestPDPProvider.class.php
+
+		-
+			message: '#^Property AbstractPDPProvider\:\:\$exchangeProtocol \(AbstractProtocol\) in empty\(\) is not falsy\.$#'
+			identifier: empty.property
+			count: 1
+			path: ../../../einvoicing/class/providers/TestPDPProvider.class.php
+
+		-
+			message: '#^Method CdarHandler\:\:addAcknowledgementDocument\(\) has parameter \$doc with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/utils/CdarHandler.class.php
+
+		-
+			message: '#^Method CdarHandler\:\:addExchangedDocument\(\) has parameter \$doc with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/utils/CdarHandler.class.php
+
+		-
+			message: '#^Method CdarHandler\:\:addReferencedDocument\(\) has parameter \$doc with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/utils/CdarHandler.class.php
+
+		-
+			message: '#^Method CdarHandler\:\:addTradeParty\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/utils/CdarHandler.class.php
+
+		-
+			message: '#^Method CdarHandler\:\:generate\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/utils/CdarHandler.class.php
+
+		-
+			message: '#^Method CdarHandler\:\:readFromFile\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 2
+			path: ../../../einvoicing/class/utils/CdarHandler.class.php
+
+		-
+			message: '#^Method CdarHandler\:\:readFromString\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 2
+			path: ../../../einvoicing/class/utils/CdarHandler.class.php
+
+		-
+			message: '#^Method CdarHandler\:\:saveToFile\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/utils/CdarHandler.class.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/class/utils/CdarHandler.class.php
+
+		-
+			message: '#^Property CdarHandler\:\:\$namespaces has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: ../../../einvoicing/class/utils/CdarHandler.class.php
+
+		-
+			message: '#^Offset 3 on array\{array\{name\: ''basic'', altname\: ''BASIC'', description\: ''The BASIC profile…'', contextparameter\: ''urn\:cen\.eu\:en16931…'', alternativecontextparameters\: array\{''urn\:cen\.eu\:en16931…''\}, businessprocess\: null, attachmentfilename\: ''factur\-x\.xml'', xmpname\: ''BASIC'', \.\.\.\}, array\{name\: ''basicwl'', altname\: ''BASIC WL'', description\: ''The BASIC WL…'', contextparameter\: ''urn\:factur\-x\.eu\:1p0…'', alternativecontextparameters\: array\{''urn\:zugferd\.de\:2p0…''\}, businessprocess\: null, attachmentfilename\: ''factur\-x\.xml'', xmpname\: ''BASIC WL'', \.\.\.\}, array\{name\: ''en16931'', altname\: ''EN 16931 \(COMFORT\)'', description\: ''The EN 16931 …'', contextparameter\: ''urn\:cen\.eu\:en16931…'', alternativecontextparameters\: array\{\}, businessprocess\: null, attachmentfilename\: ''factur\-x\.xml'', xmpname\: ''EN 16931'', \.\.\.\}, array\{name\: ''extended'', altname\: ''EXTENDED'', description\: ''The EXTENDED…'', contextparameter\: ''urn\:cen\.eu\:en16931…'', alternativecontextparameters\: array\{''urn\:cen\.eu\:en16931…''\}, businessprocess\: ''urn\:fdc\:peppol\.eu…'', attachmentfilename\: ''factur\-x\.xml'', xmpname\: ''EXTENDED'', \.\.\.\}, array\{name\: ''en16931'', altname\: ''XRECHNUNG'', description\: ''The reference…'', contextparameter\: ''urn\:cen\.eu\:en16931…'', alternativecontextparameters\: array\{\}, businessprocess\: null, attachmentfilename\: ''xrechnung\.xml'', xmpname\: ''XRECHNUNG'', \.\.\.\}, array\{name\: ''en16931'', altname\: ''XRECHNUNG'', description\: ''The reference…'', contextparameter\: ''urn\:cen\.eu\:en16931…'', alternativecontextparameters\: array\{\}, businessprocess\: null, attachmentfilename\: ''xrechnung\.xml'', xmpname\: ''XRECHNUNG'', \.\.\.\}, array\{name\: ''en16931'', altname\: ''XRECHNUNG'', description\: ''The reference…'', contextparameter\: ''urn\:cen\.eu\:en16931…'', alternativecontextparameters\: array\{\}, businessprocess\: null, attachmentfilename\: ''xrechnung\.xml'', xmpname\: ''XRECHNUNG'', \.\.\.\}, array\{name\: ''en16931'', altname\: ''XRECHNUNG'', description\: ''The reference…'', contextparameter\: ''urn\:cen\.eu\:en16931…'', alternativecontextparameters\: array\{\}, businessprocess\: null, attachmentfilename\: ''xrechnung\.xml'', xmpname\: ''XRECHNUNG'', \.\.\.\}, \.\.\.\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: ../../../einvoicing/class/utils/CtcFrPdfMerger.class.php
+
+		-
+			message: '#^Offset 3 on array\{array\{name\: ''basic'', altname\: ''BASIC'', description\: ''The BASIC profile…'', contextparameter\: ''urn\:cen\.eu\:en16931…'', alternativecontextparameters\: array\{''urn\:cen\.eu\:en16931…''\}, businessprocess\: null, attachmentfilename\: ''factur\-x\.xml'', xmpname\: ''BASIC'', \.\.\.\}, array\{name\: ''basicwl'', altname\: ''BASIC WL'', description\: ''The BASIC WL…'', contextparameter\: ''urn\:factur\-x\.eu\:1p0…'', alternativecontextparameters\: array\{''urn\:zugferd\.de\:2p0…''\}, businessprocess\: null, attachmentfilename\: ''factur\-x\.xml'', xmpname\: ''BASIC WL'', \.\.\.\}, array\{name\: ''en16931'', altname\: ''EN 16931 \(COMFORT\)'', description\: ''The EN 16931 …'', contextparameter\: ''urn\:cen\.eu\:en16931…'', alternativecontextparameters\: array\{\}, businessprocess\: null, attachmentfilename\: ''factur\-x\.xml'', xmpname\: ''EN 16931'', \.\.\.\}, array\{name\: ''extended'', altname\: ''EXTENDED'', description\: ''The EXTENDED…'', contextparameter\: ''urn\:cen\.eu\:en16931…'', alternativecontextparameters\: array\{''urn\:cen\.eu\:en16931…''\}, businessprocess\: ''urn\:fdc\:peppol\.eu…'', attachmentfilename\: ''factur\-x\.xml'', xmpname\: ''EXTENDED'', \.\.\.\}, array\{name\: ''en16931'', altname\: ''XRECHNUNG'', description\: ''The reference…'', contextparameter\: ''urn\:cen\.eu\:en16931…'', alternativecontextparameters\: array\{\}, businessprocess\: null, attachmentfilename\: ''xrechnung\.xml'', xmpname\: ''XRECHNUNG'', \.\.\.\}, array\{name\: ''en16931'', altname\: ''XRECHNUNG'', description\: ''The reference…'', contextparameter\: ''urn\:cen\.eu\:en16931…'', alternativecontextparameters\: array\{\}, businessprocess\: null, attachmentfilename\: ''xrechnung\.xml'', xmpname\: ''XRECHNUNG'', \.\.\.\}, array\{name\: ''en16931'', altname\: ''XRECHNUNG'', description\: ''The reference…'', contextparameter\: ''urn\:cen\.eu\:en16931…'', alternativecontextparameters\: array\{\}, businessprocess\: null, attachmentfilename\: ''xrechnung\.xml'', xmpname\: ''XRECHNUNG'', \.\.\.\}, array\{name\: ''en16931'', altname\: ''XRECHNUNG'', description\: ''The reference…'', contextparameter\: ''urn\:cen\.eu\:en16931…'', alternativecontextparameters\: array\{\}, businessprocess\: null, attachmentfilename\: ''xrechnung\.xml'', xmpname\: ''XRECHNUNG'', \.\.\.\}, \.\.\.\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: ../../../einvoicing/class/utils/FacturxTcpdfMerger.class.php
+
+		-
+			message: '#^Method PdfAttachmentExtractor\:\:applyFilters\(\) has parameter \$dict with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/utils/PdfAttachmentExtractor.class.php
+
+		-
+			message: '#^Method PdfAttachmentExtractor\:\:arrayOf\(\) has parameter \$element with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/utils/PdfAttachmentExtractor.class.php
+
+		-
+			message: '#^Method PdfAttachmentExtractor\:\:arrayOf\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/utils/PdfAttachmentExtractor.class.php
+
+		-
+			message: '#^Method PdfAttachmentExtractor\:\:dictOf\(\) has parameter \$element with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/utils/PdfAttachmentExtractor.class.php
+
+		-
+			message: '#^Method PdfAttachmentExtractor\:\:dictOf\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/utils/PdfAttachmentExtractor.class.php
+
+		-
+			message: '#^Method PdfAttachmentExtractor\:\:readFileSpec\(\) has parameter \$element with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/utils/PdfAttachmentExtractor.class.php
+
+		-
+			message: '#^Method PdfAttachmentExtractor\:\:walkNameTree\(\) has parameter \$node with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/utils/PdfAttachmentExtractor.class.php
+
+		-
+			message: '#^Parameter \#7 \$notused of function calcul_price_total expects int, float given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/utils/PriceHelper.class.php
+
+		-
+			message: '#^Method SupplierInvoiceHelper\:\:checkDolInvoiceAndEInvoiceConsistency\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/utils/SupplierInvoiceHelper.class.php
+
+		-
+			message: '#^Offset ''roundoftotal'' on non\-empty\-array\<''current''\|''roundoftotal''\|''totalofround'', list\> on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: ../../../einvoicing/class/utils/SupplierInvoiceHelper.class.php
+
+		-
+			message: '#^Parameter \#12 \$localtaxes_array of static method PriceHelper\:\:calculatePriceTotal\(\) expects array\{string, int\|string, string, int\|string, string, string\}\|array\{string, int\|string, string, string\}, array\{int\<0, 6\>, float, int\<0, 6\>, float\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/class/utils/SupplierInvoiceHelper.class.php
+
+		-
+			message: '#^Property CommonInvoiceLine\:\:\$situation_percent \(float\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/class/utils/SupplierInvoiceHelper.class.php
+
+		-
+			message: '#^Property CommonObject\:\:\$multicurrency_code \(array\<string\>\|string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/class/utils/SupplierInvoiceHelper.class.php
+
+		-
+			message: '#^Method XmlPatcher\:\:patchXmlString\(\) has parameter \$depositRefs with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/class/utils/XmlPatcher.class.php
+
+		-
+			message: '#^Static method XmlPatcher\:\:patchGuidelineId\(\) is unused\.$#'
+			identifier: method.unused
+			count: 1
+			path: ../../../einvoicing/class/utils/XmlPatcher.class.php
+
+		-
+			message: '#^Loose comparison using \=\= between string\|false and string\|false will always evaluate to true\.$#'
+			identifier: equal.alwaysTrue
+			count: 4
+			path: ../../../einvoicing/compat/profid.lib.php
+
+		-
+			message: '#^Result of \|\| is always true\.$#'
+			identifier: booleanOr.alwaysTrue
+			count: 2
+			path: ../../../einvoicing/compat/profid.lib.php
+
+		-
+			message: '#^Call to function is_numeric\(\) with 0 will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: ../../../einvoicing/document_agenda.php
+
+		-
+			message: '#^Call to function property_exists\(\) with Document and ''module'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: ../../../einvoicing/document_agenda.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/document_agenda.php
+
+		-
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
+			count: 2
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Loose comparison using \=\= between 1 and 0 will always evaluate to false\.$#'
+			identifier: equal.alwaysFalse
+			count: 2
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 2
+			path: ../../../einvoicing/document_card.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/document_contact.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/document_document.php
+
+		-
+			message: '#^Empty array passed to foreach\.$#'
+			identifier: foreach.emptyArray
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between array\{type\: string, label\: string, enabled\: int\<0, 2\>\|string, position\: int, visible\: int\<\-6, 6\>\|string, langfile\?\: string, notnull\?\: int\<\-1, 1\>, noteditable\?\: int\<0, 1\>, \.\.\.\} and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Variable \$permissiontoread in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: ../../../einvoicing/document_list.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/document_note.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/einvoice_tracking.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/einvoicingindex.php
+
+		-
+			message: '#^Expression "''…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Parameter \#12 \$localtaxes_array of function calcul_price_total expects array\{\}\|array\{string, int\|string, string, int\|string, string, string\}\|array\{string, int\|string, string, string\}, array\{int\<0, 6\>, float, int\<0, 6\>, float\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property CommonInvoice\:\:\$total_ht \(float\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property CommonInvoice\:\:\$type \(int\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property CommonInvoiceLine\:\:\$remise_percent \(float\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 2
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property CommonInvoiceLine\:\:\$situation_percent \(float\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property CommonInvoiceLine\:\:\$vat_src_code \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property CommonObjectLine\:\:\$subprice_ttc \(float\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property CommonObjectLine\:\:\$subprice_ttc \(float\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property DiscountAbsolute\:\:\$description \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 2
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property Facture\:\:\$fk_facture_source \(int\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Property Facture\:\:\$ref_client \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: ../../../einvoicing/lib/buildinvoicelines.inc.php
+
+		-
+			message: '#^Call to function is_numeric\(\) with int\<min, \-1\>\|int\<1, max\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/lib/einvoicing.lib.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''Societe'' and ''findNearest'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../einvoicing/lib/einvoicing.lib.php
+
+		-
+			message: '#^Function einvoicingDolGetButtonActionDropdown\(\) has parameter \$params with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/lib/einvoicing.lib.php
+
+		-
+			message: '#^Function einvoicingDolGetButtonActionDropdown\(\) has parameter \$urlButtons with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/lib/einvoicing.lib.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/product_mapping.php
+
+		-
+			message: '#^Loose comparison using \=\= between ''proxy'' and ''proxy'' will always evaluate to true\.$#'
+			identifier: equal.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/public/proxy_oauthcallback.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/public/proxy_oauthcallback.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: ../../../einvoicing/public/proxy_oauthcallback.php
+
+		-
+			message: '#^Function fnmapCardHtml\(\) has parameter \$functions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapCardHtml\(\) has parameter \$node with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapDiagramWidth\(\) has parameter \$diagram with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapDiagramWidth\(\) has parameter \$functions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapExtractFacts\(\) has parameter \$index with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapNodeLines\(\) has parameter \$function with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapNodeLines\(\) has parameter \$node with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapRenderBlockHtml\(\) has parameter \$block with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapRenderBlockHtml\(\) has parameter \$functions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapRenderBlockMd\(\) has parameter \$block with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapRenderBlockMd\(\) has parameter \$functions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapRenderDiagramHtml\(\) has parameter \$diagram with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapRenderDiagramHtml\(\) has parameter \$functions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapRenderDiagramMd\(\) has parameter \$diagram with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapRenderDiagramMd\(\) has parameter \$functions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapRenderHtml\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapRenderHtml\(\) has parameter \$functions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapRenderMarkdown\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapRenderMarkdown\(\) has parameter \$functions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapReportDrift\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapReportDrift\(\) has parameter \$facts with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapResolveSymbol\(\) has parameter \$index with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapSourceRef\(\) has parameter \$function with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Function fnmapSourceUrl\(\) has parameter \$function with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: ../../../einvoicing/scripts/build_function_map.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/scripts/regenerate_einvoicing_fixtures.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/scripts/testconnect.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/vendorref_list.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../einvoicing/xmlpreview.php

--- a/dev/tools/phpstan/bootstrap.php
+++ b/dev/tools/phpstan/bootstrap.php
@@ -1,0 +1,48 @@
+<?php
+/* Copyright (C) 2026 Pierre Grasswill
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    dev/tools/phpstan/bootstrap.php
+ * \brief   Gives PHPStan the few Dolibarr constants a module resolves its includes against.
+ * \remarks Read DOLIBARR_HTDOCS, the same variable the CI actions and the other tools of this
+ *          repository use. This file deliberately does NOT load master.inc.php or main.inc.php:
+ *          those open a database connection, start a session and read a conf.php that does not
+ *          exist here, and PHPStan needs none of it. The classes and functions of the core reach
+ *          the analysis through scanDirectories in phpstan.neon.dist, which indexes the symbols
+ *          without running anything.
+ */
+
+$htdocs = getenv('DOLIBARR_HTDOCS');
+if (!is_string($htdocs) || $htdocs === '' || !is_file($htdocs . '/filefunc.inc.php')) {
+	fwrite(STDERR, "DOLIBARR_HTDOCS does not point at the htdocs directory of a Dolibarr checkout (got \"" . (string) $htdocs . "\").\n");
+	fwrite(STDERR, "Run the analysis through dev/tools/phpstan/phpstan.sh, which resolves it.\n");
+	exit(2);
+}
+$htdocs = rtrim(str_replace('\\', '/', $htdocs), '/');
+
+// The constants every page and class of a module builds its require_once on. Without them PHPStan
+// resolves nothing and reports the whole module as unknown symbols.
+define('DOL_DOCUMENT_ROOT', $htdocs);
+define('DOL_DOCUMENT_ROOT_ALT', $htdocs . '/custom');
+define('DOL_DATA_ROOT', dirname($htdocs) . '/documents');
+define('DOL_URL_ROOT', '');
+define('DOL_MAIN_URL_ROOT', 'http://localhost');
+define('MAIN_DB_PREFIX', 'llx_');
+
+// DOL_VERSION is deliberately left undefined, and listed in dynamicConstantNames as well: a module
+// that supports several cores guards its calls with version tests, and pinning the constant to the
+// version of the checkout under analysis would let PHPStan declare each of those guards dead code.

--- a/dev/tools/phpstan/phpstan.sh
+++ b/dev/tools/phpstan/phpstan.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Runs PHPStan on the modules of this repository against a Dolibarr checkout.
+#
+# The core is not analysed, only indexed, so any checkout of a supported release works. Point at
+# one with DOLIBARR_HTDOCS, or let the script find one in the usual places.
+#
+#   dev/tools/phpstan/phpstan.sh                                  # analyse
+#   DOLIBARR_HTDOCS=~/git/dolibarr/htdocs dev/tools/phpstan/phpstan.sh
+#   dev/tools/phpstan/phpstan.sh einvoicing/class/document.class.php   # one file
+#
+# Any argument is passed on to PHPStan, so --generate-baseline, --error-format and the rest work.
+set -euo pipefail
+
+# The version the Dolibarr core runs in its own CI, so both projects report the same things.
+PHPSTAN_VERSION="${PHPSTAN_VERSION:-2.1.12}"
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../.." && pwd)
+cache_dir="$repo_root/.run-phpstan"
+phar="$cache_dir/phpstan-$PHPSTAN_VERSION.phar"
+
+# Where the Dolibarr core is. A checkout of any supported release does, the analysis reads it only
+# to know the symbols of the core.
+if [ -z "${DOLIBARR_HTDOCS:-}" ]; then
+	for candidate in \
+		"$repo_root/../dolibarr/htdocs" \
+		"$HOME/git/dolibarr/htdocs" \
+		"$HOME/dolibarr/htdocs"; do
+		if [ -f "$candidate/filefunc.inc.php" ]; then
+			DOLIBARR_HTDOCS=$(cd -- "$candidate" && pwd)
+			break
+		fi
+	done
+fi
+if [ -z "${DOLIBARR_HTDOCS:-}" ] || [ ! -f "$DOLIBARR_HTDOCS/filefunc.inc.php" ]; then
+	echo "No Dolibarr core found. Set DOLIBARR_HTDOCS to the htdocs directory of a checkout:" >&2
+	echo "  DOLIBARR_HTDOCS=/path/to/dolibarr/htdocs $0" >&2
+	exit 2
+fi
+export DOLIBARR_HTDOCS
+
+# PHPStan itself. The phar is pinned and cached next to the analysis cache, both out of git.
+mkdir -p "$cache_dir"
+if [ ! -f "$phar" ]; then
+	echo "Fetching PHPStan $PHPSTAN_VERSION..." >&2
+	curl -sSfL -o "$phar.tmp" \
+		"https://github.com/phpstan/phpstan/releases/download/$PHPSTAN_VERSION/phpstan.phar"
+	mv "$phar.tmp" "$phar"
+fi
+
+echo "PHPStan $PHPSTAN_VERSION on $DOLIBARR_HTDOCS" >&2
+
+cd "$repo_root"
+exec php -d memory_limit="${PHPSTAN_MEMORY_LIMIT:-4G}" "$phar" analyse "$@"

--- a/dev/tools/phpstan/refresh-baseline.sh
+++ b/dev/tools/phpstan/refresh-baseline.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Rebuilds the two PHPStan baselines from scratch, over every core the module supports.
+#
+#   DOLIBARR_GIT=~/git/dolibarr dev/tools/phpstan/refresh-baseline.sh
+#
+# baseline.neon gets what the newest core reports. baseline-legacy.neon gets, core by core from the
+# oldest up, only what that core adds on top of everything already listed: an error seen on several
+# cores is written once. Both files are loaded by phpstan.neon.dist, so every core stays green and
+# a new error on any of them is reported.
+#
+# Refresh it after a batch of fixes lands, never inside one: two branches editing the same baseline
+# conflict on every line.
+set -euo pipefail
+
+# The cores the module supports, oldest first, newest last. Same list as the PHPUnit matrix.
+CORES=(18.0.0 19.0.0 20.0.0 21.0.0 22.0.0 23.0.0 24.0.0)
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../.." && pwd)
+here="$repo_root/dev/tools/phpstan"
+newest="${CORES[${#CORES[@]}-1]}"
+
+if [ -z "${DOLIBARR_GIT:-}" ] || ! git -C "$DOLIBARR_GIT" rev-parse --git-dir >/dev/null 2>&1; then
+	echo "Set DOLIBARR_GIT to a clone of Dolibarr/dolibarr holding the release tags." >&2
+	exit 2
+fi
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+checkout() { # tag -> prints the htdocs of a fresh extraction
+	rm -rf "${work:?}/core"
+	mkdir -p "$work/core"
+	git -C "$DOLIBARR_GIT" archive "$1" htdocs | tar -x -C "$work/core"
+	echo "$work/core/htdocs"
+}
+
+# An empty baseline has to be in place first: --generate-baseline writes what is reported, so a
+# file still listing yesterday's errors would produce an empty one.
+empty() { printf 'parameters:\n\tignoreErrors: []\n' > "$1"; }
+empty "$here/baseline.neon"
+empty "$here/baseline-legacy.neon"
+
+echo "== $newest -> baseline.neon"
+DOLIBARR_HTDOCS=$(checkout "$newest") "$here/phpstan.sh" \
+	--generate-baseline="$here/baseline.neon" --allow-empty-baseline --no-progress
+
+for tag in "${CORES[@]}"; do
+	[ "$tag" = "$newest" ] && continue
+	echo "== $tag -> baseline-legacy.neon"
+	tmp="$work/add.neon"
+	DOLIBARR_HTDOCS=$(checkout "$tag") "$here/phpstan.sh" \
+		--generate-baseline="$tmp" --allow-empty-baseline --no-progress
+	python3 - "$here/baseline-legacy.neon" "$tmp" "$repo_root" <<'PY'
+import sys
+legacy, added, root = sys.argv[1], sys.argv[2], sys.argv[3]
+new = open(added).read()
+cut = new.find('ignoreErrors:')
+body = new[new.find('\n', cut) + 1:].rstrip('\n') if cut >= 0 else ''
+# --generate-baseline writes paths relative to the file it writes; here it wrote to a temp dir.
+body = body.replace('path: ' + root + '/', 'path: ../../../')
+if not body.strip():
+    sys.exit(0)
+cur = open(legacy).read().replace('ignoreErrors: []', 'ignoreErrors:')
+open(legacy, 'w').write(cur.rstrip('\n') + '\n' + body + '\n')
+PY
+done
+
+echo
+echo "baseline.neon        $(grep -c 'message:' "$here/baseline.neon") entries"
+echo "baseline-legacy.neon $(grep -c 'message:' "$here/baseline-legacy.neon") entries"

--- a/einvoicing/class/actions_einvoicing.class.php
+++ b/einvoicing/class/actions_einvoicing.class.php
@@ -605,6 +605,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 
 		if ($isFactureContext) {
 			'@phan-var-force Facture $object';
+			/** @var Facture $object */
 			$permissiontoedit = $user->hasRight('facture', 'write');
 
 			$db->begin();
@@ -1341,7 +1342,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 * @param array			$parameters		Array of parameters
 	 * @param CommonObject	$object			Object
 	 * @param string		$action			Action code
-	 * @param Hookmanager	$hookmanager	Hook manager
+	 * @param HookManager	$hookmanager	Hook manager
 	 * @return int
 	 */
 	public function formConfirm($parameters, $object, &$action, $hookmanager)
@@ -1457,7 +1458,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 * @param array<string,mixed> 	$parameters		Array of parameters
 	 * @param CommonObject			$object			Object invoice
 	 * @param string		 		$action			Code action
-	 * @param Hookmanager			$hookmanager	Hookmanager
+	 * @param HookManager			$hookmanager	Hookmanager
 	 * @return int									Result
 	 */
 	public function formObjectOptions($parameters, $object, &$action, $hookmanager)
@@ -1478,18 +1479,21 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 			// generation status/history, not only the send-related parts (those are gated individually inside it).
 			if (in_array($object->element, ['facture']) && (!getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP') || getDolGlobalString('EINVOICING_ONLY_GENERATE'))) {
 				'@phan-var-force Facture $object';
+				/** @var Facture $object */
 				$this->resprints .= $einvoicing->EInvoiceCardBlock($object, $action, $parameters);		// Output fields in card, including js for refreshing state
 			}
 
 			// Add block in supplier invoice card (reception only)
 			if (in_array($object->element, ['invoice_supplier']) && !einvoicingIsReceiveDisabled()) {
 				'@phan-var-force FactureFournisseur $object';
+				/** @var FactureFournisseur $object */
 				$this->resprints .= $einvoicing->supplierInvoiceCardBlock($object, $action, $parameters);		// Output fields in card, including js for refreshing state
 			}
 
 			// Add block in product/service card  (reception only)
 			if (in_array($object->element, ['product']) && !einvoicingIsReceiveDisabled()) {
 				'@phan-var-force Product $object';
+				/** @var Product $object */
 				$this->resprints .= $einvoicing->productServiceCardBlock($object, $action, $parameters);		// Output fields in card, including js for refreshing state
 			}
 
@@ -1498,6 +1502,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 			// import" part is gated individually inside thirdpartyCardBlock().
 			if (in_array($object->element, ['societe']) && (!getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP') || !getDolGlobalString('EINVOICING_DISABLE_SYNC_AP_TO_DOLI') || getDolGlobalString('EINVOICING_ONLY_GENERATE'))) {
 				'@phan-var-force Societe $object';
+				/** @var Societe $object */
 				$this->resprints .= $einvoicing->thirdpartyCardBlock($object, $action, $parameters);		// Output fields in card
 			}
 		}
@@ -1512,7 +1517,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 * @param array<string,mixed> 	$parameters		Array of parameters
 	 * @param CommonObject			$object			Object invoice
 	 * @param string		 		$action			Code action
-	 * @param Hookmanager			$hookmanager	Hookmanager
+	 * @param HookManager			$hookmanager	Hookmanager
 	 * @return int									Result
 	 */
 	public function completeArrayFields($parameters, $object, &$action, $hookmanager)
@@ -1607,7 +1612,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 * @param array<string,mixed> 	$parameters		Array of parameters
 	 * @param CommonObject			$object			Object invoice
 	 * @param string		 		$action			Code action
-	 * @param Hookmanager			$hookmanager	Hookmanager
+	 * @param HookManager			$hookmanager	Hookmanager
 	 * @return int									Result
 	 */
 	public function printFieldListSelect($parameters, $object, &$action, $hookmanager)
@@ -1680,7 +1685,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 * @param array<string,mixed> 	$parameters		Array of parameters
 	 * @param CommonObject			$object			Object invoice
 	 * @param string		 		$action			Code action
-	 * @param Hookmanager			$hookmanager	Hookmanager
+	 * @param HookManager			$hookmanager	Hookmanager
 	 * @return int									Result
 	 */
 	public function printFieldListFrom($parameters, $object, &$action, $hookmanager)
@@ -1722,7 +1727,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 * @param array<string,mixed> 	$parameters		Array of parameters
 	 * @param CommonObject			$object			Object invoice
 	 * @param string		 		$action			Code action
-	 * @param Hookmanager			$hookmanager	Hookmanager
+	 * @param HookManager			$hookmanager	Hookmanager
 	 * @return int									Result
 	 */
 	public function printFieldListWhere($parameters, $object, &$action, $hookmanager)
@@ -1783,7 +1788,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 * @param array<string,mixed> 	$parameters		Array of parameters
 	 * @param CommonObject			$object			Object invoice
 	 * @param string		 		$action			Code action
-	 * @param Hookmanager			$hookmanager	Hookmanager
+	 * @param HookManager			$hookmanager	Hookmanager
 	 * @return int									Result
 	 */
 	public function printFieldListGroupBy($parameters, $object, &$action, $hookmanager)
@@ -1801,7 +1806,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 * @param array<string,mixed> 	$parameters		Array of parameters
 	 * @param CommonObject			$object			Object invoice
 	 * @param string		 		$action			Code action
-	 * @param Hookmanager			$hookmanager	Hookmanager
+	 * @param HookManager			$hookmanager	Hookmanager
 	 * @return int									Result
 	 */
 	public function printFieldListOption($parameters, $object, &$action, $hookmanager)
@@ -1943,7 +1948,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 * @param array<string,mixed> 	$parameters		Array of parameters
 	 * @param CommonObject			$object			Object invoice
 	 * @param string		 		$action			Code action
-	 * @param Hookmanager			$hookmanager	Hookmanager
+	 * @param HookManager			$hookmanager	Hookmanager
 	 * @return int									Result
 	 */
 	public function printFieldListTitle($parameters, $object, &$action, $hookmanager)
@@ -2000,7 +2005,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 * @param array<string,mixed> 	$parameters		Array of parameters
 	 * @param CommonObject			$object			Object invoice
 	 * @param string		 		$action			Code action
-	 * @param Hookmanager			$hookmanager	Hookmanager
+	 * @param HookManager			$hookmanager	Hookmanager
 	 * @return int									Result
 	 */
 	public function printFieldListValue($parameters, $object, &$action, $hookmanager)
@@ -2113,7 +2118,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 * @param array<string,mixed> 	$parameters		Array of parameters
 	 * @param CommonObject			$object			Object invoice
 	 * @param string		 		$action			Code action
-	 * @param Hookmanager			$hookmanager	Hookmanager
+	 * @param HookManager			$hookmanager	Hookmanager
 	 * @return int									Result
 	 */
 	public function isEditable($parameters, $object, &$action, $hookmanager)
@@ -2151,7 +2156,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 * @param array{soc_origin:int,soc_dest:int} 	$parameters		Array of parameters (soc_origin = absorbed thirdparty id, soc_dest = surviving thirdparty id)
 	 * @param CommonObject							$object			Destination thirdparty object
 	 * @param string								$action			Code action
-	 * @param Hookmanager							$hookmanager	Hookmanager
+	 * @param HookManager							$hookmanager	Hookmanager
 	 * @return int									0 on success/nothing to do, -1 on error (sets $this->error/$this->errors)
 	 */
 	public function replaceThirdparty($parameters, $object, &$action, $hookmanager)
@@ -2277,7 +2282,7 @@ class ActionsEInvoicing extends CommonHookActions  // @phan-suppress-current-lin
 	 * @param array{colspan:int,socid:int|string,id:int|string,modulepart:string,relativepath:string}	$parameters		Array of parameters
 	 * @param array<string,mixed>																		$object			The file of the line being rendered
 	 * @param string																					$action			Code action
-	 * @param Hookmanager																				$hookmanager	Hookmanager
+	 * @param HookManager																				$hookmanager	Hookmanager
 	 * @return int																										0 in all cases (the line is completed, never replaced)
 	 */
 	public function formBuilddocLineOptions($parameters, $object, &$action, $hookmanager)

--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -882,6 +882,9 @@ class EInvoicing
 			// Remove Dolibarr internal statuses
 			unset($options[self::STATUS_UNKNOWN]);
 			unset($options[self::STATUS_IGNORE]);
+			// STATUS_IGNORE_2 is commented out of STATUS_LABEL_KEYS, so the key is never there to
+			// begin with. The line stays for the day that entry is turned on again.
+			// @phpstan-ignore unset.offset
 			unset($options[self::STATUS_IGNORE_2]);
 			unset($options[self::STATUS_NOT_GENERATED]);
 		}

--- a/einvoicing/class/providers/EsalinkPDPProvider.class.php
+++ b/einvoicing/class/providers/EsalinkPDPProvider.class.php
@@ -168,7 +168,7 @@ class EsalinkPDPProvider extends AbstractPDPProvider
 
 		// Client secret
 		$item = $formSetup->newItem($prefix . 'PASSWORD'.(getDolGlobalInt('EINVOICING_LIVE') ? '_PROD' : ''));
-		if (method_exists('FormSetupItem', 'setAsGenericPassword')) {
+		if (method_exists($item, 'setAsGenericPassword')) {
 			$item->setAsGenericPassword();
 		} else {
 			// Dolibarr 18/19 fallback: setAsGenericPassword() does not exist yet.

--- a/einvoicing/class/providers/PDPProviderManager.class.php
+++ b/einvoicing/class/providers/PDPProviderManager.class.php
@@ -282,6 +282,7 @@ class PDPProviderManager
 		// The is_subclass_of() above is what makes this type true, and a constructor never returns
 		// anything falsy: the object is usable as an AbstractPDPProvider from here on.
 		'@phan-var-force AbstractPDPProvider $provider';
+		/** @var AbstractPDPProvider $provider */
 		$provider->providerName = $name;
 
 		return $provider;

--- a/einvoicing/class/providers/SuperPDPProvider.class.php
+++ b/einvoicing/class/providers/SuperPDPProvider.class.php
@@ -317,7 +317,7 @@ class SuperPDPProvider extends AbstractPDPProvider
 
 			// Password
 			$item = $formSetup->newItem($prefix.'CLIENT_SECRET'.(getDolGlobalInt('EINVOICING_LIVE') ? '_PROD' : ''));
-			if (method_exists('FormSetupItem', 'setAsGenericPassword')) {
+			if (method_exists($item, 'setAsGenericPassword')) {
 				$item->setAsGenericPassword();
 			} else {
 				// Dolibarr 18/19 fallback: setAsGenericPassword() does not exist yet.

--- a/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
+++ b/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
@@ -150,6 +150,7 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 		if ($action == 'BILL_CREATE') {
 			/** @var Facture $object */
 			'@phan-var-force Facture $object';
+			/** @var Facture $object */
 
 			if (!getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP')) {		// If sync Dolibarr to AP is on
 				$einvoicing = new EInvoicing($this->db);
@@ -172,6 +173,7 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 		if ($action == 'BILL_VALIDATE') {
 			/** @var Facture $object */
 			'@phan-var-force Facture $object';
+			/** @var Facture $object */
 
 			// Tell the afterPDFCreation() hook that the document rebuild about to happen is the one that
 			// follows a validation. Set unconditionally and before anything else: this only records a fact
@@ -210,6 +212,7 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 		if ($action == 'BILL_UNVALIDATE') {
 			/** @var Facture $object */
 			'@phan-var-force Facture $object';
+			/** @var Facture $object */
 			$einvoicing = new EInvoicing($this->db);
 
 			// Lock on the REAL PA state (persistent flow_id), not the Dolibarr syncstatus which is reset to
@@ -224,6 +227,7 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 		if ($action == 'BILL_DELETE') {
 			/** @var Facture $object */
 			'@phan-var-force Facture $object';
+			/** @var Facture $object */
 			$einvoicing = new EInvoicing($this->db);
 
 			// Lock on the REAL PA state (persistent flow_id), see BILL_UNVALIDATE above.
@@ -236,6 +240,7 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 		if ($action == 'BILL_MODIFY') {
 			/** @var Facture $object */
 			'@phan-var-force Facture $object';
+			/** @var Facture $object */
 			$einvoicing = new EInvoicing($this->db);
 
 			// Lock on the REAL PA state (persistent flow_id), see BILL_UNVALIDATE above.
@@ -277,6 +282,7 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 		if ($action == 'PAYMENT_CUSTOMER_CREATE') {
 			/** @var Paiement $object */
 			'@phan-var-force Paiement $object';
+			/** @var Paiement $object */
 
 			if (!einvoicingIsSendDisabled()) {		// If sync Dolibarr to AP is on
 				require_once DOL_DOCUMENT_ROOT . '/compta/facture/class/facture.class.php';
@@ -302,6 +308,7 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 		if ($action == 'BILL_SUPPLIER_VALIDATE') {
 			/** @var FactureFournisseur $object */
 			'@phan-var-force FactureFournisseur $object';
+			/** @var FactureFournisseur $object */
 			// An invoice the import could not make total what its document announces never becomes
 			// payable by being validated: the totals are confronted again here, so an invoice corrected
 			// to the figures the vendor bills validates normally and drops the mark (issue #861).
@@ -379,6 +386,7 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 		if ($action == 'BILL_SUPPLIER_PAYED') {
 			/** @var FactureFournisseur $object */
 			'@phan-var-force FactureFournisseur $object';
+			/** @var FactureFournisseur $object */
 
 			if (getDolGlobalInt('EINVOICING_SEND_PAYMENT_SENT_STATUS') && !einvoicingIsSendDisabled()) {
 				$paidAmount = (float) $object->getSommePaiement();
@@ -412,6 +420,7 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 		if ($action == 'BILL_SUPPLIER_DELETE') {
 			/** @var FactureFournisseur $object */
 			'@phan-var-force FactureFournisseur $object';
+			/** @var FactureFournisseur $object */
 			$duplicate = false;
 			if (SupplierInvoiceHelper::isEInvoice($object->id, true, $duplicate)) {
 				if ($duplicate) {
@@ -452,6 +461,7 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 			 * @var Document $object
 			 */
 			'@phan-var-force Document $object';
+			/** @var Document $object */
 			$duplicate = false;
 
 			// A flow does not always carry a supplier invoice id: a lifecycle message never resolves one,

--- a/einvoicing/einvoicingindex.php
+++ b/einvoicing/einvoicingindex.php
@@ -72,6 +72,7 @@ if (!$res) {
  * @var User $user
  */
 '@phan-var-force User $user';
+/** @var User $user */
 include_once DOL_DOCUMENT_ROOT.'/core/class/html.formfile.class.php';
 
 // Load translation files required by the page

--- a/einvoicing/product_mapping.php
+++ b/einvoicing/product_mapping.php
@@ -304,6 +304,7 @@ if (!empty($parsedLines)) {
 	// Run the matching on each line (read only, nothing is created here)
 	// The matching method comes from the CommonProtocol trait, used by the protocols able to import an invoice.
 	'@phan-var-force ?CIIProtocol $protocol';
+	/** @var ?CIIProtocol $protocol */
 	$nbtomap = 0;
 	$matchresults = array();
 	foreach ($parsedLines as $idx => $parsedLine) {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,162 @@
+# PHPStan configuration for the modules of this repository.
+#
+# It analyses the module code only. The Dolibarr core is not analysed: it is indexed through
+# scanDirectories so PHPStan knows its classes, methods, properties and functions, and reports
+# nothing about them. The core to index is DOLIBARR_HTDOCS, the variable the CI actions of this
+# repository already use; dev/tools/phpstan/phpstan.sh resolves it and runs the analysis.
+#
+# Phan is untouched and stays the check the dolibarr-community-modules ecosystem expects; PHPStan
+# is a second opinion next to it, mainly on argument types and on the drift between core versions.
+#
+# See dev/tools/phpstan/README.md.
+includes:
+	# What the module already reported when PHPStan was introduced, so the check gates new errors.
+	# baseline.neon holds what the newest supported core reports, baseline-legacy.neon the errors
+	# only the older cores add. Both are always loaded, so every core of the matrix stays green.
+	- dev/tools/phpstan/baseline.neon
+	- dev/tools/phpstan/baseline-legacy.neon
+
+parameters:
+	# The posture of the core, copied from its own phpstan.neon.dist: level 10, with the families of
+	# checks the hand written PHPDoc of Dolibarr cannot honour turned off. Reading it as a plain
+	# level 10 would be wrong - customRulesetUsed says so - and reading it as lax would be wrong too:
+	# on this module it reports more than a strict level 5 does (349 against 295 on Dolibarr 24).
+	# Keeping the same dials as the core means a contributor who knows its CI finds what he knows,
+	# and that what the core judges worth reporting is what is reported here.
+	customRulesetUsed: true
+	level: 10
+	polluteScopeWithLoopInitialAssignments: false
+	polluteScopeWithAlwaysIterableForeach: false
+	checkClassCaseSensitivity: true
+	checkFunctionArgumentTypes: true
+	checkFunctionNameCase: true
+	checkInternalClassCaseSensitivity: true
+	checkArgumentsPassedByReference: true
+	checkMaybeUndefinedVariables: true
+	checkNullables: false
+	checkThisOnly: true
+	checkUnionTypes: false
+	checkExplicitMixedMissingReturn: true
+	reportMaybes: false
+	reportMaybesInMethodSignatures: false
+	reportStaticMethodSignatures: false
+	reportMagicMethods: false
+	reportMagicProperties: false
+
+	# The module declares Dolibarr 18 and up. That range of cores runs on PHP 7.1 (the floor
+	# install/check.php of Dolibarr 18 warns below) up to the 8.4 the latest core is tested on, so
+	# the analysis has to hold on all of them: a PHP 8 only function reaching a page that Dolibarr
+	# 18 serves is a fatal error on a supported instance.
+	phpVersion:
+		min: 70100
+		max: 80400
+
+	paths:
+		- einvoicing
+
+	excludePaths:
+		analyse:
+			# Third party libraries: their classes must be known (the module extends some of them),
+			# their own code is not this repository's to fix.
+			- einvoicing/vendor
+		analyseAndScan:
+			# The PHPUnit suite runs against a real instance and is not part of the delivered
+			# module. Phan leaves it out the same way.
+			- einvoicing/test
+
+	scanDirectories:
+		- %env.DOLIBARR_HTDOCS%
+
+	bootstrapFiles:
+		- dev/tools/phpstan/bootstrap.php
+
+	tmpDir: .run-phpstan/cache
+
+	# A module that supports seven cores tests the version it runs on. Pinning these to the values
+	# of the checkout under analysis would turn every one of those guards into dead code.
+	dynamicConstantNames:
+		- DOL_VERSION
+		- DOL_MAJOR_VERSION
+		- DOL_MINOR_VERSION
+		# Same reason, for PHP itself: the module guards a few calls with PHP_VERSION_ID, and the
+		# analysis runs over a range of PHP versions rather than one. The core lists them too.
+		- PHP_VERSION
+		- PHP_MAJOR_VERSION
+		- PHP_MINOR_VERSION
+		- PHP_RELEASE_VERSION
+		- PHP_VERSION_ID
+		- PHP_OS
+		- PHP_OS_FAMILY
+		- PHP_SAPI
+		- PHP_INT_MAX
+		- PHP_INT_MIN
+		- PHP_INT_SIZE
+		- PHP_FLOAT_EPSILON
+		- PHP_FLOAT_MIN
+		- PHP_FLOAT_MAX
+
+	# fetch_object() hands back a stdClass whose properties are the columns of the query.
+	universalObjectCratesClasses:
+		- stdClass
+		- SimpleXMLElement
+
+	# The PHPDoc of the core is written by hand and is wrong often enough that treating it as proof
+	# turns honest defensive code into "always true". Part of the same block as above.
+	treatPhpDocTypesAsCertain: false
+
+	# A baseline built on the newest core lists errors the older cores do not report, and the other
+	# way round. Neither is a problem to flag.
+	reportUnmatchedIgnoredErrors: false
+
+	ignoreErrors:
+		# The header every external Dolibarr module page opens with: it walks up the tree looking
+		# for main.inc.php (master.inc.php for the command line scripts) because it does not know
+		# how deep under htdocs/custom it was installed. The ladder resolves at runtime, from
+		# inside the instance; it cannot resolve here, where the module sits in its own repository
+		# next to the core rather than inside it.
+		-
+			identifier: include.fileNotFound
+			message: '#^Path in include\(\) "(\.\./)+(main|master)\.inc\.php" is not a file or it does not exist\.$#'
+
+		# Phan reads its inline type assertions from a string expression on its own line. PHPStan
+		# sees a statement without effect. The core ignores the same pattern in its own config.
+		-
+			identifier: expr.resultUnused
+			message: '#^Expression "''@phan-(var|var-force|suppress-current-line|suppress-next-line)#'
+
+		# Multicompany is a separate, non free module. The calls are reached only after
+		# isModEnabled(''multicompany''), so its classes are absent from every checkout here.
+		-
+			identifier: class.notFound
+			message: '#(ActionsMulticompany|DaoMulticompany)#'
+		-
+			message: '#^(Call to method \w+\(\)|Access to property \$\w+) on an unknown class (ActionsMulticompany|DaoMulticompany)\.$#'
+
+		# The .inc.php files of a module are included from inside a method of the class that uses
+		# them, so they run with that $this and reach its private members. PHPStan analyses them as
+		# stand alone files, where that scope does not exist. Phan is told the same thing by the
+		# @phan-file-suppress PhanAccessMethodPrivate these files already carry.
+		-
+			identifier: method.private
+			path: einvoicing/lib/buildinvoicelines.inc.php
+		-
+			identifier: method.protected
+			path: einvoicing/lib/buildinvoicelines.inc.php
+
+		# The other half of a version gate: the module includes the core file when the core has it
+		# and its own backport when it does not. DOL_VERSION is dynamic here (see above), so both
+		# branches are analysed, and on an older core the branch meant for the newer one names a
+		# file that checkout does not carry. Which is the whole point of the gate.
+		-
+			identifier: requireOnce.fileNotFound
+			message: '#/core/(class/commonhookactions\.class\.php|lib/profid\.lib\.php)" is not a file or it does not exist\.$#'
+			paths:
+				- einvoicing/class/actions_einvoicing.class.php
+				- einvoicing/class/einvoicing.class.php
+
+		# TCPDF renamed its setters between the versions the supported cores bundle: Dolibarr 18
+		# ships "SetAutoPageBreak", Dolibarr 24 "setAutoPageBreak". PHP does not care about the case
+		# of a method name, and no spelling would satisfy both cores anyway.
+		-
+			identifier: method.nameCase
+			path: einvoicing/class/utils/FacturxTcpdfMerger.class.php


### PR DESCRIPTION
Adds PHPStan on the `einvoicing` module. **phan is untouched** — same config, same baseline, same
workflow — and stays the check the ecosystem expects. The two tools do not report the same things
and both have to pass, which is what the core itself does in its own CI.

## Why a second analyser

It answers on the drift between the core versions the module supports, which phan cannot see: the
core is given to it as a checkout, so the same code can be analysed against Dolibarr 18 and against
Dolibarr 24 and the two answers compared.

That is what found the bug of #917 — `einvoice_tracking.php` called `recordNotFound()`, a function
the core only ships from Dolibarr 20 on, so the page died on Dolibarr 18 and 19.

## How the core is given to it

Only the module is analysed. The core is **indexed, never analysed**: `scanDirectories` points at a
checkout so PHPStan knows its classes, methods, properties and functions, and reports nothing about
them. The checkout is named by `DOLIBARR_HTDOCS`, the variable `.github/actions/dolibarr-instance`
and `.github/scripts/` already use.

`dev/tools/phpstan/bootstrap.php` defines the handful of constants a module resolves its
`require_once` against, and **loads neither `master.inc.php` nor `main.inc.php`**: those open a
database, start a session and read a `conf.php` that does not exist in this repository, and none of
it is needed to know the symbols.

`DOL_VERSION` is left undefined and declared dynamic. A module that supports seven cores guards its
calls with version tests; pinning the constant to the checkout under analysis would let PHPStan
call every one of those guards dead code.

## Settings

The settings block of the core's own `phpstan.neon.dist`, copied as is: level 10 with
`customRulesetUsed: true` and the families of checks the hand written PHPDoc of Dolibarr cannot
honour turned off (`checkNullables`, `checkUnionTypes`, `reportMaybes`,
`treatPhpDocTypesAsCertain`…). A contributor who knows the CI of Dolibarr finds here what he knows,
and what the core judges worth reporting is what is reported here.

`phpVersion` is a range, 7.1 to 8.4 — the PHP versions the supported cores run on — so a call that
only exists in a recent PHP is caught the same way a call that only exists in a recent core is.

## Baselines

Two files, both always loaded: `baseline.neon` (299 entries) holds what the newest core reports,
`baseline-legacy.neon` (350 entries) what the older ones add. The seven cores are green and a new
error is reported — including a second occurrence of an error the baseline already holds once,
since a PHPStan baseline counts rather than muting a file.

They are the entry price of putting the tool on an existing code base, not a place to park new
findings; `dev/tools/phpstan/README.md` says so and
`dev/tools/phpstan/refresh-baseline.sh` rebuilds them after a batch lands. For scale, the core
carries 1 527 entries for its own 1.4 million lines.

## What was answered rather than listed

- every `'@phan-var-force X $y'` assertion the module already carried now has the
  `/** @var X $y */` form PHPStan reads next to it;
- `@param Hookmanager` becomes `@param HookManager`, the real case of the class;
- `method_exists()` is asked about the object rather than about a class name, so the Dolibarr 18/19
  fallback of `setAsGenericPassword()` narrows properly instead of needing an exception;
- a dead `unset()` is documented where it happens.

Six `ignoreErrors`, each with its reason next to it: the `main.inc.php`/`master.inc.php` ladder of
an external module, the string expressions phan reads its assertions from, the classes of the
separate Multicompany module, the private and protected calls of a `.inc.php` included from inside a
method, the core file of a version gate whose other branch is the module's own backport, and the
TCPDF setters the bundled library renamed between Dolibarr 18 and 24.

## Running it

```bash
DOLIBARR_HTDOCS=/path/to/dolibarr/htdocs dev/tools/phpstan/phpstan.sh
```

The script pins PHPStan 2.1.12 — the version the core runs — and caches the phar and the analysis
cache in `.run-phpstan/`, which git ignores. Nothing to install, no composer added.

## CI

`.github/workflows/phpstan.yml` is new; `phan.yml` and the others are untouched. A pull request is
analysed against Dolibarr 18.0.0 and 24.0.0, what lands on `main` against all seven. No database and
no instance: a checkout of the core and the phar.

## Tested

- PHPStan green on **Dolibarr 18.0.0, 19.0.0, 20.0.0, 21.0.0, 22.0.0, 23.0.0, 24.0.0** and on
  `develop`; a deliberately wrong return type injected into a file was reported through the
  baselines, and so was a third occurrence of an error the baseline holds twice.
- **phan green**, run the way its own workflow runs it, and `phpcs` clean on every file touched.
- On the bench, the whole PHPUnit suite of the module file by file on the seven cores plus
  `develop`: **32/32 green on each**. The setup page, the index, the product mapping, the document
  list and the call list open on **18.0.10** and **24.0.0**, with the password field of the provider
  still masked on both — that is the one behaviour change of this pull request.
