### PR TITLE
FIX: [einvoicing] The deliver-to party no longer carries the buyer's company identifier

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -2809,8 +2809,10 @@ class CIIProtocol extends AbstractProtocol
 
 		// ID / GlobalID — only one of the two may be present. If GlobalID is present, omit the ID to avoid XSD validation errors
 		// The MINIMUM schema declares neither: its TradePartyType starts at ram:Name, and the party is
-		// identified there by its ram:SpecifiedLegalOrganization/ram:ID instead.
-		if (!$this->isMinimumProfile($profile)) {
+		// identified there by its ram:SpecifiedLegalOrganization/ram:ID instead. Left out in minimal mode
+		// too: on the deliver-to party the term is BT-71, which identifies the place goods are delivered to
+		// and not the buyer company (issue #920).
+		if (!$minimal && !$this->isMinimumProfile($profile)) {
 			if (!empty($data[$prefix . 'GlobalIds'])) {
 				foreach ($data[$prefix . 'GlobalIds'] as $globalId) {
 					$g = $doc->createElement('ram:GlobalID', einvoicingXmlText((string) $globalId['value']));
@@ -2827,8 +2829,8 @@ class CIIProtocol extends AbstractProtocol
 			// Routing code of the buyer (BT-46 under scheme 0224), where BR-FR-CPRO-11 and BR-FR-CPRO-13 read
 			// the Chorus Pro "code service exécutant". It is a second ram:GlobalID, which only the EXTENDED
 			// profiles accept (FX-SCH-A-000164 caps that element at one occurrence below them), and it belongs
-			// to the buyer alone: on the deliver-to party the identifier is BT-71, a location (issue #678).
-			if ($type === 'buyer' && !$minimal && $this->isExtendedProfile($profile) && !empty($data['buyerRoutingCode'])) {
+			// to the buyer alone, which the guard above already restricts it to (issue #678).
+			if ($type === 'buyer' && $this->isExtendedProfile($profile) && !empty($data['buyerRoutingCode'])) {
 				$routing = $doc->createElement('ram:GlobalID', einvoicingXmlText($data['buyerRoutingCode']));
 				$routing->setAttribute('schemeID', EInvoicing::SCHEME_FR_ROUTING_CODE);
 				$node->appendChild($routing);

--- a/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_creditnote.xml
+++ b/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_creditnote.xml
@@ -124,7 +124,6 @@
     <!--Delivery-->
     <ram:ApplicableHeaderTradeDelivery>
       <ram:ShipToTradeParty>
-        <ram:GlobalID schemeID="0225">000000002</ram:GlobalID>
         <ram:Name>EINVOICING TEST BUYER</ram:Name>
         <ram:PostalTradeAddress>
           <ram:PostcodeCode>75000</ram:PostcodeCode>

--- a/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_deposit.xml
+++ b/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_deposit.xml
@@ -124,7 +124,6 @@
     <!--Delivery-->
     <ram:ApplicableHeaderTradeDelivery>
       <ram:ShipToTradeParty>
-        <ram:GlobalID schemeID="0225">000000002</ram:GlobalID>
         <ram:Name>EINVOICING TEST BUYER</ram:Name>
         <ram:PostalTradeAddress>
           <ram:PostcodeCode>75000</ram:PostcodeCode>

--- a/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_replacement.xml
+++ b/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_replacement.xml
@@ -124,7 +124,6 @@
     <!--Delivery-->
     <ram:ApplicableHeaderTradeDelivery>
       <ram:ShipToTradeParty>
-        <ram:GlobalID schemeID="0225">000000002</ram:GlobalID>
         <ram:Name>EINVOICING TEST BUYER</ram:Name>
         <ram:PostalTradeAddress>
           <ram:PostcodeCode>75000</ram:PostcodeCode>

--- a/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_situation.xml
+++ b/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_situation.xml
@@ -124,7 +124,6 @@
     <!--Delivery-->
     <ram:ApplicableHeaderTradeDelivery>
       <ram:ShipToTradeParty>
-        <ram:GlobalID schemeID="0225">000000002</ram:GlobalID>
         <ram:Name>EINVOICING TEST BUYER</ram:Name>
         <ram:PostalTradeAddress>
           <ram:PostcodeCode>75000</ram:PostcodeCode>

--- a/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_standard.xml
+++ b/einvoicing/test/phpunit/fixtures/einvoicing_samples/cii_standard.xml
@@ -124,7 +124,6 @@
     <!--Delivery-->
     <ram:ApplicableHeaderTradeDelivery>
       <ram:ShipToTradeParty>
-        <ram:GlobalID schemeID="0225">000000002</ram:GlobalID>
         <ram:Name>EINVOICING TEST BUYER</ram:Name>
         <ram:PostalTradeAddress>
           <ram:PostcodeCode>75000</ram:PostcodeCode>


### PR DESCRIPTION
Closes #920.

#926 made the scheme of the party identifier an option and #923 taught the import to read a
received `0225` by its shape. This is the third and last point that issue reported, the one
neither of them covers: the same identifier leaks onto a party it does not belong to, at the
default value and at every other one.

## What leaks

When no shipping contact gives the invoice an address of its own, the deliver-to party falls
back to the buyer data — `buildParty($doc, $shiptotrade, $invoiceData, 'buyer', false, true, $profile)`.
The `ram:GlobalID` block was guarded by the profile alone, never by that `$minimal` flag, so
the party got one:

```xml
<ram:ShipToTradeParty>
  <ram:GlobalID schemeID="0225">612554930</ram:GlobalID>   <!-- BT-71 -->
  <ram:Name>EINVOICING ROUND TRIP BUYER</ram:Name>
```

On the buyer party that element is BT-46, an identifier of the company. On the deliver-to
party it is **BT-71**, "an identifier for the location the goods are delivered to", from the
same ISO 6523 list. It was carrying the buyer SIREN under `0225`, which is neither a place
nor the scheme of one: `0225` addresses a mailbox in the national directory, and its rightful
place on the document is BT-34 / BT-49, where the module already uses it correctly.

Nothing refuses it — the three FNFE stages accept the document before and after — so this is a
term stating something untrue rather than an invoice that gets rejected. The same reading
already stands in the code: the routing code, a second `ram:GlobalID` added by #678, was given
a `!$minimal` test of its own with the comment *"on the deliver-to party the identifier is
BT-71, a location"*. Only the first `GlobalID` was left out of that reasoning.

## What lands

The identifier block is left out in minimal mode, like every other optional block of
`buildParty()` already is — the legal organisation, the contact, the electronic address and
the tax registrations all test `$minimal`. The routing code drops its own test, now covered by
the guard above it.

Untouched: **BT-29 and BT-46**, which keep the scheme `EINVOICING_PARTY_IDENTIFIER_SCHEME`
decides; **BT-30 and BT-47** on `0002`; **BT-34 and BT-49** on `0225`; and the deliver-to party
built from a distinct shipping contact (BG-15), whose builder never declared an identifier.

The five reference fixtures are regenerated with `scripts/regenerate_einvoicing_fixtures.php`:
each loses that one line, and nothing else moves.

## Tested

Bench, Dolibarr **18.0 to 25.0**: PHPUnit **256 runs, 256 OK** (32 files × 8 cores, each under
the PHP its core gets in CI). `phpcs` clean.

Two invoices emitted for real on Dolibarr 24, one CII and one Factur-X, on a buyer whose SIREN
differs from the seller's so the two cannot be confused. Before, `ShipToTradeParty` carried
`<ram:GlobalID schemeID="0225">612554930</ram:GlobalID>`; after, it carries its name and its
address and nothing else, while `BuyerTradeParty` still declares `612554930` under `0225` and
`0002` as it did.

The five specimens and both emitted documents come back **VALID** through the three FNFE stages
(XSD, profile XSLT, `BR-FR-Flux2` schematron), France_RFE `v1.4.0.03`.

## Not in this PR

`0231`, the SIREN of a VAT group, which #926 deliberately left out of the list: `BR-FR-CO-14`
and `BR-FR-CO-15` make the `MEMBRE_ASSUJETTI_UNIQUE` note and the fiscal representative block
mandatory as soon as it appears, so it belongs with the support of that case rather than alone
in a dropdown.
