### PR TITLE
CI: [phpcs] a pull request that deletes a PHP file no longer fails the job

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -76,7 +76,12 @@ jobs:
             echo "mode=all" >> "$GITHUB_OUTPUT"
             echo "The ruleset itself changed: the whole repository is checked."
           else
-            grep -E '\.php$' "$FILES" > changed-php.txt || true
+            # A pull request that deletes or renames a PHP file lists a path that is gone, and
+            # phpcs stops the job on it ("The file ... does not exist"). What left has nothing
+            # to check, so only the files still on disk are handed over.
+            grep -E '\.php$' "$FILES" | while IFS= read -r file; do
+              [ -f "$file" ] && printf '%s\n' "$file"
+            done > changed-php.txt || true
             if [ -s changed-php.txt ]; then
               echo "mode=list" >> "$GITHUB_OUTPUT"
             else


### PR DESCRIPTION
## The defect

The `build` job of the phpcs workflow hands phpcs the PHP files of the pull request, read from the files endpoint — which lists **what the change touches, deletions included**. phpcs stops on a path that is no longer on disk:

```
ERROR: The file "einvoicing/class/utils/XmlPatcher.class.php" does not exist.
Error: Expecting xml stream starting with a xml opening tag.
Process completed with exit code 2
```

So any pull request that deletes or renames a PHP file fails a check that has nothing to say about it. Seen on #928, which removes one class file.

## The change

The list is filtered to the files still present. A pull request that only deletes PHP files takes the `mode=none` branch that already exists ("No PHP file changed."), and one that mixes deletions with edits checks the edits.

Measured on the three shapes, with the step's own `set -uo pipefail`:

| list | kept | mode |
|---|---|---|
| an edited file + a deleted one + a .md | the edited file | `list` |
| a deleted file alone | nothing | `none` |
| edited files only | all of them | `list` |
