### PR TITLE
FIX: [einvoicing] The invoice a credit note starts from is read as an identifier

### DIFF
--- a/einvoicing/class/einvoicing.class.php
+++ b/einvoicing/class/einvoicing.class.php
@@ -1751,12 +1751,14 @@ class EInvoicing
 			$arrayofeinvoicestatus = $this->getEinvoiceStatusOptions(0, 0, 0, ($action == 'create' ? 1 : 0), 0, ((empty($currentStatusInfo['code']) && $action != 'create') ? 0 : 1), ($action != 'create' ? 1 : 0));
 
 			// If we create a credit note from another invoice, if original invoice has a status to ignore einvoicing, we propagate it by default to the new credit note to create
-			if (!GETPOSTISSET('seteinvoicestatus') && $action == 'create' && GETPOST('fac_avoir') && GETPOST('type') == 2) {
+			if (!GETPOSTISSET('seteinvoicestatus') && $action == 'create' && GETPOSTINT('fac_avoir') > 0 && GETPOSTINT('type') == Facture::TYPE_CREDIT_NOTE) {
 				$tmpinvoicesrc = new Facture($this->db);
-				$tmpinvoicesrc->fetch(GETPOST('fac_avoir'));
-				$tmpinvoicesrcstatus = $this->fetchLastknownInvoiceStatus($tmpinvoicesrc->id, $tmpinvoicesrc->ref);
-				if ($tmpinvoicesrcstatus['code'] == Einvoicing::STATUS_IGNORE || $tmpinvoicesrcstatus['code'] == Einvoicing::STATUS_IGNORE_2) {
-					$currentStatusInfo['code'] = $tmpinvoicesrcstatus['code'];
+				// A source we cannot read tells us nothing: leave the default the qualification rules just computed.
+				if ($tmpinvoicesrc->fetch(GETPOSTINT('fac_avoir')) > 0) {
+					$tmpinvoicesrcstatus = $this->fetchLastknownInvoiceStatus($tmpinvoicesrc->id, $tmpinvoicesrc->ref);
+					if (self::isIgnoredStatus($tmpinvoicesrcstatus['code'])) {
+						$currentStatusInfo['code'] = $tmpinvoicesrcstatus['code'];
+					}
 				}
 			}
 


### PR DESCRIPTION
## What this fixes

Commit 9d5849c8, on `main`, added the block that gives a credit note the ignored status of the
invoice it is created from. That block reads the request with `GETPOST('fac_avoir')`, which answers
a string or an array, and hands the result to `Facture::fetch()`, which takes an int; and it writes
the class name as `Einvoicing` where the class is `EInvoicing`.

Both analysers refuse it, so **`main` is red since that commit**, and every open pull request
inherits the red because phan analyses the whole repository:

- phan: `PhanTypeMismatchArgument: Argument 1 ($rowid) is GETPOST('fac_avoir') of type mixed[]|string but \Facture::fetch() takes int`
- phpstan (all seven cores): `class.nameCase: Class EInvoicing referenced with incorrect case: Einvoicing.`

## The change

- `GETPOSTINT()` for both request values, which is what the core uses for `fac_avoir` in
  `compta/facture/card.php` on every supported version.
- `Facture::TYPE_CREDIT_NOTE` instead of the literal 2, and `self::isIgnoredStatus()`, the helper
  that already holds the list of codes that keep an invoice out of e-invoicing.
- The source invoice is read only when `fetch()` found it. A source we cannot read tells us nothing
  about the credit note, so the default the qualification rules just computed stays; before, its
  empty ref went to `fetchLastknownInvoiceStatus()`, which then looked the status up by `syncref = ''`.

Behaviour of the feature is unchanged.

## Tested

On the bench, Dolibarr 18.0.10, 22.0.5 and 24.0.0, invoice creation card loaded over HTTP with a
real session, before (main) and after, on five request shapes:

| request | preselected status, main | preselected status, this PR |
|---|---|---|
| `action=create&type=2&fac_avoir=<invoice kept out of e-invoicing>` | 99 | 99 |
| `action=create` (plain invoice) | 5 | 5 |
| `action=create&type=2&fac_avoir[]=<id>` (array) | 5 | 5 |
| `action=create&type=2&fac_avoir=99999999` (unreadable source) | 5 | 5 |
| `action=create&type=2&fac_avoir=<id>&seteinvoicestatus=5` (form reposted) | 5 | 5 |

No fatal, no warning, same page in every case.
