### PR TITLE
FIX: [einvoicing] The status chosen before validation survives the configuration check

### DIFF
--- a/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
+++ b/einvoicing/core/triggers/interface_98_modEInvoicing_EInvoicingTriggers.class.php
@@ -183,29 +183,31 @@ class InterfaceEInvoicingTriggers extends DolibarrTriggers
 			if (!getDolGlobalString('EINVOICING_DISABLE_SYNC_DOLI_TO_AP')) {		// If sync Dolibarr to AP is on
 				$einvoicing = new EInvoicing($this->db);
 
-				$result = $einvoicing->fetchLastknownInvoiceStatus($object->id, (string) $object->ref);
+				// The known status and the configuration check are two different answers: keep them in two
+				// variables, the status is still needed after the check to decide what to write.
+				$statusinfo = $einvoicing->fetchLastknownInvoiceStatus($object->id, (string) $object->ref);
 
-				// If $result is $einvoicing::STATUS_IGNORE or STATUS_IGNORE_2, we do nothing.
+				// If $statusinfo is $einvoicing::STATUS_IGNORE or STATUS_IGNORE_2, we do nothing.
 
 				// If einvoice was set to $einvoicing::STATUS_NOT_GENERATED or $einvoicing::STATUS_UNKNOWN, we set it to STATUS_IGNORE (if not qualified for einvoice) or STATUS_NOT_GENERATED (if qualified for einvoice)
-				if ($result['code'] == $einvoicing::STATUS_NOT_GENERATED || $result['code'] == $einvoicing::STATUS_UNKNOWN) {
+				if ($statusinfo['code'] == $einvoicing::STATUS_NOT_GENERATED || $statusinfo['code'] == $einvoicing::STATUS_UNKNOWN) {
 					if (getDolGlobalString('EINVOICING_EINVOICE_IN_REAL_TIME')) {
 						// Check configuration
-						$result = $einvoicing->checkRequiredinformations($object);
-						if ($result['res'] < 0) {
-							$message = $langs->trans("InvoiceNotgeneratedDueToConfigurationIssues") . ': <br>' . $result['message'];
+						$checkresult = $einvoicing->checkRequiredinformations($object);
+						if ($checkresult['res'] < 0) {
+							$message = $langs->trans("InvoiceNotgeneratedDueToConfigurationIssues") . ': <br>' . $checkresult['message'];
 							dol_syslog(__METHOD__ . " " . $message);
 
 							if (getDolGlobalString('EINVOICING_EINVOICE_CANCEL_IF_EINVOICE_FAILS')) {
 								$error++;
-								$this->errors[] = $result['message'];
+								$this->errors[] = $checkresult['message'];
 								return -1;		// This should generate a rollback
 							}
 						}
 					}
 
 					// Test if invoice need to be managed by EInvoice and set the new status to use
-					if ($result['code'] == $einvoicing::STATUS_UNKNOWN) {
+					if ($statusinfo['code'] == $einvoicing::STATUS_UNKNOWN) {
 						$statustouse = $einvoicing::STATUS_IGNORE;	// default status to use if none of following rules match
 						$needEinvoice = $einvoicing->needEInvoiceManagement($object);
 						if ($needEinvoice) {


### PR DESCRIPTION
## What this fixes

Commit 306994b8, on `main`, moved the configuration check into the `BILL_VALIDATE` trigger so that
a cancellation happens where it should. The check result landed in `$result`, the variable that was
already holding the known e-invoice status of the invoice:

```php
$result = $einvoicing->fetchLastknownInvoiceStatus($object->id, (string) $object->ref);
if ($result['code'] == ...STATUS_NOT_GENERATED || $result['code'] == ...STATUS_UNKNOWN) {
    if (getDolGlobalString('EINVOICING_EINVOICE_IN_REAL_TIME')) {
        $result = $einvoicing->checkRequiredinformations($object);   // ['res', 'message']
        ...
    }
    if ($result['code'] == $einvoicing::STATUS_UNKNOWN) {            // 'code' is gone
```

`checkRequiredinformations()` answers `['res' => …, 'message' => …]`, so the test right after it
reads a key that is not there. Two consequences when `EINVOICING_EINVOICE_IN_REAL_TIME` is on:

- a PHP warning at every invoice validation:
  `Undefined array key "code" in interface_98_modEInvoicing_EInvoicingTriggers.class.php on line 208`;
- `null == 0` being true, the condition passes whatever the status was, so an invoice already set to
  "to generate" is recomputed and silently moved back to "do not manage" when the qualification
  rules do not retain it — exactly what the restructured test was written to avoid.

## The change

The known status and the check result are two different answers, so they get two variables. Nothing
else moves: the check, the cancellation and the status written are the ones the commit introduced.

## Tested

Bench, Dolibarr 18.0.10, 22.0.5 and 24.0.0, `EINVOICING_EINVOICE_IN_REAL_TIME` on, a real
`validate()` on a fresh invoice each time.

Invoice set to "to generate" (5) for a customer the rules do not retain (non-FR), before:

```
status before validate             : 5
PHP Warning:  Undefined array key "code" in …EInvoicingTriggers.class.php on line 208
status after validate              : 99
```

after:

```
status before validate             : 5
status after validate              : 5
undefined-key warnings             : 'none'
```

Nominal path unchanged: an invoice whose status is still unknown at validation gets the status the
qualification rules give it (5 for a French customer) on all three cores.
