### PR TITLE
FIX: [einvoicing] A missing deposit no longer disappears from the invoice that deducts it

### DIFF
--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -778,6 +778,57 @@ class CIIProtocol extends AbstractProtocol
 	}
 
 	/**
+	 * Decide what to do with a BG-3 reference (BT-25) the buyer does not hold.
+	 * BT-113 is what tells the two cases apart: an amount already paid points at a deposit the import
+	 * has to deduct, so the flow waits for it rather than importing an invoice short of its deduction;
+	 * nothing paid means the reference is documentary - a contract number, or the placeholder some
+	 * vendors always emit - and stepping over it costs nothing, as long as it is reported (#880).
+	 * ram:TypeCode cannot arbitrate this: CII-DT-018 forbids it below EXTENDED, so it is always absent.
+	 *
+	 * @param  string					$refDoc           BT-25, the identifier of the referenced document
+	 * @param  array<string,mixed>		$parsedHeader     Parsed document header
+	 * @param  int						$socId            Supplier third party the document is attached to
+	 * @param  string					$relation         How the reference is named in messages
+	 * @param  string[]					$return_messages  Import messages, appended to when stepping over
+	 * @param  bool						$reportSkip       False past the pre-check, which reported already
+	 * @return array{res:int,postponeflow:int,message:string,actioncode:string,actionurl:string,actiondata:array<string,mixed>,action:string,businessmessage:string}|null	Postpone result, or null to step over
+	 */
+	protected function resolveMissingReferencedDocument($refDoc, $parsedHeader, $socId, $relation, &$return_messages, $reportSkip = true)
+	{
+		global $langs;
+
+		$documentno = (string) ($parsedHeader['documentno'] ?? '');
+
+		if ((float) ($parsedHeader['totalPrepaidAmount'] ?? 0) <= 0) {
+			if ($reportSkip) {
+				$return_messages[] = 'Document ' . dol_escape_htmltag((string) $refDoc) . ', ' . $relation . ' ' . dol_escape_htmltag($documentno) . ', was not found in Dolibarr and was ignored: the received document declares no amount already paid.';
+			}
+			dol_syslog(get_class($this) . '::resolveMissingReferencedDocument Stepping over unresolved InvoiceReferencedDocument ref="' . $refDoc . '" (no BT-113) for ' . $documentno, LOG_DEBUG);
+			return null;
+		}
+
+		// Nothing is stored while the reference is missing: syncFlow() rolls the import back and the
+		// next synchronization takes the flow again, by then with the deposit in place.
+		$langs->load("bills");
+		$action = $langs->trans('CreateTheMissingSupplierInvoiceToImport', $refDoc);
+		$action .= ' <a class="butAction small smallpaddingimp nomarginleft" href="' . DOL_URL_ROOT . '/fourn/facture/card.php?action=create&socid=' . (int) $socId . '&ref_supplier=' . urlencode($refDoc) . '" target="_blank">';
+		$action .= '<i class="fas fa-plus-circle"></i> ';
+		$action .= $langs->trans('NewBill');
+		$action .= '</a>';
+
+		return [
+			'res' => -1,
+			'postponeflow' => 1,
+			'message' => 'Document ' . dol_escape_htmltag((string) $refDoc) . ', ' . $relation . ' ' . dol_escape_htmltag($documentno) . ', was not found in Dolibarr',
+			'actioncode' => 'LINKED_INVOICE_NOT_FOUND',
+			'actionurl' => 'none',
+			'actiondata' => array('supplierref' => $refDoc, 'linkedref' => $documentno, 'socid' => (int) $socId),
+			'action' => $action,
+			'businessmessage' => $langs->trans('CantFindLinkedInvoiceOfTheImportedInvoice', $documentno, $refDoc)
+		];
+	}
+
+	/**
 	 * Build the supplier invoice from a received CII document written to a per-call working file.
 	 * The temp-file lifecycle is owned by createSupplierInvoiceFromSource() (the public wrapper).
 	 * The vendor synchronization runs in its own transaction, opened and closed here. The invoice
@@ -928,41 +979,17 @@ class CIIProtocol extends AbstractProtocol
 			foreach ($parsedHeader['invoiceRefDocs'] as $invoiceRefDoc) {
 				$refDoc = $invoiceRefDoc['IssuerAssignedID'] ?? null;
 				$dateDoc = $invoiceRefDoc['FormattedIssueDateTime'] ?? null;
-				$typeDoc = $invoiceRefDoc['TypeCode'] ?? null;
 
 				$refDocInvoiceId = SupplierInvoiceHelper::findIdByRef($refDoc, (int) $socId);
 				if ($refDocInvoiceId < 0) {
 					return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($refDocInvoiceId, $refDoc, 'required by received document ' . ($parsedHeader['documentno'] ?? ''))];
 				}
 				if ($refDocInvoiceId == 0) {
-					// An unqualified reference (no ram:TypeCode in the XML) is a placeholder that the import
-					// does not consume — some vendors (e.g. DSV Road) always emit BG-3 with a dummy value
-					// such as "XXXX" when no preceding invoice applies. Skip it silently so it does not block
-					// the import and does not reach the post-creation loop.
-					if (empty($typeDoc)) {
-						dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Skipping unqualified InvoiceReferencedDocument ref="' . $refDoc . '" (no TypeCode) for ' . ($parsedHeader['documentno'] ?? ''), LOG_DEBUG);
-						continue;
+					$postpone = $this->resolveMissingReferencedDocument($refDoc, $parsedHeader, (int) $socId, 'required by received document', $return_messages);
+					if ($postpone !== null) {
+						return $postpone;
 					}
-					// The document references a qualified invoice this Dolibarr does not hold yet. Nothing has
-					// been created at this point, so the flow is postponed and retried on the next
-					// synchronization rather than failed, and the message spells out what to create.
-					$langs->load("bills");
-					$action = $langs->trans('CreateTheMissingSupplierInvoiceToImport', $refDoc);
-					$action .= ' <a class="butAction small smallpaddingimp nomarginleft" href="' . DOL_URL_ROOT . '/fourn/facture/card.php?action=create&socid=' . (int) $socId . '&ref_supplier=' . urlencode($refDoc) . '" target="_blank">';
-					$action .= '<i class="fas fa-plus-circle"></i> ';
-					$action .= $langs->trans('NewBill');
-					$action .= '</a>';
-
-					return [
-						'res' => -1,
-						'postponeflow' => 1,
-						'message' => 'Document ' . dol_escape_htmltag((string) $refDoc) . ', required by received document ' . dol_escape_htmltag((string) ($parsedHeader['documentno'] ?? '')) . ', was not found in Dolibarr',
-						'actioncode' => 'LINKED_INVOICE_NOT_FOUND',
-						'actionurl' => 'none',
-						'actiondata' => array('supplierref' => $refDoc, 'linkedref' => ($parsedHeader['documentno'] ?? ''), 'socid' => (int) $socId),
-						'action' => $action,
-						'businessmessage' => $langs->trans('CantFindLinkedInvoiceOfTheImportedInvoice', ($parsedHeader['documentno'] ?? ''), $refDoc)
-					];
+					continue;
 				}
 			}
 		}
@@ -1072,20 +1099,20 @@ class CIIProtocol extends AbstractProtocol
 				foreach ($parsedHeader['invoiceRefDocs'] as $doc) {
 					$refDoc = $doc['IssuerAssignedID'] ?? null;
 					$dateDoc = $doc['FormattedIssueDateTime'] ?? null;
-					$typeDoc = $doc['TypeCode'] ?? null;
 
 					$linkedObjectId = SupplierInvoiceHelper::findIdByRef($refDoc, (int) $socId);
 					if ($linkedObjectId < 0) {
 						return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($linkedObjectId, $refDoc, 'required by received document ' . ($parsedHeader['documentno'] ?? ''))];
 					}
 					if ($linkedObjectId == 0) {
-						// Unqualified references (no TypeCode) were already skipped by the pre-check above and
-						// should not reach this point. As a safety net, skip them here too rather than failing.
-						if (empty($typeDoc)) {
-							dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Skipping unqualified InvoiceReferencedDocument ref="' . $refDoc . '" (no TypeCode) in post-creation loop for ' . ($parsedHeader['documentno'] ?? ''), LOG_DEBUG);
-							continue;
+						// The pre-check above already adjudicated every reference, so this is only reached if
+						// one disappeared in between. Answering the same way keeps a bare failure - which
+						// syncFlows() turns into "Aborting synchronization" - out of the post-creation path.
+						$postpone = $this->resolveMissingReferencedDocument($refDoc, $parsedHeader, (int) $socId, 'required by received document', $return_messages, false);
+						if ($postpone !== null) {
+							return $postpone;
 						}
-						return ['res' => -1, 'message' => 'Document ' . dol_escape_htmltag((string) $refDoc) . ', required by received document ' . dol_escape_htmltag((string) ($parsedHeader['documentno'] ?? '')) . ', was not found in Dolibarr'];
+						continue;
 					}
 
 					// Fetch Object

--- a/einvoicing/class/protocols/CIIProtocol.class.php
+++ b/einvoicing/class/protocols/CIIProtocol.class.php
@@ -784,6 +784,8 @@ class CIIProtocol extends AbstractProtocol
 	 * nothing paid means the reference is documentary - a contract number, or the placeholder some
 	 * vendors always emit - and stepping over it costs nothing, as long as it is reported (#880).
 	 * ram:TypeCode cannot arbitrate this: CII-DT-018 forbids it below EXTENDED, so it is always absent.
+	 * A reference repeating the document's own number (BT-1) is settled before BT-113 is even read:
+	 * it can never resolve, so waiting for it is waiting for ever (#927).
 	 *
 	 * @param  string					$refDoc           BT-25, the identifier of the referenced document
 	 * @param  array<string,mixed>		$parsedHeader     Parsed document header
@@ -798,6 +800,18 @@ class CIIProtocol extends AbstractProtocol
 		global $langs;
 
 		$documentno = (string) ($parsedHeader['documentno'] ?? '');
+
+		// A document naming itself as the invoice it follows has nothing to wait for: the reference
+		// resolves through the very lookup already run on the document above, which came back empty -
+		// reaching this point proves it. Postponing would postpone for ever, so it is stepped over
+		// whatever BT-113 says, and reported because an accounting document cannot precede itself.
+		if (trim((string) $refDoc) !== '' && trim((string) $refDoc) === trim($documentno)) {
+			if ($reportSkip) {
+				$return_messages[] = 'Document ' . dol_escape_htmltag($documentno) . ' names itself as the invoice it follows; the reference was ignored.';
+			}
+			dol_syslog(get_class($this) . '::resolveMissingReferencedDocument Stepping over self-referencing InvoiceReferencedDocument ref="' . $refDoc . '" for ' . $documentno, LOG_WARNING);
+			return null;
+		}
 
 		if ((float) ($parsedHeader['totalPrepaidAmount'] ?? 0) <= 0) {
 			if ($reportSkip) {

--- a/einvoicing/class/protocols/FacturXProtocol.class.php
+++ b/einvoicing/class/protocols/FacturXProtocol.class.php
@@ -709,41 +709,17 @@ class FacturXProtocol extends CIIProtocol
 			foreach ($parsedHeader['invoiceRefDocs'] as $invoiceRefDoc) {
 				$refDoc = $invoiceRefDoc['IssuerAssignedID'] ?? null;
 				$dateDoc = $invoiceRefDoc['FormattedIssueDateTime'] ?? null;
-				$typeDoc = $invoiceRefDoc['TypeCode'] ?? null;
 
 				$refDocInvoiceId = SupplierInvoiceHelper::findIdByRef($refDoc, (int) $socId);
 				if ($refDocInvoiceId < 0) {
 					return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($refDocInvoiceId, $refDoc, 'linked to document ' . ($parsedHeader['documentno'] ?? ''))];
 				}
 				if ($refDocInvoiceId == 0) {
-					// An unqualified reference (no ram:TypeCode in the XML) is a placeholder that the import
-					// does not consume — some vendors (e.g. DSV Road) always emit BG-3 with a dummy value
-					// such as "XXXX" when no preceding invoice applies. Skip it silently so it does not block
-					// the import and does not reach the post-creation loop.
-					if (empty($typeDoc)) {
-						dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Skipping unqualified InvoiceReferencedDocument ref="' . $refDoc . '" (no TypeCode) for ' . ($parsedHeader['documentno'] ?? ''), LOG_DEBUG);
-						continue;
+					$postpone = $this->resolveMissingReferencedDocument($refDoc, $parsedHeader, (int) $socId, 'linked to document', $return_messages);
+					if ($postpone !== null) {
+						return $postpone;
 					}
-					// The invoice references a qualified document this Dolibarr does not hold yet (deposit,
-					// credited or replaced invoice). Nothing has been created yet, so the flow is postponed
-					// rather than failed, and the message spells out what to create.
-					$langs->load("bills");
-					$action = $langs->trans('CreateTheMissingSupplierInvoiceToImport', $refDoc);
-					$action .= ' <a class="butAction small smallpaddingimp nomarginleft" href="' . DOL_URL_ROOT . '/fourn/facture/card.php?action=create&socid=' . (int) $socId . '&ref_supplier=' . urlencode($refDoc) . '" target="_blank">';
-					$action .= '<i class="fas fa-plus-circle"></i> ';
-					$action .= $langs->trans('NewBill');
-					$action .= '</a>';
-
-					return [
-						'res' => -1,
-						'postponeflow' => 1,
-						'message' => 'Document : ' . $refDoc . ' linked to document ' . $parsedHeader['documentno'] . ' not found in Dolibarr',
-						'actioncode' => 'LINKED_INVOICE_NOT_FOUND',
-						'actionurl' => 'none',
-						'actiondata' => array('supplierref' => $refDoc, 'linkedref' => ($parsedHeader['documentno'] ?? ''), 'socid' => (int) $socId),
-						'action' => $action,
-						'businessmessage' => $langs->trans('CantFindLinkedInvoiceOfTheImportedInvoice', ($parsedHeader['documentno'] ?? ''), $refDoc)
-					];
+					continue;
 				}
 			}
 		}
@@ -853,20 +829,20 @@ class FacturXProtocol extends CIIProtocol
 				foreach ($parsedHeader['invoiceRefDocs'] as $doc) {
 					$refDoc = $doc['IssuerAssignedID'] ?? null;
 					$dateDoc = $doc['FormattedIssueDateTime'] ?? null;
-					$typeDoc = $doc['TypeCode'] ?? null;
 
 					$linkedObjectId = SupplierInvoiceHelper::findIdByRef($refDoc, (int) $socId);
 					if ($linkedObjectId < 0) {
 						return ['res' => -1, 'message' => SupplierInvoiceHelper::refLookupErrorMessage($linkedObjectId, $refDoc, 'linked to document ' . ($parsedHeader['documentno'] ?? ''))];
 					}
 					if ($linkedObjectId == 0) {
-						// Unqualified references (no TypeCode) were already skipped by the pre-check above and
-						// should not reach this point. As a safety net, skip them here too rather than failing.
-						if (empty($typeDoc)) {
-							dol_syslog(get_class($this) . '::doCreateSupplierInvoiceFromSource Skipping unqualified InvoiceReferencedDocument ref="' . $refDoc . '" (no TypeCode) in post-creation loop for ' . ($parsedHeader['documentno'] ?? ''), LOG_DEBUG);
-							continue;
+						// The pre-check above already adjudicated every reference, so this is only reached if
+						// one disappeared in between. Answering the same way keeps a bare failure - which
+						// syncFlows() turns into "Aborting synchronization" - out of the post-creation path.
+						$postpone = $this->resolveMissingReferencedDocument($refDoc, $parsedHeader, (int) $socId, 'linked to document', $return_messages, false);
+						if ($postpone !== null) {
+							return $postpone;
 						}
-						return ['res' => -1, 'message' => 'Document : ' . $refDoc . ' linked to document ' . $parsedHeader['documentno'] . ' not found in Dolibarr'];
+						continue;
 					}
 
 					// Fetch Object


### PR DESCRIPTION
## The defect

#884 skips a BG-3 reference (BT-25) the buyer does not hold when the entry carries no `ram:TypeCode`, reading that absence as "placeholder, nothing to consume".

That code cannot be present to begin with. **CII-DT-018 is `flag="fatal"`** — *"TypeCode should not be present"* — on an `InvoiceReferencedDocument` below EXTENDED, which is why this module writes it under `isExtendedProfile()` and nowhere else (`CIIProtocol.class.php:2617`). The two specimens committed in this repository, both `urn:cen.eu:en16931:2017` and both produced by this module, carry no TypeCode:

```
cii_creditnote.xml    InvoiceReferencedDocument: IssuerAssignedID, FormattedIssueDateTime   TypeCode: absent
cii_replacement.xml   InvoiceReferencedDocument: IssuerAssignedID, FormattedIssueDateTime   TypeCode: absent
```

So on an EN 16931 document the test never reads the nature of the reference — it reads the profile, and always answers "skip".

## What it costs, measured

Dolibarr 22.0.5, PHP 8.3, dd22 on a bench. Real import through `createSupplierInvoiceFromSource()`, each case inside a transaction that is rolled back. Three CII documents with `TypeCode 380`, run on `main` before and after #884, then on this branch.

| case | before #884 | after #884 (`main`) | this branch |
|---|---|---|---|
| **A** — deposit not imported yet, BT-113 = 120.00 | postponed, nothing created | **imported at 540.27, no deduction, nothing said** | postponed, nothing created ✅ |
| **B** — `XXXX` placeholder, BT-113 = 0.00 (#880) | postponed, blocked forever ❌ | imported ✅ | imported, and reported in the import messages ✅ |
| **C** — control, the deposit is present | 420.27 + its discount line | 420.27 + its discount line | 420.27 + its discount line ✅ |

Case A is the defect: a final invoice whose deposit has not been imported yet went from *"postponed until the deposit arrives"* to *"imported for its full amount, silently and for good"*. The 120 € the buyer already paid is gone from the invoice, the flow is marked done, and the only trace is one `LOG_DEBUG` line. That is the ordinary order of arrival at an access point — the final invoice can be processed before its deposit exists in Dolibarr.

## The rule this uses instead

BT-113, `TotalPrepaidAmount`, which no profile forbids:

1. reference found → link it, as today;
2. not found and BT-113 > 0 → postpone; nothing is stored, `syncFlow()` rolls back, the next run takes it again;
3. not found and nothing declared paid → step over it **and say so in the import messages**.

The `XXXX` of #880 falls in case 3 and stops blocking, which is what that issue asked for.

## What this keeps from #884

The parse of `'TypeCode'` into `invoiceRefDocs`, which filled a real gap: `:931` read that key while the parser never wrote it. The `$typeDoc` locals that this change orphaned are removed; `$dateDoc`, dead before #884, is left alone as unrelated.

Both loops — the pre-check and the post-creation one — now share `resolveMissingReferencedDocument()` instead of duplicating thirty lines of message and action link. The post-creation loop also stops answering with a bare `-1`, which `syncFlows()` turns into *"Aborting synchronization"* (#675).

## Measured on the end-to-end path too

A full round trip through the access point, one instance issuing to another: a final invoice whose deposit is deducted at document level (BT-113 = 120.00, BG-3 → the deposit) is postponed with `LINKED_INVOICE_NOT_FOUND`, the batch carries on, and once the deposit is recorded the next synchronization imports the invoice at **480.00 TTC with its `(DEPOSIT) -120.00` line**.

One thing that measurement settled: when the deposit is deducted **as a line** instead, Dolibarr emits `TotalPrepaidAmount` = **0.00** (the deduction is in the lines, nothing is "already paid"). This branch steps over that reference, and rightly — the total is correct and nothing is lost. Before #884 that shape was postponed indefinitely for nothing.

## A document that names itself as the invoice it follows (#927)

Reported on a real flow received through SuperPDP: the same number appears as the invoice number (BT-1), as the despatch advice reference (BT-16) and as the preceding invoice reference (BT-25), the latter dated with the invoice's own issue date. The sender's mapping writes the invoice number into every reference slot it has.

Rule 2 above then postpones such a flow **for ever** as soon as it declares an amount already paid, because that reference can never resolve: the lookup on it is the very one already run on the document itself a few lines above, and reaching the check proves it came back empty — otherwise the import would have left through the *"supplier invoice already exists"* branch. Nothing is waiting to arrive.

So a reference repeating BT-1 is now stepped over before BT-113 is read, and reported, an accounting document being unable to precede itself. Nothing in EN 16931 or in the French rules forbids that shape — the only assertions on BT-25 are `BR-55` (non-empty), `BR-FR-01` (35 characters) and `BR-FR-02` (character set) — so it reaches us and has to be handled rather than refused.

**Only BT-25 decides.** BT-16 repeating BT-1 is a symptom of the same sloppy mapping, but it says nothing about the preceding invoice reference, and this module never resolves it against the database. Measured on dd22 (Dolibarr 22.0.5, PHP 8.3), real import rolled back, five CII 380 documents:

| document | BT-25 | BT-16 | BT-113 | before | this branch | if BT-16 also skipped |
|---|---|---|---|---|---|---|
| **A** | its own BT-1 | — | 120.00 | postponed for ever | **imported and reported** ✅ | imported |
| **B** | its own BT-1 | — | 0.00 | imported | imported ✅ | imported |
| **C** | deposit absent | — | 120.00 | postponed | postponed ✅ | postponed |
| **D** | `XXXX` | — | 0.00 | imported | imported ✅ | imported |
| **E** | deposit absent | its own BT-1 | 120.00 | postponed | postponed ✅ | **imported at 540.27, deduction lost** ❌ |

The document behind #927 has since been attached to the issue, and it matches case B: a carrier's invoice in UBL EXTENDED-CTC-FR carrying its own number in BT-25 (dated with its own issue date), in BT-16, and `Pas de reference` in BT-17, with **no `cbc:PrepaidAmount` at all**. Replayed on a bench with that reference shape, module 1.2.0 postpones it with the exact message the reporter pasted, and this branch imports it and says why.

The same reporter also hit `0` as the preceding invoice reference, and worked around it by recording a blank supplier invoice with `0` as its reference. Rule 3 above covers that shape without the workaround: measured on the same bench, postponed on 1.2.0, imported and reported here.

Case E is why the despatch advice reference stays out of the test: a sender careless with BT-16 can still name a genuine deposit in BG-3, and skipping the check there brings back exactly the silent loss this branch exists to close.

Fixes #927. It also repairs the regression #884 introduced, while keeping #880 fixed.


